### PR TITLE
refactor: give the visible-channels ACL two named readings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,9 +68,17 @@ built; build them once, then reuse.
   eager-loads exactly the relations `MessageData::fromMessage()` reads. Every
   timeline / thread / search / broadcast / edit payload goes through it, so the
   N+1 contract has one home. Never hand-write the `with([...])` relation list.
-- **Visible-channels ACL** _(ADR-0003)_ — one scope on `User` returning
-  the channel ids a user may see in a team. This *is* the authorization boundary
-  for search, the thread inbox, unread dots, and forwarding. Never re-`pluck` it.
+- **Visible-channels ACL** _(ADR-0003)_ — the channel authorization boundary,
+  **two named readings on `User`** because two different questions share the word
+  "visible". `memberChannelIds(Team)` (and `memberChannelIdsAcrossTeams()`) is
+  *what is mine* — search, the thread inbox, unread dots, forwarding, placement.
+  `readableChannels(Team)` / `readableChannelIds(Team)` is *what may I open* — in
+  a team I belong to, and either public or one I belong to — behind
+  `ChannelPolicy::view()` (the channel page) and, through
+  `ApiChannelAccess::channelIds()`, the REST channel list. The split is
+  deliberate: `browse` exists so a user discovers a public channel and *joins*
+  it. Never re-`pluck` either, and never re-spell "public or member" at a call
+  site; `tests/Unit/VisibleChannelsAclHomeTest.php` fails if you do.
 - **Channel timeline window** _(ADR-0004)_ — the read-model/query object
   that resolves where a channel's initial message window opens (unread anchoring,
   jump context, paging). Takes explicit params; the controller keeps HTTP glue.
@@ -277,7 +285,9 @@ built; build them once, then reuse.
 - New realtime behaviour → a composable with a seam + a pure decision core in
   `lib/`; never inline in a page.
 - New channel message payload → the **Message load-set scope**.
-- New "which channels can this user see" check → the **Visible-channels ACL**.
+- New "which channels can this user see" check → the **Visible-channels ACL**,
+  after deciding which reading you mean: *is it mine* (`memberChannelIds`) or
+  *may I open it* (`readableChannels`).
 - New auditable mutation → give it an Action if it has none, then dispatch
   `AuditableActionOccurred` from it — the **domain-event seam**, next to the
   mutation.

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -52,7 +52,7 @@ class SearchMessages
     {
         $query = trim($criteria->query);
 
-        $channelIds = $this->visibleChannelIds($user, $team, $criteria->scope);
+        $channelIds = $this->memberChannelIds($user, $team, $criteria->scope);
 
         if ($query === '' || $channelIds === []) {
             return new Collection;
@@ -75,16 +75,20 @@ class SearchMessages
     }
 
     /**
-     * The visible channel ids that form the whole ACL for this search, scoped to
-     * the current team or unioned across every team the user belongs to.
+     * The channel ids that form the whole ACL for this search, scoped to the
+     * current team or unioned across every team the user belongs to.
+     *
+     * Search reads the *membership* reading, not the wider readable one: a
+     * public channel the user never joined is theirs to open from `browse`, not
+     * to have its messages surfaced unasked.
      *
      * @return array<int, string>
      */
-    private function visibleChannelIds(User $user, Team $team, SearchScope $scope): array
+    private function memberChannelIds(User $user, Team $team, SearchScope $scope): array
     {
         $ids = $scope === SearchScope::All
-            ? $user->visibleChannelIdsAcrossTeams()
-            : $user->visibleChannelIds($team);
+            ? $user->memberChannelIdsAcrossTeams()
+            : $user->memberChannelIds($team);
 
         return $ids->all();
     }

--- a/app/Http/Controllers/Api/V1/ChannelController.php
+++ b/app/Http/Controllers/Api/V1/ChannelController.php
@@ -11,7 +11,6 @@ use App\Http\Resources\Api\V1\ChannelResource;
 use App\Models\Channel;
 use App\Models\User;
 use App\Support\Integrations\ApiChannelAccess;
-use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -31,20 +30,8 @@ class ChannelController extends Controller
         $subject = $request->user();
         assert($subject instanceof User);
 
-        $team = ApiChannelAccess::team($subject);
-
         $channels = Channel::query()
-            ->where('team_id', $team->id)
-            ->where(function (Builder $query) use ($subject): void {
-                if ($subject->isBot()) {
-                    $query->whereHas('channelMembers', fn (Builder $member) => $member->where('user_id', $subject->id));
-
-                    return;
-                }
-
-                $query->where('visibility', ChannelVisibility::Public)
-                    ->orWhereHas('channelMembers', fn (Builder $member) => $member->where('user_id', $subject->id));
-            })
+            ->whereIn('id', ApiChannelAccess::channelIds($subject))
             ->orderBy('name')
             ->get();
 

--- a/app/Http/Requests/Channels/ForwardMessageRequest.php
+++ b/app/Http/Requests/Channels/ForwardMessageRequest.php
@@ -107,6 +107,6 @@ class ForwardMessageRequest extends FormRequest
      */
     protected function membershipChannelIds(): array
     {
-        return $this->user()->visibleChannelIds($this->sourceChannel()->team)->all();
+        return $this->user()->memberChannelIds($this->sourceChannel()->team)->all();
     }
 }

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -52,7 +52,7 @@ class Channel extends Model
     /**
      * Soft deletes are the grace window an admin's "Delete channel" opens: the
      * stamp hides the channel from every read path at once — the relation-backed
-     * sidebar, browse, the {@see User::visibleChannelIds()} ACL search and the
+     * sidebar, browse, the {@see User::memberChannelIds()} ACL search and the
      * thread inbox share, and route-model binding, which all inherit the trait's
      * global scope — while the scheduled purge does the irreversible work only
      * once the window has closed.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use App\Data\UserData;
 use App\Data\UserDndData;
 use App\Data\UserStatusData;
 use App\Enums\AppLocale;
+use App\Enums\ChannelVisibility;
 use App\Enums\ChimeSound;
 use App\Enums\PresenceState;
 use App\Enums\SidebarPosition;
@@ -27,6 +28,7 @@ use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -504,19 +506,27 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
     }
 
     /**
-     * The ids of the channels this user may see in a team — the whole
+     * The ids of the channels this user *belongs to* in a team — the whole
      * authorization boundary for message search, the thread inbox, unread
      * indicators, forwarding, and sidebar placement.
      *
-     * "Visible" is membership scoped to the team: every channel the user belongs
-     * to within it, archived ones included (they are still readable, just hidden
-     * from the sidebar). This is the single home of that decision — no consumer
-     * re-derives the ACL with its own query, so tightening it (a block-list, an
-     * archived exclusion) is one change every consumer inherits.
+     * This is the narrower of the two channel-ACL readings this model owns, and
+     * the one that answers "what is mine": membership scoped to the team, every
+     * channel the user belongs to within it, archived ones included (they are
+     * still readable, just hidden from the sidebar). A public channel they have
+     * never joined is deliberately *not* here — surfacing its messages in their
+     * search results is a product decision about privacy, not an ACL detail.
+     * {@see readableChannels()} is the wider reading, for the surfaces that ask
+     * "what may I open".
+     *
+     * Both readings live here and nowhere else, so tightening either one (a
+     * block-list, an archived exclusion) is a single change every consumer
+     * inherits. `tests/Unit/VisibleChannelsAclHomeTest.php` keeps a third copy
+     * from being written.
      *
      * @return SupportCollection<int, string>
      */
-    public function visibleChannelIds(Team $team): SupportCollection
+    public function memberChannelIds(Team $team): SupportCollection
     {
         return $this->channels()
             ->where('channels.team_id', $team->id)
@@ -524,19 +534,64 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
     }
 
     /**
-     * The ids of every channel this user may see across all their teams — the ACL
-     * boundary for cross-team ("All workspaces") message search.
+     * The ids of every channel this user belongs to across all their teams — the
+     * ACL boundary for cross-team ("All workspaces") message search.
      *
-     * The team-agnostic counterpart to {@see visibleChannelIds()}: membership
+     * The team-agnostic counterpart to {@see memberChannelIds()}: membership
      * alone, unscoped by team. Because it is still the whole authorization
      * boundary, widening a search to this set can never surface a channel the user
      * is not a member of, in any team.
      *
      * @return SupportCollection<int, string>
      */
-    public function visibleChannelIdsAcrossTeams(): SupportCollection
+    public function memberChannelIdsAcrossTeams(): SupportCollection
     {
         return $this->channels()->pluck('channels.id');
+    }
+
+    /**
+     * The channels this user *may open* in a team — the wider of the two ACL
+     * readings, behind {@see ChannelPolicy::view()} (so the channel page) and the
+     * REST channel list.
+     *
+     * Readable is "in a team I belong to, and either public or one I belong to":
+     * a public channel nobody has joined is still something any teammate may
+     * open, which is exactly what makes `browse` a place to *discover* channels.
+     * The team-membership half is part of the rule, not a caller's preamble — a
+     * credential that outlives its holder's membership (a personal access token
+     * survives removal) must stop reading the team's public channels at the same
+     * moment it stops reading a single one of them.
+     *
+     * Returned as a query rather than a set so both shapes the rule is asked in
+     * derive from one place: `->whereKey($id)->exists()` for the policy's
+     * per-channel question, {@see readableChannelIds()} for the list.
+     *
+     * @return Builder<Channel>
+     */
+    public function readableChannels(Team $team): Builder
+    {
+        $channels = Channel::query()->where('channels.team_id', $team->id);
+
+        if (! $this->belongsToTeam($team)) {
+            return $channels->whereRaw('1 = 0');
+        }
+
+        return $channels->where(fn (Builder $query): Builder => $query
+            ->where('visibility', ChannelVisibility::Public)
+            ->orWhereHas('channelMembers', fn (Builder $member): Builder => $member->where('user_id', $this->id)));
+    }
+
+    /**
+     * The ids of the channels this user may open in a team.
+     *
+     * The set form of {@see readableChannels()}, for the surfaces that enumerate
+     * rather than ask about one channel.
+     *
+     * @return SupportCollection<int, string>
+     */
+    public function readableChannelIds(Team $team): SupportCollection
+    {
+        return $this->readableChannels($team)->pluck('channels.id');
     }
 
     /**

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -66,15 +66,15 @@ class ChannelPolicy
 
     /**
      * Determine whether the user can view the channel.
+     *
+     * The rule — in a team I belong to, and either public or one I belong to —
+     * lives on {@see User::readableChannels()} rather than here, because the REST
+     * channel list asks the same question in bulk and the two must never drift
+     * apart. This is that query narrowed to one channel.
      */
     public function view(User $user, Channel $channel): bool
     {
-        if (! $user->belongsToTeam($channel->team)) {
-            return false;
-        }
-
-        return $channel->visibility === ChannelVisibility::Public
-            || $channel->members()->whereKey($user->id)->exists();
+        return $user->readableChannels($channel->team)->whereKey($channel->id)->exists();
     }
 
     /**

--- a/app/Support/ChannelMembership.php
+++ b/app/Support/ChannelMembership.php
@@ -139,7 +139,7 @@ final class ChannelMembership
      * each of the user's matching memberships takes its index as the new
      * position, so a drag persists the whole group's order in one write. Ids for
      * channels they don't belong to — or in another team — are ignored, the ACL
-     * coming from {@see User::visibleChannelIds()} rather than being re-derived
+     * coming from {@see User::memberChannelIds()} rather than being re-derived
      * here.
      *
      * When `$moveSection` is true the channel's `section_id` is set to
@@ -153,7 +153,7 @@ final class ChannelMembership
         ManualOrder::apply(
             ChannelMember::query()
                 ->where('user_id', $this->user->id)
-                ->whereIn('channel_id', $this->user->visibleChannelIds($this->channel->team)),
+                ->whereIn('channel_id', $this->user->memberChannelIds($this->channel->team)),
             'channel_id',
             $orderedIds,
         );

--- a/app/Support/Integrations/ApiChannelAccess.php
+++ b/app/Support/Integrations/ApiChannelAccess.php
@@ -10,6 +10,7 @@ use App\Models\PersonalAccessToken;
 use App\Models\Team;
 use App\Models\User;
 use App\Support\ChannelMembership;
+use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -46,6 +47,25 @@ class ApiChannelAccess
         abort_if(! $token instanceof PersonalAccessToken || $token->team_id === null, 403);
 
         return $token->team()->firstOrFail();
+    }
+
+    /**
+     * The ids of every channel the subject may see within its acting team.
+     *
+     * The bulk counterpart of {@see allows()}, asking the same question of a
+     * whole team at once and branching on subject kind in the same place, so the
+     * list and the single-channel read can never answer differently. Both
+     * readings it defers to are {@see User}'s.
+     *
+     * @return SupportCollection<int, string>
+     */
+    public static function channelIds(User $subject): SupportCollection
+    {
+        $team = self::team($subject);
+
+        return $subject->isBot()
+            ? $subject->memberChannelIds($team)
+            : $subject->readableChannelIds($team);
     }
 
     /**

--- a/app/Support/ThreadInbox.php
+++ b/app/Support/ThreadInbox.php
@@ -100,7 +100,7 @@ class ThreadInbox
     private function followed(): Builder
     {
         return Message::query()
-            ->whereIn('channel_id', $this->viewer->visibleChannelIds($this->team))
+            ->whereIn('channel_id', $this->viewer->memberChannelIds($this->team))
             ->whereNull('thread_root_id')
             ->where('reply_count', '>', 0)
             ->followedBy($this->viewer);

--- a/dev-docs/adr/0003-single-visible-channels-acl-scope.md
+++ b/dev-docs/adr/0003-single-visible-channels-acl-scope.md
@@ -1,8 +1,45 @@
 # ADR-0003: One scope for the visible-channels ACL
 
-- Status: Accepted
+- Status: Accepted — amended: the ACL has two readings, and `Api/V1` is in scope (2026-08-02)
 - Date: 2026-07-10
-- Relates to: epic architecture-hardening (child: Visible-channels ACL)
+- Relates to: epic architecture-hardening (child: Visible-channels ACL); epic IV (#1142, child #1144)
+
+> **Status note (2026-08-02).** As accepted, this collapsed five `pluck` copies into
+> one method — and then quietly acquired the problem it was written to prevent, because
+> it did not anticipate that **two different questions** were sharing the name
+> "visible", nor that `app/Http/Controllers/Api/V1/` was outside the sweep that
+> applied it.
+>
+> `visibleChannelIds()` answered *membership* ("which channels are mine"), which is
+> what search, the thread inbox, forwarding and sidebar placement want.
+> `ChannelPolicy::view()` answered *readability* ("which channels may I open" — in a
+> team I belong to, and either public or one I belong to), which is what the channel
+> page wants. `Api/V1\ChannelController::index` was a raw third copy of the second,
+> and it had already drifted: it omitted the team-membership half, so a personal
+> access token outliving its holder's membership still enumerated the team's public
+> channels while every `show` on them 404'd.
+>
+> The decision below still holds, with one correction: **there are two named
+> readings, both on `User`, and no consumer re-derives either.**
+>
+> - `memberChannelIds(Team)` / `memberChannelIdsAcrossTeams()` — the membership
+>   reading (search, the thread inbox, forwarding, `ChannelMembership` placement).
+> - `readableChannels(Team)` / `readableChannelIds(Team)` — the readable reading
+>   (`ChannelPolicy::view()`, and through `ApiChannelAccess::channelIds()` the REST
+>   channel list). Returned as a query so the policy's per-channel `exists()` and the
+>   list's id set derive from one expression.
+>
+> The split is intentional and stays: `browse` exists precisely so a user discovers a
+> public channel and *joins* it, so widening search to surface messages from channels
+> they never opted into is a product decision about privacy, not a refactor. A third
+> question — "public and not a member", the browse listing itself — is genuinely
+> different and stays local to `ChannelController::browse()`.
+>
+> `tests/Unit/VisibleChannelsAclHomeTest.php` fails if a third spelling of either
+> reading appears anywhere in `app/`. Like its sibling in ADR-0010 it is a tripwire,
+> not a proof: it matches the *disjunction*, because filtering on visibility alone
+> and asking whether one user is in one channel are both legitimate questions it must
+> stay quiet about.
 
 ## Context
 

--- a/tests/Feature/Api/V1/PersonalAccessTokenApiTest.php
+++ b/tests/Feature/Api/V1/PersonalAccessTokenApiTest.php
@@ -34,12 +34,46 @@ beforeEach(function (): void {
 });
 
 it('lists the channels in the token’s bound team a human PAT may view', function (): void {
+    // The list answers the readable reading, the same one the web page asks:
+    // a public channel they never joined is in it, a private one is not.
+    $publicNotJoined = Channel::factory()->for($this->team)->create();
+    $privateNotJoined = Channel::factory()->private()->for($this->team)->create();
+
     $token = humanToken($this->user, $this->team, ['channels:read']);
+
+    $response = $this->withToken($token)
+        ->getJson('/api/v1/channels')
+        ->assertOk()
+        ->assertJsonFragment(['id' => $this->channel->id])
+        ->assertJsonFragment(['id' => $publicNotJoined->id]);
+
+    expect(collect($response->json('data'))->pluck('id')->all())
+        ->not->toContain($privateNotJoined->id);
+});
+
+/**
+ * The list and the single-channel read are the same question asked in bulk, so
+ * they have to answer alike. Before #1144 the list re-derived the rule itself
+ * and skipped the team-membership half of it, so a token outliving its holder's
+ * membership still enumerated the team's public channels while every `show` on
+ * them 404'd.
+ */
+it('stops listing a team’s channels once the human has been removed from it', function (): void {
+    $public = Channel::factory()->for($this->team)->create();
+    $token = humanToken($this->user, $this->team, ['channels:read']);
+
+    // Removal leaves the token and the channel memberships behind — only the
+    // team membership goes.
+    $this->team->members()->detach($this->user);
+
+    $this->withToken($token)
+        ->getJson("/api/v1/channels/{$public->id}")
+        ->assertNotFound();
 
     $this->withToken($token)
         ->getJson('/api/v1/channels')
         ->assertOk()
-        ->assertJsonFragment(['id' => $this->channel->id]);
+        ->assertJsonCount(0, 'data');
 });
 
 it('confines the token to its bound team, even across the human’s other teams', function (): void {

--- a/tests/Feature/Channels/CrossTeamSearchTest.php
+++ b/tests/Feature/Channels/CrossTeamSearchTest.php
@@ -53,20 +53,20 @@ function crossTeamSearch(User $user, Team $team, array $params): TestResponse
     ]));
 }
 
-test('visibleChannelIdsAcrossTeams unions the channels of every team the user is in but never one they are not in', function (): void {
+test('memberChannelIdsAcrossTeams unions the channels of every team the user is in but never one they are not in', function (): void {
     [$member, $teamA, $generalA] = crossTeamWithGeneral('Acme');
     [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
     $generalB = addToTeam($member, $teamB);
     // A private channel in team B the member is NOT a member of.
     $privateB = Channel::factory()->for($teamB)->private()->create(['created_by' => $ownerB->id]);
 
-    $ids = $member->visibleChannelIdsAcrossTeams()->all();
+    $ids = $member->memberChannelIdsAcrossTeams()->all();
 
     // The union spans both teams, excludes the private channel the member is not
     // in, and is strictly wider than the team-scoped ACL, which never leaves A.
     expect($ids)->toContain($generalA->id, $generalB->id)
         ->not->toContain($privateB->id)
-        ->and($member->visibleChannelIds($teamA)->all())->not->toContain($generalB->id);
+        ->and($member->memberChannelIds($teamA)->all())->not->toContain($generalB->id);
 });
 
 test('scope=all searches the union of the user teams', function (): void {

--- a/tests/Feature/Channels/DeletedChannelVisibilityTest.php
+++ b/tests/Feature/Channels/DeletedChannelVisibilityTest.php
@@ -61,8 +61,8 @@ test('a deleted channel drops out of the visible-channel ACL', function (): void
 
     app(DeleteChannel::class)->handle($channel, null);
 
-    expect($owner->visibleChannelIds($team)->all())->not->toContain($channel->id)
-        ->and($owner->visibleChannelIdsAcrossTeams()->all())->not->toContain($channel->id);
+    expect($owner->memberChannelIds($team)->all())->not->toContain($channel->id)
+        ->and($owner->memberChannelIdsAcrossTeams()->all())->not->toContain($channel->id);
 });
 
 test('messages in a deleted channel stop matching search', function (): void {

--- a/tests/Feature/Channels/VisibleChannelsAclTest.php
+++ b/tests/Feature/Channels/VisibleChannelsAclTest.php
@@ -3,14 +3,18 @@
 use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
 use App\Models\Channel;
+use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 
 /**
- * A user in a team, joined to a mix of channels, alongside channels they cannot
- * see: one in the same team they never joined, and one in another team.
+ * A user in a team, joined to a mix of channels, alongside the two channels the
+ * readings disagree about: a public one in the same team they never joined
+ * (readable, not a membership) and a private one they never joined (neither).
  *
- * @return array{user: User, team: Team, visible: array<int, string>, hidden: array<int, string>}
+ * @return array{user: User, team: Team, member: array<int, string>, publicNotJoined: Channel, privateNotJoined: Channel, otherTeamChannel: Channel}
  */
 function aclFixture(): array
 {
@@ -18,19 +22,22 @@ function aclFixture(): array
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
 
-    $joined = Channel::factory()->for($team)->create();
+    $joined = Channel::factory()->private()->for($team)->create();
     $joined->channelMembers()->create(['user_id' => $user->id]);
 
-    // An archived channel the user still belongs to stays in the ACL — "visible"
-    // for authorization is membership, not sidebar presence.
-    $archivedJoined = Channel::factory()->for($team)->create(['archived_at' => now()]);
+    // An archived channel the user still belongs to stays in the membership
+    // reading — it is membership, not sidebar presence.
+    $archivedJoined = Channel::factory()->private()->for($team)->create(['archived_at' => now()]);
     $archivedJoined->channelMembers()->create(['user_id' => $user->id]);
 
-    // Same team, never joined — must not be visible.
-    $notJoined = Channel::factory()->for($team)->create();
+    // Same team, public, never joined: readable, but not a membership.
+    $publicNotJoined = Channel::factory()->for($team)->create();
+
+    // Same team, private, never joined: neither reading.
+    $privateNotJoined = Channel::factory()->private()->for($team)->create();
 
     // Another team the user also belongs to; its channels must not leak into
-    // this team's ACL.
+    // this team's readings.
     $otherTeam = app(CreateTeam::class)->handle($user, 'Globex');
     $otherTeamChannel = Channel::factory()->for($otherTeam)->create();
     $otherTeamChannel->channelMembers()->create(['user_id' => $user->id]);
@@ -38,37 +45,106 @@ function aclFixture(): array
     return [
         'user' => $user,
         'team' => $team,
-        'visible' => [$general->id, $joined->id, $archivedJoined->id],
-        'hidden' => [$notJoined->id, $otherTeamChannel->id],
+        'member' => [$general->id, $joined->id, $archivedJoined->id],
+        'publicNotJoined' => $publicNotJoined,
+        'privateNotJoined' => $privateNotJoined,
+        'otherTeamChannel' => $otherTeamChannel,
     ];
 }
 
-it('returns exactly the channels a user has joined in the team', function (): void {
-    ['user' => $user, 'team' => $team, 'visible' => $visible, 'hidden' => $hidden] = aclFixture();
+it('scopes the membership reading to exactly the channels a user has joined in the team', function (): void {
+    [
+        'user' => $user,
+        'team' => $team,
+        'member' => $member,
+        'publicNotJoined' => $publicNotJoined,
+        'privateNotJoined' => $privateNotJoined,
+        'otherTeamChannel' => $otherTeamChannel,
+    ] = aclFixture();
 
-    $ids = $user->visibleChannelIds($team)->all();
+    $ids = $user->memberChannelIds($team)->all();
 
-    expect($ids)->toEqualCanonicalizing($visible)
-        ->and($ids)->not->toContain(...$hidden);
+    expect($ids)->toEqualCanonicalizing($member)
+        ->and($ids)->not->toContain($publicNotJoined->id, $privateNotJoined->id, $otherTeamChannel->id);
 });
 
-it('excludes channels in other teams even when the user is a member', function (): void {
+it('widens the readable reading to every public channel in the team, joined or not', function (): void {
+    [
+        'user' => $user,
+        'team' => $team,
+        'member' => $member,
+        'publicNotJoined' => $publicNotJoined,
+        'privateNotJoined' => $privateNotJoined,
+        'otherTeamChannel' => $otherTeamChannel,
+    ] = aclFixture();
+
+    $ids = $user->readableChannelIds($team)->all();
+
+    expect($ids)->toEqualCanonicalizing([...$member, $publicNotJoined->id])
+        ->and($ids)->not->toContain($privateNotJoined->id, $otherTeamChannel->id);
+});
+
+it('reads nothing in a team the user does not belong to, however public its channels', function (): void {
+    $stranger = User::factory()->create();
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $public = Channel::factory()->for($team)->create();
+
+    expect($stranger->readableChannelIds($team)->all())->toBe([])
+        ->and($stranger->memberChannelIds($team)->all())->toBe([])
+        ->and(Gate::forUser($stranger)->allows('view', $public))->toBeFalse();
+});
+
+it('excludes channels in other teams from the membership reading even when the user is a member', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $otherTeam = app(CreateTeam::class)->handle($user, 'Globex');
     $otherChannel = Channel::factory()->for($otherTeam)->create();
     $otherChannel->channelMembers()->create(['user_id' => $user->id]);
 
-    expect($user->visibleChannelIds($team)->all())->not->toContain($otherChannel->id);
+    expect($user->memberChannelIds($team)->all())->not->toContain($otherChannel->id);
 });
 
-it('excludes channels in the team the user never joined', function (): void {
+it('excludes channels in the team the user never joined from the membership reading', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $stranger = User::factory()->create();
     $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
-    $private = Channel::factory()->for($team)->create();
+    $private = Channel::factory()->private()->for($team)->create();
     $private->channelMembers()->create(['user_id' => $stranger->id]);
 
-    expect($user->visibleChannelIds($team)->all())->not->toContain($private->id);
+    expect($user->memberChannelIds($team)->all())->not->toContain($private->id);
+});
+
+/**
+ * The split is the whole point of the two names, so it is pinned end to end
+ * rather than only on the model: a public channel the viewer never joined opens
+ * as a page and is absent from every membership-scoped surface. `browse` exists
+ * precisely so they discover it and *join*; widening search or forwarding to
+ * never-joined channels is a product decision, not this refactor.
+ */
+it('lets a public channel the viewer never joined be readable while staying out of the membership surfaces', function (): void {
+    ['user' => $user, 'team' => $team, 'publicNotJoined' => $channel] = aclFixture();
+
+    // Readable: the channel page opens, and the policy the page and the API
+    // both consult agrees.
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team, 'channel' => $channel]))
+        ->assertOk();
+
+    expect(Gate::forUser($user)->allows('view', $channel))->toBeTrue();
+
+    // Not a membership: forwarding refuses it as a destination, and the id set
+    // the thread inbox and search filter on excludes it.
+    $source = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    $message = Message::factory()->for($source)->for($user)->create();
+
+    $this->actingAs($user)
+        ->post(route('channels.messages.forward', ['team' => $team, 'channel' => $source, 'message' => $message]), [
+            'client_uuid' => (string) Str::uuid(),
+            'target_channel_id' => $channel->id,
+        ])
+        ->assertSessionHasErrors('target_channel_id');
+
+    expect($user->memberChannelIds($team)->all())->not->toContain($channel->id);
 });

--- a/tests/Feature/Teams/DeletedChannelsTest.php
+++ b/tests/Feature/Teams/DeletedChannelsTest.php
@@ -86,7 +86,7 @@ test('an admin restores a deleted channel, bringing it and its messages back', f
         ->assertRedirect(route('teams.deleted-channels.index', ['team' => $team->slug]));
 
     expect(Channel::query()->whereKey($channel->id)->exists())->toBeTrue()
-        ->and($owner->visibleChannelIds($team)->all())->toContain($channel->id)
+        ->and($owner->memberChannelIds($team)->all())->toContain($channel->id)
         ->and(Message::where('channel_id', $channel->id)->where('body', 'still here')->exists())->toBeTrue();
 });
 

--- a/tests/Unit/VisibleChannelsAclHomeTest.php
+++ b/tests/Unit/VisibleChannelsAclHomeTest.php
@@ -37,11 +37,16 @@ $sourceRoot = dirname(__DIR__, 2);
  */
 function readableAclSpellingPatterns(): array
 {
+    // The enum is backed, so a query copy can name it either way — `->value` is
+    // how `Channel::defaultsForTeam()` spells it, and the next copy is as likely
+    // to be written from that as from this one.
+    $public = 'ChannelVisibility::Public(->value)?';
+
     return [
         // `Api/V1\ChannelController::index`, the copy that had drifted.
-        'query builder' => "/'visibility',\s*ChannelVisibility::Public[\s\S]{0,120}?orWhereHas\(\s*'channelMembers'/",
+        'query builder' => "/'visibility',\s*{$public}[\s\S]{0,120}?orWhereHas\(\s*'channelMembers'/",
         // `ChannelPolicy::view()`, the reading the other two answered to.
-        'PHP expression' => '/visibility\s*===\s*ChannelVisibility::Public\s*\|\|\s*\$?[\w>-]*members\(\)/',
+        'PHP expression' => "/visibility(->value)?\s*===\s*{$public}\s*\|\|\s*\\\$?[\w>-]*members\(\)/",
     ];
 }
 
@@ -104,6 +109,10 @@ test('each pattern still catches the copy it was written for', function (string 
 })->with([
     'query builder' => ['query builder', <<<'PHP'
                 $query->where('visibility', ChannelVisibility::Public)
+                    ->orWhereHas('channelMembers', fn (Builder $member) => $member->where('user_id', $subject->id));
+    PHP],
+    'query builder, backed-enum spelling' => ['query builder', <<<'PHP'
+                $query->where('visibility', ChannelVisibility::Public->value)
                     ->orWhereHas('channelMembers', fn (Builder $member) => $member->where('user_id', $subject->id));
     PHP],
     'PHP expression' => ['PHP expression', <<<'PHP'

--- a/tests/Unit/VisibleChannelsAclHomeTest.php
+++ b/tests/Unit/VisibleChannelsAclHomeTest.php
@@ -64,14 +64,13 @@ function memberAclSpellingPatterns(): array
 }
 
 /**
- * Every file under `app/` that spells either rule out, as repository-relative
+ * Every file under `app/` that spells the given rule out, as repository-relative
  * paths.
  *
+ * @param  array<string, string>  $patterns
  * @return array<int, string>
  */
-$spellings = function () use ($sourceRoot): array {
-    $patterns = [...readableAclSpellingPatterns(), ...memberAclSpellingPatterns()];
-
+$spellings = function (array $patterns) use ($sourceRoot): array {
     $files = (new Finder)->files()->in($sourceRoot.'/app')->name('*.php');
 
     $found = [];
@@ -91,8 +90,14 @@ $spellings = function () use ($sourceRoot): array {
     return $found;
 };
 
-test('both readings of the ACL are spelled in exactly one place', function () use ($spellings): void {
-    expect($spellings())->toBe(['app/Models/User.php']);
+/**
+ * Each reading is scanned for on its own. Merging the two pattern sets would let
+ * a dead readable pattern hide behind the membership one still matching `User`,
+ * which is precisely the failure this file exists to notice.
+ */
+test('each reading of the ACL is spelled in exactly one place', function () use ($spellings): void {
+    expect($spellings(readableAclSpellingPatterns()))->toBe(['app/Models/User.php'])
+        ->and($spellings(memberAclSpellingPatterns()))->toBe(['app/Models/User.php']);
 });
 
 /**

--- a/tests/Unit/VisibleChannelsAclHomeTest.php
+++ b/tests/Unit/VisibleChannelsAclHomeTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * "Which channels may this user see in a team" is the authorization boundary for
+ * search, the thread inbox, forwarding, the channel page and the REST channel
+ * list. Before #1144 it had one name and three implementations — and two of them
+ * answered a different question: `visibleChannelIds()` was membership only,
+ * `ChannelPolicy::view()` was public-or-member, and `Api/V1\ChannelController`
+ * was a third raw copy of the second, under a docblock claiming there was a
+ * single home. The third copy had drifted: it skipped the team-membership half,
+ * so a personal access token outliving its holder's membership still enumerated
+ * the team's public channels.
+ *
+ * There are now two readings, both on {@see User} — `memberChannelIds()` and
+ * `readableChannelIds()` / `readableChannels()` — and this test is what keeps a
+ * fourth copy from being written: a re-derivation fails here rather than in
+ * production, on whichever surface was missed. See ADR-0003.
+ */
+$sourceRoot = dirname(__DIR__, 2);
+
+/**
+ * The forms the readable rule — "public in this team, or one I belong to" — has
+ * actually taken, each keyed by the copy it came from.
+ *
+ * They match the *disjunction*. Filtering on visibility alone is a legitimate
+ * question (`Channel::defaultsForTeam()` asks which public channels are
+ * defaults), and so is asking whether one user is in one channel
+ * (`ChannelPolicy::isMember()`). It is joining the two into "which channels may
+ * this user see" that is this rule.
+ *
+ * @return array<string, string>
+ */
+function readableAclSpellingPatterns(): array
+{
+    return [
+        // `Api/V1\ChannelController::index`, the copy that had drifted.
+        'query builder' => "/'visibility',\s*ChannelVisibility::Public[\s\S]{0,120}?orWhereHas\(\s*'channelMembers'/",
+        // `ChannelPolicy::view()`, the reading the other two answered to.
+        'PHP expression' => '/visibility\s*===\s*ChannelVisibility::Public\s*\|\|\s*\$?[\w>-]*members\(\)/',
+    ];
+}
+
+/**
+ * The form the membership rule took before ADR-0003 collapsed its five copies:
+ * a `pluck` of the user's channel ids re-derived at the call site.
+ *
+ * @return array<string, string>
+ */
+function memberAclSpellingPatterns(): array
+{
+    return [
+        'membership pluck' => "/->channels\(\)[\s\S]{0,120}?pluck\(\s*'channels\.id'/",
+    ];
+}
+
+/**
+ * Every file under `app/` that spells either rule out, as repository-relative
+ * paths.
+ *
+ * @return array<int, string>
+ */
+$spellings = function () use ($sourceRoot): array {
+    $patterns = [...readableAclSpellingPatterns(), ...memberAclSpellingPatterns()];
+
+    $files = (new Finder)->files()->in($sourceRoot.'/app')->name('*.php');
+
+    $found = [];
+
+    foreach ($files as $file) {
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $file->getContents()) === 1) {
+                $found[] = str_replace($sourceRoot.'/', '', $file->getPathname());
+
+                break;
+            }
+        }
+    }
+
+    sort($found);
+
+    return $found;
+};
+
+test('both readings of the ACL are spelled in exactly one place', function () use ($spellings): void {
+    expect($spellings())->toBe(['app/Models/User.php']);
+});
+
+/**
+ * A guard nothing can trip proves nothing, and these patterns are the kind that
+ * rot quietly — they are regular expressions over source, so a typo makes them
+ * match nothing at all and the suite stays green. Each copy #1144 removed is
+ * replayed here verbatim, so the tripwire is pinned against what it exists to
+ * catch.
+ */
+test('each pattern still catches the copy it was written for', function (string $spelling, string $source): void {
+    $patterns = [...readableAclSpellingPatterns(), ...memberAclSpellingPatterns()];
+
+    expect(preg_match($patterns[$spelling], $source))->toBe(1);
+})->with([
+    'query builder' => ['query builder', <<<'PHP'
+                $query->where('visibility', ChannelVisibility::Public)
+                    ->orWhereHas('channelMembers', fn (Builder $member) => $member->where('user_id', $subject->id));
+    PHP],
+    'PHP expression' => ['PHP expression', <<<'PHP'
+        return $channel->visibility === ChannelVisibility::Public
+            || $channel->members()->whereKey($user->id)->exists();
+    PHP],
+    'membership pluck' => ['membership pluck', <<<'PHP'
+        return $user->channels()
+            ->where('channels.team_id', $team->id)
+            ->pluck('channels.id');
+    PHP],
+]);
+
+/**
+ * The other half of a trustworthy tripwire: what it must stay quiet about.
+ *
+ * Each pattern is loose enough to survive reformatting, which is what makes it
+ * useful and what bounds its cost here — code asking only *one* of the two
+ * halves has to stay out of the results, or the guard becomes noise someone
+ * silences by widening the expected list.
+ */
+test('each pattern leaves a legitimate single-half question alone', function (string $source): void {
+    $patterns = [...readableAclSpellingPatterns(), ...memberAclSpellingPatterns()];
+
+    foreach ($patterns as $pattern) {
+        expect(preg_match($pattern, $source))->toBe(0);
+    }
+})->with([
+    // `Channel::defaultsForTeam()` — which public channels are defaults.
+    'a visibility filter on its own' => ["->where('visibility', ChannelVisibility::Public->value)"],
+    // `ChannelPolicy::isMember()` — is this one user in this one channel.
+    'a membership check on its own' => ['return $channel->members()->whereKey($user->id)->exists();'],
+    // `ChannelController::browse()` — public channels the user can still join,
+    // which is the inverse of membership, a third and genuinely different question.
+    'the browse inverse' => ["->whereDoesntHave('channelMembers', fn (\$query) => \$query->where('user_id', \$request->user()->id))"],
+    // Setting a channel's visibility is not reading the rule.
+    'writing the visibility' => ["'visibility' => ChannelVisibility::Public,"],
+]);


### PR DESCRIPTION
Closes #1144. Second child of #1142, after #1143. Unblocks #1148.

## What

"Which channels may this user see in a team" had **one name and three implementations**, two of which answered different questions:

| home | rule | fed |
|---|---|---|
| `User::visibleChannelIds()` | membership only | search, thread inbox, forwarding, placement |
| `ChannelPolicy::view()` | `belongsToTeam && (public \|\| member)` | the channel page |
| `Api/V1\ChannelController::index` | a raw re-derivation of the second | the REST channel list |

...all under a `User.php` docblock asserting there was a single home and that no consumer re-derived the ACL. Every reader trusting it was reasoning from a guarantee the code did not provide.

Both readings now live on `User` and nowhere else:

- **`memberChannelIds(Team)` / `memberChannelIdsAcrossTeams()`** — *what is mine*: search, the thread inbox, forwarding, `ChannelMembership` placement.
- **`readableChannels(Team)` / `readableChannelIds(Team)`** — *what may I open*: in a team I belong to, and either public or one I belong to. Returned as a **query** rather than a set so `ChannelPolicy::view()`'s per-channel `exists()` and the list's id set derive from one expression — the policy keeps its cheap single-row check instead of plucking a whole team per call.

The REST list goes through a new `ApiChannelAccess::channelIds()`, the bulk counterpart of the existing `allows()`, so the bot/human branch stays in the one place the singular check already made it.

`browse()` is left alone: "public **and not** a member" is a third, genuinely different question, already local to one method.

## The divergence this closes

Per the issue, this is a rename **except** where the `Api/V1` copy converges on the policy's rule — and it did not already agree. The raw copy omitted the team-membership half, so a personal access token outliving its holder's team membership (`RemoveTeamMember` does not revoke tokens) still enumerated the team's public channels, while every `show` on those same channels 404'd. The list and the singular read now answer alike.

## Testing

- `tests/Feature/Channels/VisibleChannelsAclTest.php` — rewritten around the two readings, and **pins the split as intentional**: a public channel the viewer never joined opens as a page and passes `view`, while being refused as a forward destination and absent from the membership id set the thread inbox and search filter on. Plus the new "a team I do not belong to reads as nothing" case.
- `tests/Feature/Api/V1/PersonalAccessTokenApiTest.php` — the list answers the readable reading (public-not-joined in, private-not-joined out), and stops listing once the human is removed from the token's bound team. **That test is red before this change** (3 channels returned, `show` already 404ing).
- `tests/Unit/VisibleChannelsAclHomeTest.php` — new tripwire, in the shape #1143 established: a third spelling of either reading anywhere in `app/` fails here. Each pattern is pinned against the copy it was written for *and* against the legitimate single-half questions it must stay quiet about (`Channel::defaultsForTeam`, `ChannelPolicy::isMember`, `browse`'s inverse). Each reading is scanned for independently so a dead pattern cannot hide behind the other.

`grep -rn "whereHas('channelMembers'" app/Http/` now returns nothing.

## Records

- `dev-docs/adr/0003-single-visible-channels-acl-scope.md` carries a dated status note: the ACL has two readings, not one, and `Api/V1` is in scope. (Amendment, not a rewrite — the ADR records what was decided in July; ADR-0005 set the precedent.)
- `CONTEXT.md`'s **Visible-channels ACL** entry names both readings, and the "new check" line says to decide which one you mean first.

## Gates

`composer ci:check` green; coverage `Total: 100.0 %`. No user-facing copy and no operator-facing settings, so no i18n or `docs/` changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788282141&installation_model_id=428379&pr_number=1158&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1158&signature=fda4c785a31b7a525e29eb82d2057d2e5adddb5a4fb2e9483cb5e2bb484ecebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->