### PR TITLE
refactor: put nested-resource tenancy on the route, not in 15 call sites

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -292,6 +292,10 @@ built; build them once, then reuse.
   `AuditableActionOccurred` from it — the **domain-event seam**, next to the
   mutation.
 - New channel-member preference → the **channel membership settings** concern.
+- A new nested resource under `settings/teams/{team}/…` → name its route parameter after
+  the relationship that owns it (`{customEmoji}` → `Team::customEmojis()`), and let the
+  group's `->scopeBindings()` do the tenancy. A hand-rolled `belongs to this team` check
+  in a controller or a FormRequest is a defect (ADR-0014).
 - New message action (a row affordance that writes) → one method on the **message-action
   context**; never a new prop/emit pair through the timeline.
 - A write that shows its outcome before the server answers →

--- a/app/Concerns/ResolvesUserGroupRoute.php
+++ b/app/Concerns/ResolvesUserGroupRoute.php
@@ -6,10 +6,13 @@ use App\Models\Team;
 use App\Models\UserGroup;
 
 /**
- * Resolves the `{team}` and `{group}` route bindings for the user-group
- * management requests, and enforces that the group really belongs to the team
- * in the URL. The scoping check runs before any policy so another workspace's
- * group reads as absent here rather than merely forbidden.
+ * Resolves the `{team}` and `{userGroup}` route bindings for the user-group
+ * management requests.
+ *
+ * Neither accessor re-asks whether the group belongs to the team in the URL:
+ * the route binds `{userGroup}` through `Team::userGroups()`, so a group from
+ * another workspace is already a 404 by the time a request is validated
+ * (ADR-0014).
  */
 trait ResolvesUserGroupRoute
 {
@@ -26,14 +29,13 @@ trait ResolvesUserGroupRoute
     }
 
     /**
-     * Get the group in the URL, scoped to that team.
+     * Get the group in the URL.
      */
     public function group(): UserGroup
     {
-        $group = $this->route('group');
+        $group = $this->route('userGroup');
 
         abort_if(! $group instanceof UserGroup, 404);
-        abort_unless($group->team_id === $this->team()->id, 404);
 
         return $group;
     }

--- a/app/Http/Controllers/Teams/AuditExportController.php
+++ b/app/Http/Controllers/Teams/AuditExportController.php
@@ -104,8 +104,6 @@ class AuditExportController extends Controller
      */
     public function download(Request $request, Team $team, AuditExport $auditExport): StreamedResponse
     {
-        abort_unless($auditExport->team_id === $team->id, 404);
-
         Gate::authorize(
             $auditExport->log_type === AuditExportLogType::Security ? 'viewSecurityLog' : 'viewAudit',
             $team,

--- a/app/Http/Controllers/Teams/CustomEmojiController.php
+++ b/app/Http/Controllers/Teams/CustomEmojiController.php
@@ -57,13 +57,11 @@ class CustomEmojiController extends Controller
     /**
      * Remove a custom emoji — the uploader deletes their own, an admin revokes any.
      */
-    public function destroy(Request $request, Team $team, CustomEmoji $emoji, RevokeCustomEmoji $revokeCustomEmoji): RedirectResponse
+    public function destroy(Request $request, Team $team, CustomEmoji $customEmoji, RevokeCustomEmoji $revokeCustomEmoji): RedirectResponse
     {
-        abort_unless($emoji->team_id === $team->id, 404);
+        Gate::authorize('delete', $customEmoji);
 
-        Gate::authorize('delete', $emoji);
-
-        $revokeCustomEmoji->handle($team, $request->user(), $emoji);
+        $revokeCustomEmoji->handle($team, $request->user(), $customEmoji);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Emoji removed')]);
 

--- a/app/Http/Controllers/Teams/Integrations/BotChannelController.php
+++ b/app/Http/Controllers/Teams/Integrations/BotChannelController.php
@@ -15,7 +15,6 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 
 /**
@@ -34,8 +33,6 @@ class BotChannelController extends Controller
      */
     public function store(StoreBotChannelRequest $request, Team $team, User $bot, JoinChannel $joinChannel): RedirectResponse
     {
-        $this->ensureBotBelongsToTeam($bot, $team);
-
         /** @var Channel $channel */
         $channel = $team->channels()->whereKey($request->validated('channel_id'))->firstOrFail();
 
@@ -51,24 +48,14 @@ class BotChannelController extends Controller
      */
     public function destroy(Request $request, Team $team, User $bot, Channel $channel, RemoveChannelMember $removeChannelMember): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureBotBelongsToTeam($bot, $team);
-
-        abort_unless($channel->team_id === $team->id && $channel->type === ChannelType::Standard, 404);
+        // Tenancy is the route's job; what is left is the domain rule that this
+        // surface manages standard-channel membership only, never a DM.
+        abort_unless($channel->type === ChannelType::Standard, 404);
 
         $removeChannelMember->handle($channel, $bot, removedBy: $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Bot removed from :channel', ['channel' => $channel->name])]);
 
         return to_route('teams.integrations.bots.show', ['team' => $team->slug, 'bot' => $bot->id]);
-    }
-
-    /**
-     * Guard that the resolved user really is a bot scoped to this team.
-     */
-    private function ensureBotBelongsToTeam(User $bot, Team $team): void
-    {
-        abort_unless($bot->isBot() && $bot->owner_team_id === $team->id, 404);
     }
 }

--- a/app/Http/Controllers/Teams/Integrations/BotController.php
+++ b/app/Http/Controllers/Teams/Integrations/BotController.php
@@ -17,7 +17,6 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -40,10 +39,6 @@ class BotController extends Controller
      */
     public function show(Request $request, Team $team, User $bot): Response
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureBotBelongsToTeam($bot, $team);
-
         $bot->loadCount(['channels', 'tokens'])->loadMax('messages', 'created_at')->load('creator');
 
         $memberships = $this->botChannels($bot);
@@ -67,10 +62,6 @@ class BotController extends Controller
      */
     public function destroy(Request $request, Team $team, User $bot, DeleteBot $deleteBot): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureBotBelongsToTeam($bot, $team);
-
         $deleteBot->handle($request->user(), $bot);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Bot deleted')]);
@@ -120,13 +111,5 @@ class BotController extends Controller
                 'visibility' => $channel->visibility->value,
             ])
             ->all();
-    }
-
-    /**
-     * Guard that the resolved user really is a bot scoped to this team.
-     */
-    private function ensureBotBelongsToTeam(User $bot, Team $team): void
-    {
-        abort_unless($bot->isBot() && $bot->owner_team_id === $team->id, 404);
     }
 }

--- a/app/Http/Controllers/Teams/Integrations/BotTokenController.php
+++ b/app/Http/Controllers/Teams/Integrations/BotTokenController.php
@@ -12,7 +12,6 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 
 class BotTokenController extends Controller
@@ -22,8 +21,6 @@ class BotTokenController extends Controller
      */
     public function store(StoreBotTokenRequest $request, Team $team, User $bot, MintBotToken $mint): RedirectResponse
     {
-        $this->ensureBotBelongsToTeam($bot, $team);
-
         $token = $mint->handle($bot, $request->user(), $request->validated('name'), $request->abilities());
 
         Inertia::flash('revealed', [
@@ -40,10 +37,6 @@ class BotTokenController extends Controller
      */
     public function destroy(Request $request, Team $team, User $bot, string $token, RevokeBotToken $revoke): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureBotBelongsToTeam($bot, $team);
-
         $accessToken = $bot->tokens()->whereKey($token)->firstOrFail();
 
         $revoke->handle($request->user(), $accessToken);
@@ -51,13 +44,5 @@ class BotTokenController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Token revoked')]);
 
         return back();
-    }
-
-    /**
-     * Guard that the resolved user really is a bot scoped to this team.
-     */
-    private function ensureBotBelongsToTeam(User $bot, Team $team): void
-    {
-        abort_unless($bot->isBot() && $bot->owner_team_id === $team->id, 404);
     }
 }

--- a/app/Http/Controllers/Teams/Integrations/IncomingWebhookController.php
+++ b/app/Http/Controllers/Teams/Integrations/IncomingWebhookController.php
@@ -14,7 +14,6 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 
 class IncomingWebhookController extends Controller
@@ -52,10 +51,6 @@ class IncomingWebhookController extends Controller
      */
     public function destroy(Request $request, Team $team, IncomingWebhook $incomingWebhook, RevokeIncomingWebhook $revoke): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        abort_unless($incomingWebhook->team_id === $team->id, 404);
-
         $revoke->handle($request->user(), $incomingWebhook);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Incoming webhook revoked')]);

--- a/app/Http/Controllers/Teams/Integrations/IntegrationsController.php
+++ b/app/Http/Controllers/Teams/Integrations/IntegrationsController.php
@@ -13,7 +13,6 @@ use App\Http\Controllers\Controller;
 use App\Models\Channel;
 use App\Models\Team;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -25,8 +24,6 @@ class IntegrationsController extends Controller
      */
     public function index(Request $request, Team $team): Response
     {
-        Gate::authorize('manageIntegrations', $team);
-
         return Inertia::render('teams/integrations/Index', [
             'team' => [
                 'id' => $team->id,

--- a/app/Http/Controllers/Teams/Integrations/WebhookSubscriptionController.php
+++ b/app/Http/Controllers/Teams/Integrations/WebhookSubscriptionController.php
@@ -17,7 +17,6 @@ use App\Models\WebhookDelivery;
 use App\Models\WebhookSubscription;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -51,10 +50,6 @@ class WebhookSubscriptionController extends Controller
      */
     public function show(Request $request, Team $team, WebhookSubscription $webhookSubscription): Response
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureSubscriptionBelongsToTeam($webhookSubscription, $team);
-
         return Inertia::render('teams/integrations/Webhook', [
             'team' => [
                 'id' => $team->id,
@@ -70,10 +65,6 @@ class WebhookSubscriptionController extends Controller
      */
     public function destroy(Request $request, Team $team, WebhookSubscription $webhookSubscription, RevokeWebhookSubscription $revoke): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureSubscriptionBelongsToTeam($webhookSubscription, $team);
-
         $revoke->handle($request->user(), $webhookSubscription);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Subscription revoked')]);
@@ -86,10 +77,6 @@ class WebhookSubscriptionController extends Controller
      */
     public function reenable(Request $request, Team $team, WebhookSubscription $webhookSubscription, ReenableWebhookSubscription $reenable): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureSubscriptionBelongsToTeam($webhookSubscription, $team);
-
         $reenable->handle($request->user(), $webhookSubscription);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Subscription re-enabled')]);
@@ -104,16 +91,11 @@ class WebhookSubscriptionController extends Controller
      * so it is offered on a disabled subscription too — verifying a fixed
      * endpoint is exactly what it is for.
      */
-    public function replay(Request $request, Team $team, WebhookSubscription $webhookSubscription, WebhookDelivery $webhookDelivery, ReplayWebhookDelivery $replay): RedirectResponse
+    public function replay(Request $request, Team $team, WebhookSubscription $webhookSubscription, WebhookDelivery $delivery, ReplayWebhookDelivery $replay): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
+        abort_unless($delivery->isReplayable(), 422, __('This delivery was logged before payloads were retained, so it cannot be replayed.'));
 
-        $this->ensureSubscriptionBelongsToTeam($webhookSubscription, $team);
-
-        abort_unless($webhookDelivery->webhook_subscription_id === $webhookSubscription->id, 404);
-        abort_unless($webhookDelivery->isReplayable(), 422, __('This delivery was logged before payloads were retained, so it cannot be replayed.'));
-
-        $replay->handle($request->user(), $webhookDelivery);
+        $replay->handle($request->user(), $delivery);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Delivery queued for replay')]);
 
@@ -125,10 +107,6 @@ class WebhookSubscriptionController extends Controller
      */
     public function rotateSecret(Request $request, Team $team, WebhookSubscription $webhookSubscription, RotateWebhookSecret $rotate): RedirectResponse
     {
-        Gate::authorize('manageIntegrations', $team);
-
-        $this->ensureSubscriptionBelongsToTeam($webhookSubscription, $team);
-
         $secret = $rotate->handle($request->user(), $webhookSubscription);
 
         Inertia::flash('revealed', [
@@ -138,13 +116,5 @@ class WebhookSubscriptionController extends Controller
         ]);
 
         return back();
-    }
-
-    /**
-     * Guard that the subscription belongs to this team.
-     */
-    private function ensureSubscriptionBelongsToTeam(WebhookSubscription $subscription, Team $team): void
-    {
-        abort_unless($subscription->team_id === $team->id, 404);
     }
 }

--- a/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -44,8 +44,6 @@ class TeamInvitationController extends Controller
      */
     public function destroy(Request $request, Team $team, TeamInvitation $invitation, RevokeTeamInvitation $revokeInvitation): RedirectResponse
     {
-        abort_unless($invitation->team_id === $team->id, 404);
-
         Gate::authorize('cancelInvitation', $team);
 
         $revokeInvitation->handle($invitation, $request->user());
@@ -63,8 +61,6 @@ class TeamInvitationController extends Controller
      */
     public function resend(Request $request, Team $team, TeamInvitation $invitation, ResendTeamInvitation $resendInvitation): RedirectResponse
     {
-        abort_unless($invitation->team_id === $team->id, 404);
-
         Gate::authorize('inviteMember', $team);
 
         abort_if($invitation->isAccepted(), 404);

--- a/app/Http/Controllers/Teams/TeamMemberController.php
+++ b/app/Http/Controllers/Teams/TeamMemberController.php
@@ -28,17 +28,15 @@ class TeamMemberController extends Controller
      * membership middleware); a user who is not a member of that team resolves
      * to a 404 so profiles never leak across team boundaries.
      */
-    public function show(Request $request, Team $team, User $user): Response
+    public function show(Request $request, Team $team, User $member): Response
     {
-        $membership = $this->membershipOrFail($team, $user);
-
         return Inertia::render('teams/MemberProfile', [
             'team' => [
                 'id' => $team->id,
                 'name' => $team->name,
                 'slug' => $team->slug,
             ],
-            'profile' => UserProfileData::forMember($user, $membership, $request->user()),
+            'profile' => UserProfileData::forMember($member, $this->membership($member), $request->user()),
         ]);
     }
 
@@ -48,23 +46,22 @@ class TeamMemberController extends Controller
      * Same team-scoped visibility as {@see show()}; fetched lazily by the hover
      * card so names across the app can reveal richer details on demand.
      */
-    public function card(Request $request, Team $team, User $user): UserProfileData
+    public function card(Request $request, Team $team, User $member): UserProfileData
     {
-        return UserProfileData::forMember($user, $this->membershipOrFail($team, $user), $request->user());
+        return UserProfileData::forMember($member, $this->membership($member), $request->user());
     }
 
     /**
-     * Resolve the target user's membership of the team, or 404 when they are not
-     * a member so profiles never leak across team boundaries.
+     * The membership row the route already resolved the member through.
+     *
+     * `{member}` is scoped to `Team::members()`, so the pivot arrives hydrated
+     * and a non-member is a 404 before this controller runs — there is nothing
+     * left here to re-check.
      */
-    private function membershipOrFail(Team $team, User $user): Membership
+    private function membership(User $member): Membership
     {
-        /** @var Membership|null $membership */
-        $membership = $team->memberships()
-            ->where('user_id', $user->id)
-            ->first();
-
-        abort_if($membership === null, 404);
+        /** @var Membership $membership */
+        $membership = $member->getRelation('pivot');
 
         return $membership;
     }
@@ -72,11 +69,11 @@ class TeamMemberController extends Controller
     /**
      * Update the specified team member's role.
      */
-    public function update(UpdateTeamMemberRequest $request, Team $team, User $user, UpdateTeamMemberRole $updateRole): RedirectResponse
+    public function update(UpdateTeamMemberRequest $request, Team $team, User $member, UpdateTeamMemberRole $updateRole): RedirectResponse
     {
         Gate::authorize('updateMember', $team);
 
-        $updateRole->handle($team, $user, TeamRole::from($request->validated('role')), $request->user());
+        $updateRole->handle($team, $member, TeamRole::from($request->validated('role')), $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member role updated')]);
 
@@ -90,15 +87,13 @@ class TeamMemberController extends Controller
      * member of the team. The outgoing owner is demoted to Admin and the new
      * owner holds the sole Owner pivot row (see {@see TransferTeamOwnership}).
      */
-    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $user, TransferTeamOwnership $transferOwnership): RedirectResponse
+    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $member, TransferTeamOwnership $transferOwnership): RedirectResponse
     {
         Gate::authorize('transferOwnership', $team);
 
-        abort_if($request->user()->is($user), 403, __('You cannot transfer ownership to yourself.'));
+        abort_if($request->user()->is($member), 403, __('You cannot transfer ownership to yourself.'));
 
-        abort_unless($user->belongsToTeam($team), 404);
-
-        $transferOwnership->handle($team, $request->user(), $user);
+        $transferOwnership->handle($team, $request->user(), $member);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Team ownership transferred')]);
 
@@ -108,13 +103,13 @@ class TeamMemberController extends Controller
     /**
      * Remove the specified team member.
      */
-    public function destroy(Request $request, Team $team, User $user, RemoveTeamMember $removeMember): RedirectResponse
+    public function destroy(Request $request, Team $team, User $member, RemoveTeamMember $removeMember): RedirectResponse
     {
         Gate::authorize('removeMember', $team);
 
-        abort_if($team->owner()?->is($user), 403, __('The team owner cannot be removed.'));
+        abort_if($team->owner()?->is($member), 403, __('The team owner cannot be removed.'));
 
-        $removeMember->handle($team, $user, $request->user());
+        $removeMember->handle($team, $member, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member removed')]);
 

--- a/app/Http/Controllers/Teams/UserGroupController.php
+++ b/app/Http/Controllers/Teams/UserGroupController.php
@@ -60,9 +60,9 @@ class UserGroupController extends Controller
      * Existing messages keep the label baked into their token at post time, so a
      * rename never rewrites history — old bodies still read as they were sent.
      */
-    public function update(UpdateUserGroupRequest $request, Team $team, UserGroup $group): RedirectResponse
+    public function update(UpdateUserGroupRequest $request, Team $team, UserGroup $userGroup): RedirectResponse
     {
-        $group->update($request->safe()->only(['name', 'slug']));
+        $userGroup->update($request->safe()->only(['name', 'slug']));
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Group updated')]);
 
@@ -73,13 +73,11 @@ class UserGroupController extends Controller
      * Delete a group. Its `@handle` tokens in existing messages fall back to
      * plain text, and the mention rows they already fanned out to stay put.
      */
-    public function destroy(Team $team, UserGroup $group): RedirectResponse
+    public function destroy(Team $team, UserGroup $userGroup): RedirectResponse
     {
-        abort_unless($group->team_id === $team->id, 404);
+        Gate::authorize('delete', $userGroup);
 
-        Gate::authorize('delete', $group);
-
-        $group->delete();
+        $userGroup->delete();
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Group deleted')]);
 
@@ -89,11 +87,11 @@ class UserGroupController extends Controller
     /**
      * Add a workspace member to a group.
      */
-    public function storeMember(StoreUserGroupMemberRequest $request, Team $team, UserGroup $group): RedirectResponse
+    public function storeMember(StoreUserGroupMemberRequest $request, Team $team, UserGroup $userGroup): RedirectResponse
     {
         // `syncWithoutDetaching` keeps a repeated add idempotent rather than
         // tripping the pivot's unique constraint.
-        $group->members()->syncWithoutDetaching([$request->validated('user_id')]);
+        $userGroup->members()->syncWithoutDetaching([$request->validated('user_id')]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member added to the group')]);
 
@@ -103,13 +101,11 @@ class UserGroupController extends Controller
     /**
      * Remove a member from a group.
      */
-    public function destroyMember(Team $team, UserGroup $group, User $user): RedirectResponse
+    public function destroyMember(Team $team, UserGroup $userGroup, User $member): RedirectResponse
     {
-        abort_unless($group->team_id === $team->id, 404);
+        Gate::authorize('update', $userGroup);
 
-        Gate::authorize('update', $group);
-
-        $group->members()->detach($user->id);
+        $userGroup->members()->detach($member->id);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member removed from the group')]);
 

--- a/app/Http/Requests/Teams/Integrations/StoreBotChannelRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreBotChannelRequest.php
@@ -10,7 +10,6 @@ use App\Models\User;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
 /**
@@ -20,14 +19,6 @@ use Illuminate\Validation\Rule;
  */
 class StoreBotChannelRequest extends FormRequest
 {
-    /**
-     * Only integration managers (Owner + Admin) may manage a bot's channels.
-     */
-    public function authorize(): bool
-    {
-        return Gate::allows('manageIntegrations', $this->team());
-    }
-
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */

--- a/app/Http/Requests/Teams/Integrations/StoreBotRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreBotRequest.php
@@ -4,24 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Teams\Integrations;
 
-use App\Models\Team;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Gate;
 
 /**
  * Validates creating a bot identity from the integrations settings surface.
  */
 class StoreBotRequest extends FormRequest
 {
-    /**
-     * Only integration managers (Owner + Admin) may create bots.
-     */
-    public function authorize(): bool
-    {
-        return Gate::allows('manageIntegrations', $this->team());
-    }
-
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */
@@ -30,17 +20,5 @@ class StoreBotRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
         ];
-    }
-
-    /**
-     * The team the bot belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Teams/Integrations/StoreBotTokenRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreBotTokenRequest.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Requests\Teams\Integrations;
 
 use App\Enums\IntegrationScope;
-use App\Models\Team;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
 /**
@@ -16,14 +14,6 @@ use Illuminate\Validation\Rule;
  */
 class StoreBotTokenRequest extends FormRequest
 {
-    /**
-     * Only integration managers (Owner + Admin) may mint bot tokens.
-     */
-    public function authorize(): bool
-    {
-        return Gate::allows('manageIntegrations', $this->team());
-    }
-
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */
@@ -47,17 +37,5 @@ class StoreBotTokenRequest extends FormRequest
         $abilities = array_values(array_unique($this->validated('abilities')));
 
         return $abilities;
-    }
-
-    /**
-     * The team the bot belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Teams/Integrations/StoreIncomingWebhookRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreIncomingWebhookRequest.php
@@ -7,7 +7,6 @@ namespace App\Http\Requests\Teams\Integrations;
 use App\Models\Team;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
 /**
@@ -17,14 +16,6 @@ use Illuminate\Validation\Rule;
  */
 class StoreIncomingWebhookRequest extends FormRequest
 {
-    /**
-     * Only integration managers (Owner + Admin) may create incoming webhooks.
-     */
-    public function authorize(): bool
-    {
-        return Gate::allows('manageIntegrations', $this->team());
-    }
-
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */

--- a/app/Http/Requests/Teams/Integrations/StoreWebhookSubscriptionRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreWebhookSubscriptionRequest.php
@@ -11,7 +11,6 @@ use App\Rules\PublicWebhookUrl;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
@@ -22,14 +21,6 @@ use Illuminate\Validation\Validator;
  */
 class StoreWebhookSubscriptionRequest extends FormRequest
 {
-    /**
-     * Only integration managers (Owner + Admin) may register subscriptions.
-     */
-    public function authorize(): bool
-    {
-        return Gate::allows('manageIntegrations', $this->team());
-    }
-
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */

--- a/dev-docs/adr/0014-nested-resource-tenancy-on-the-route.md
+++ b/dev-docs/adr/0014-nested-resource-tenancy-on-the-route.md
@@ -1,0 +1,95 @@
+# ADR-0014: Nested-resource tenancy is enforced by the route, not by controller preamble
+
+- Status: Accepted
+- Date: 2026-08-02
+- Relates to: epic architecture-hardening IV (#1142), child #1149
+
+## Context
+
+`routes/settings.php` hung twenty-six nested resources off `settings/teams/{team}/…`
+and bound every one of them by id alone. Nothing on the route tied a child to the
+workspace in the URL, so each controller re-answered *"does this row actually belong to
+this team?"* by hand, and each one answered it in its own words:
+
+```php
+abort_unless($incomingWebhook->team_id === $team->id, 404);          // IncomingWebhookController
+abort_unless($invitation->team_id === $team->id, 404);               // TeamInvitationController
+abort_unless($bot->isBot() && $bot->owner_team_id === $team->id, 404); // three controllers, verbatim
+abort_unless($user->belongsToTeam($team), 404);                      // TeamMemberController
+```
+
+`ensureBotBelongsToTeam` was copy-pasted body-and-docblock into three controllers and
+called from six sites; `ensureSubscriptionBelongsToTeam` was called from five. Counting
+the FormRequest accessors that carried the same check, the rule had **fifteen spellings**.
+
+Two consequences, and only the second is about duplication.
+
+**Cross-tenant isolation rested on fifteen remembered call sites.** A guard you have to
+remember is a guard you can forget, and `settings/teams/{team}/members/{user}` had:
+`Gate::authorize('removeMember', $team)` asked whether the actor may remove *somebody*,
+and then `RemoveTeamMember::handle()` ran against a user who was never in the workspace.
+The delete matched no row, but the action still emitted `AuditAction::MemberRemoved`
+carrying that outsider's name — an admin could write a fabricated removal into their own
+audit log naming any user in the instance. No test caught it because there was no rule to
+test against, only a habit that this method happened not to follow.
+
+**`manageIntegrations` was asked sixteen times for one surface** — eleven controller
+sites plus five FormRequests — and the placement disagreed by verb. `store` delegated to
+its FormRequest's `authorize()`; `show`, `destroy`, `reenable`, `replay` and
+`rotateSecret` asked inline. A reader of any one method could not tell which stratum had
+answered, or whether anything had.
+
+## Decision
+
+**A nested resource is scoped to its parent by the route, and a controller under
+`settings/teams/{team}/…` never re-checks tenancy.**
+
+Three parts:
+
+1. **`->scopeBindings()` on the whole `EnsureTeamMembership` group.** Laravel resolves a
+   child through the preceding model's relationship, so a row belonging to another
+   workspace — or, for a grandchild, to another parent — is a **404 raised by
+   `SubstituteBindings`, before any controller, FormRequest or policy runs.**
+2. **Each child parameter is named after the relationship that owns it.** Scoped binding
+   resolves `{customEmoji}` by calling `Team::customEmojis()`, so the parameter name *is*
+   the wiring. `{emoji}` → `{customEmoji}`, `{group}` → `{userGroup}`, `{user}` →
+   `{member}` (through `Team::members()` and `UserGroup::members()`), `{webhookDelivery}`
+   → `{delivery}`. A mismatch is not a style question: it is a `BadMethodCallException` on
+   the first request.
+3. **One `can:manageIntegrations,team` on the integrations group**, ahead of every verb,
+   replacing eleven `Gate::authorize` calls and five FormRequest `authorize()` bodies.
+   `Authorize` sorts after `SubstituteBindings` in the middleware priority list, so a
+   foreign child is a 404 and a forbidden actor is a 403, in that order.
+
+**A hand-rolled `belongs to this team` check under `settings/teams/{team}/…` is a
+defect.** If a check is needed that scoped binding cannot express, it is not tenancy —
+say what it actually is. `BotChannelController::destroy` keeps
+`abort_unless($channel->type === ChannelType::Standard, 404)` because that is a domain
+rule (this surface manages standard-channel membership, never a DM), and the comment
+above it says so.
+
+## Consequences
+
+- **The guard is structural.** A new nested route under this group is scoped the moment it
+  is declared; forgetting is no longer possible, because forgetting now means naming a
+  parameter that no relationship answers to, and that fails loudly on the first request.
+- **Two behaviour changes, both tightenings**, and both now have tests:
+  `settings/teams/{team}/members/{member}` 404s for a non-member on every verb (closing the
+  fabricated-audit-entry path above), and removing a bot from a channel it is not a member
+  of 404s rather than silently succeeding.
+- **`TeamMemberController` reads the membership off the pivot** rather than re-querying it.
+  `{member}` resolves through `Team::members()`, a `belongsToMany` with `Membership` as its
+  pivot, so the row arrives hydrated. This is a real coupling to how the binding resolved,
+  and it is stated in the method's docblock.
+- **Route parameter names are part of the public surface.** They appear in
+  Wayfinder-generated call signatures, so renaming one is a frontend change too. Tests that
+  pass positional arrays are unaffected; the ones naming keys had to be updated. That cost
+  is paid once per route and buys the scoping.
+- **`Api/V1` is deliberately out of scope.** It is a separate route group whose parents are
+  resolved from the authenticated token rather than from the URL, so it needs its own
+  answer rather than this one applied by rote. Four hand-rolled tenancy checks remain
+  there (`ReactionController`, `MessageController` ×2, `WebhookSubscriptionController`),
+  as do two in `app/Http/Requests/Channels/Sidebar/`. They are follow-up territory, not an
+  exception to the rule.
+- **The FormRequest accessors survive**, now doing only what their name says — resolving
+  the binding, not policing it. #1151 gives them one shared base.

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -18,3 +18,4 @@ seams live in [`CONTEXT.md`](../../CONTEXT.md).
 | [0010](0010-channel-traffic-predicate-has-one-home-per-language.md) | The channel-traffic predicate has one home per language |
 | [0011](0011-read-model-dto-takes-its-viewer.md) | A read-model DTO takes its viewer, and batches its roster |
 | [0012](0012-three-test-suites.md) | Three test suites: pure, database, HTTP contract |
+| [0014](0014-nested-resource-tenancy-on-the-route.md) | Nested-resource tenancy is enforced by the route |

--- a/resources/js/components/teams/DeleteUserGroupDialog.vue
+++ b/resources/js/components/teams/DeleteUserGroupDialog.vue
@@ -33,7 +33,7 @@ function confirmRemoval(): void {
         return;
     }
 
-    removalForm.delete(destroy({ team: props.team, group: group.id }).url, {
+    removalForm.delete(destroy({ team: props.team, userGroup: group.id }).url, {
         preserveScroll: true,
         // Closed only once the delete lands: a failed request leaves the
         // dialog open rather than dismissing it as though it had worked.

--- a/resources/js/components/teams/EditUserGroupDialog.vue
+++ b/resources/js/components/teams/EditUserGroupDialog.vue
@@ -68,7 +68,7 @@ function submitRename(): void {
         return;
     }
 
-    editForm.patch(update({ team: props.team, group: group.id }).url, {
+    editForm.patch(update({ team: props.team, userGroup: group.id }).url, {
         preserveScroll: true,
     });
 }

--- a/resources/js/components/teams/UserGroupMembersEditor.vue
+++ b/resources/js/components/teams/UserGroupMembersEditor.vue
@@ -47,7 +47,7 @@ const candidates = computed<Member[]>(() => {
 function addToGroup(member: Member): void {
     membershipForm.user_id = member.id;
     membershipForm.post(
-        addMember({ team: props.team, group: props.group.id }).url,
+        addMember({ team: props.team, userGroup: props.group.id }).url,
         { preserveScroll: true, onSuccess: () => (search.value = '') },
     );
 }
@@ -56,8 +56,8 @@ function removeFromGroup(memberId: string): void {
     membershipForm.delete(
         removeMember({
             team: props.team,
-            group: props.group.id,
-            user: memberId,
+            userGroup: props.group.id,
+            member: memberId,
         }).url,
         { preserveScroll: true },
     );

--- a/resources/js/pages/teams/Emojis.vue
+++ b/resources/js/pages/teams/Emojis.vue
@@ -111,7 +111,7 @@ function confirmRemoval(): void {
     }
 
     removalForm.delete(
-        destroy({ team: props.team.slug, emoji: emoji.id }).url,
+        destroy({ team: props.team.slug, customEmoji: emoji.id }).url,
         {
             preserveScroll: true,
             onFinish: () => {

--- a/resources/js/pages/teams/integrations/Webhook.vue
+++ b/resources/js/pages/teams/integrations/Webhook.vue
@@ -124,7 +124,7 @@ function replay(delivery: Delivery): void {
         webhookReplay({
             team: props.team.slug,
             webhookSubscription: subscription.value.id,
-            webhookDelivery: delivery.id,
+            delivery: delivery.id,
         }).url,
         { preserveScroll: true },
     );

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -134,7 +134,14 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::get('settings/teams', [TeamController::class, 'index'])->name('teams.index');
     Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');
 
-    Route::middleware(EnsureTeamMembership::class)->group(function (): void {
+    // Every nested resource below is bound through its parent's relationship
+    // rather than by id alone, so a child of another workspace 404s before any
+    // controller runs (ADR-0014). That is why each child parameter is named
+    // after the relationship that owns it — `{customEmoji}` resolves through
+    // `Team::customEmojis()`, `{delivery}` through
+    // `WebhookSubscription::deliveries()` — and why a controller here never
+    // re-asks whether the row belongs to the workspace in the URL.
+    Route::middleware(EnsureTeamMembership::class)->scopeBindings()->group(function (): void {
         Route::get('settings/teams/{team}', [TeamController::class, 'edit'])->name('teams.edit');
         Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
         Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
@@ -159,30 +166,29 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
             ->name('teams.deleted-channels.index');
         Route::post('settings/teams/{team}/deleted-channels/{channel:id}/restore', [DeletedChannelController::class, 'restore'])
             ->withTrashed()
-            ->scopeBindings()
             ->name('teams.deleted-channels.restore');
 
         Route::get('settings/teams/{team}/emojis', [CustomEmojiController::class, 'index'])->name('teams.emojis.index');
         Route::post('settings/teams/{team}/emojis', [CustomEmojiController::class, 'store'])->name('teams.emojis.store');
-        Route::delete('settings/teams/{team}/emojis/{emoji}', [CustomEmojiController::class, 'destroy'])
+        Route::delete('settings/teams/{team}/emojis/{customEmoji}', [CustomEmojiController::class, 'destroy'])
             ->name('teams.emojis.destroy');
 
         Route::get('settings/teams/{team}/groups', [UserGroupController::class, 'index'])->name('teams.groups.index');
         Route::post('settings/teams/{team}/groups', [UserGroupController::class, 'store'])->name('teams.groups.store');
-        Route::patch('settings/teams/{team}/groups/{group}', [UserGroupController::class, 'update'])
+        Route::patch('settings/teams/{team}/groups/{userGroup}', [UserGroupController::class, 'update'])
             ->name('teams.groups.update');
-        Route::delete('settings/teams/{team}/groups/{group}', [UserGroupController::class, 'destroy'])
+        Route::delete('settings/teams/{team}/groups/{userGroup}', [UserGroupController::class, 'destroy'])
             ->name('teams.groups.destroy');
-        Route::post('settings/teams/{team}/groups/{group}/members', [UserGroupController::class, 'storeMember'])
+        Route::post('settings/teams/{team}/groups/{userGroup}/members', [UserGroupController::class, 'storeMember'])
             ->name('teams.groups.members.store');
-        Route::delete('settings/teams/{team}/groups/{group}/members/{user}', [UserGroupController::class, 'destroyMember'])
+        Route::delete('settings/teams/{team}/groups/{userGroup}/members/{member}', [UserGroupController::class, 'destroyMember'])
             ->name('teams.groups.members.destroy');
 
-        Route::get('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'show'])->name('teams.members.show');
-        Route::get('settings/teams/{team}/members/{user}/card', [TeamMemberController::class, 'card'])->name('teams.members.card');
-        Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('teams.members.update');
-        Route::post('settings/teams/{team}/members/{user}/transfer-ownership', [TeamMemberController::class, 'transferOwnership'])->name('teams.members.transfer-ownership');
-        Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');
+        Route::get('settings/teams/{team}/members/{member}', [TeamMemberController::class, 'show'])->name('teams.members.show');
+        Route::get('settings/teams/{team}/members/{member}/card', [TeamMemberController::class, 'card'])->name('teams.members.card');
+        Route::patch('settings/teams/{team}/members/{member}', [TeamMemberController::class, 'update'])->name('teams.members.update');
+        Route::post('settings/teams/{team}/members/{member}/transfer-ownership', [TeamMemberController::class, 'transferOwnership'])->name('teams.members.transfer-ownership');
+        Route::delete('settings/teams/{team}/members/{member}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');
 
         Route::post('settings/teams/{team}/invitations', [TeamInvitationController::class, 'store'])->name('teams.invitations.store');
         Route::delete('settings/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])->name('teams.invitations.destroy');
@@ -191,8 +197,9 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         // The integrations management surface (bots, API tokens, incoming and
         // outgoing webhooks). The whole group additionally 404s when the
         // integrations platform is disabled, so the settings surface disappears
-        // in lockstep with the API.
-        Route::middleware('integrations')->group(function (): void {
+        // in lockstep with the API, and answers `manageIntegrations` once for
+        // every verb rather than once per controller method.
+        Route::middleware(['integrations', 'can:manageIntegrations,team'])->group(function (): void {
             Route::get('settings/teams/{team}/integrations', [IntegrationsController::class, 'index'])
                 ->name('teams.integrations.index');
 
@@ -231,7 +238,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
             // Replaying re-POSTs to an operator-supplied external URL, so it is
             // throttled per actor to keep the button from being used to hammer
             // a third party.
-            Route::post('settings/teams/{team}/integrations/webhooks/{webhookSubscription}/deliveries/{webhookDelivery}/replay', [WebhookSubscriptionController::class, 'replay'])
+            Route::post('settings/teams/{team}/integrations/webhooks/{webhookSubscription}/deliveries/{delivery}/replay', [WebhookSubscriptionController::class, 'replay'])
                 ->middleware('throttle:webhook-replay')
                 ->name('teams.integrations.webhooks.deliveries.replay');
         });

--- a/tests/Feature/Teams/CustomEmojiTest.php
+++ b/tests/Feature/Teams/CustomEmojiTest.php
@@ -128,7 +128,7 @@ test('the uploader can delete their own emoji', function (): void {
     Storage::disk(CustomEmoji::DISK)->put($emoji->path, 'x');
 
     $this->actingAs($member)
-        ->delete(route('teams.emojis.destroy', ['team' => $team, 'emoji' => $emoji]))
+        ->delete(route('teams.emojis.destroy', ['team' => $team, 'customEmoji' => $emoji]))
         ->assertRedirect();
 
     expect(CustomEmoji::find($emoji->id))->toBeNull();
@@ -142,7 +142,7 @@ test('a member cannot delete someone else’s emoji', function (): void {
     $emoji = CustomEmoji::factory()->for($team)->create(['created_by' => $owner->id]);
 
     $this->actingAs($member)
-        ->delete(route('teams.emojis.destroy', ['team' => $team, 'emoji' => $emoji]))
+        ->delete(route('teams.emojis.destroy', ['team' => $team, 'customEmoji' => $emoji]))
         ->assertForbidden();
 
     expect(CustomEmoji::find($emoji->id))->not->toBeNull();
@@ -155,7 +155,7 @@ test('an admin can revoke any emoji and it is recorded in the audit log', functi
     $emoji = CustomEmoji::factory()->for($team)->name('this-is-fine')->create(['created_by' => $author->id]);
 
     $this->actingAs($admin)
-        ->delete(route('teams.emojis.destroy', ['team' => $team, 'emoji' => $emoji]))
+        ->delete(route('teams.emojis.destroy', ['team' => $team, 'customEmoji' => $emoji]))
         ->assertRedirect();
 
     expect(CustomEmoji::find($emoji->id))->toBeNull();
@@ -171,7 +171,7 @@ test('an emoji scoped to another team 404s', function (): void {
     $emoji = CustomEmoji::factory()->for($other)->create();
 
     $this->actingAs($owner)
-        ->delete(route('teams.emojis.destroy', ['team' => $team, 'emoji' => $emoji]))
+        ->delete(route('teams.emojis.destroy', ['team' => $team, 'customEmoji' => $emoji]))
         ->assertNotFound();
 });
 

--- a/tests/Feature/Teams/Integrations/BotChannelManagementTest.php
+++ b/tests/Feature/Teams/Integrations/BotChannelManagementTest.php
@@ -176,6 +176,20 @@ it('unblocks creating an incoming webhook for the bot-and-channel pair', functio
     expect($team->incomingWebhooks()->where('bot_id', $bot->id)->where('channel_id', $channel->id)->exists())->toBeTrue();
 });
 
+it('404s removing a bot from a direct message', function (): void {
+    // Tenancy moved to the route binding, but this surface still manages
+    // standard-channel membership only — a DM is not its business.
+    ['team' => $team, 'owner' => $owner, 'bot' => $bot] = botChannelFixture();
+    $dm = Channel::factory()->for($team)->direct()->create();
+    $dm->channelMembers()->create(['user_id' => $bot->id]);
+
+    $this->actingAs($owner)
+        ->delete(route('teams.integrations.bots.channels.destroy', ['team' => $team->slug, 'bot' => $bot->id, 'channel' => $dm->id]))
+        ->assertNotFound();
+
+    expect($dm->channelMembers()->where('user_id', $bot->id)->exists())->toBeTrue();
+});
+
 it('404s removing from a channel in another team', function (): void {
     ['team' => $team, 'owner' => $owner, 'bot' => $bot] = botChannelFixture();
     $foreignChannel = Channel::factory()->for(Team::factory()->create())->create();

--- a/tests/Feature/Teams/Integrations/IntegrationsAuthorizationTest.php
+++ b/tests/Feature/Teams/Integrations/IntegrationsAuthorizationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\IncomingWebhook;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use App\Models\WebhookSubscription;
+
+/**
+ * A workspace with a plain member in it, and one of everything the integrations
+ * surface manages so each verb has a real row to aim at.
+ *
+ * @return array{member: User, team: Team}
+ */
+function integrationsAuthorizationFixture(): array
+{
+    $team = Team::factory()->create();
+    $member = User::factory()->create();
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    return ['member' => $member, 'team' => $team];
+}
+
+/**
+ * Every verb on the integrations surface, paired with a closure that builds the
+ * row it acts on inside the actor's own workspace — so the only thing left to
+ * refuse the request is the `manageIntegrations` gate.
+ */
+dataset('integrations verbs', [
+    'index' => ['get', 'teams.integrations.index', fn (Team $team): array => [[$team->slug], []]],
+    'bot create' => ['post', 'teams.integrations.bots.store', fn (Team $team): array => [[$team->slug], ['name' => 'Deploy Bot']]],
+    'bot detail' => ['get', 'teams.integrations.bots.show', fn (Team $team): array => [
+        [$team->slug, User::factory()->bot($team)->create()->id], [],
+    ]],
+    'bot destroy' => ['delete', 'teams.integrations.bots.destroy', fn (Team $team): array => [
+        [$team->slug, User::factory()->bot($team)->create()->id], [],
+    ]],
+    'bot channel add' => ['post', 'teams.integrations.bots.channels.store', fn (Team $team): array => [
+        [$team->slug, User::factory()->bot($team)->create()->id],
+        ['channel_id' => Channel::factory()->for($team)->create()->id],
+    ]],
+    'bot channel remove' => ['delete', 'teams.integrations.bots.channels.destroy', function (Team $team): array {
+        $bot = User::factory()->bot($team)->create();
+        $channel = Channel::factory()->for($team)->create();
+        $channel->channelMembers()->create(['user_id' => $bot->id]);
+
+        return [[$team->slug, $bot->id, $channel->id], []];
+    }],
+    'bot token mint' => ['post', 'teams.integrations.bots.tokens.store', fn (Team $team): array => [
+        [$team->slug, User::factory()->bot($team)->create()->id],
+        ['name' => 'CI', 'abilities' => ['messages:write']],
+    ]],
+    'bot token revoke' => ['delete', 'teams.integrations.bots.tokens.destroy', function (Team $team): array {
+        $bot = User::factory()->bot($team)->create();
+        $token = $bot->createToken('CI', ['messages:write']);
+
+        return [[$team->slug, $bot->id, $token->accessToken->getKey()], []];
+    }],
+    'incoming webhook create' => ['post', 'teams.integrations.incoming-webhooks.store', function (Team $team): array {
+        $bot = User::factory()->bot($team)->create();
+        $channel = Channel::factory()->for($team)->create();
+        $channel->channelMembers()->create(['user_id' => $bot->id]);
+
+        return [[$team->slug], ['name' => 'CI alerts', 'bot_id' => $bot->id, 'channel_id' => $channel->id]];
+    }],
+    'incoming webhook revoke' => ['delete', 'teams.integrations.incoming-webhooks.destroy', fn (Team $team): array => [
+        [$team->slug, IncomingWebhook::factory()->for($team)->create()->id], [],
+    ]],
+    'subscription create' => ['post', 'teams.integrations.webhooks.store', fn (Team $team): array => [
+        [$team->slug],
+        ['name' => 'Audit sink', 'url' => 'https://example.com/hook', 'events' => ['message.created']],
+    ]],
+    'subscription detail' => ['get', 'teams.integrations.webhooks.show', fn (Team $team): array => [
+        [$team->slug, WebhookSubscription::factory()->for($team)->create()->id], [],
+    ]],
+    'subscription revoke' => ['delete', 'teams.integrations.webhooks.destroy', fn (Team $team): array => [
+        [$team->slug, WebhookSubscription::factory()->for($team)->create()->id], [],
+    ]],
+    'subscription reenable' => ['post', 'teams.integrations.webhooks.reenable', fn (Team $team): array => [
+        [$team->slug, WebhookSubscription::factory()->for($team)->create()->id], [],
+    ]],
+    'subscription secret rotation' => ['post', 'teams.integrations.webhooks.rotate-secret', fn (Team $team): array => [
+        [$team->slug, WebhookSubscription::factory()->for($team)->create()->id], [],
+    ]],
+    'delivery replay' => ['post', 'teams.integrations.webhooks.deliveries.replay', function (Team $team): array {
+        $subscription = WebhookSubscription::factory()->for($team)->create();
+        $delivery = WebhookDelivery::factory()->for($subscription, 'subscription')->create();
+
+        return [[$team->slug, $subscription->id, $delivery->id], []];
+    }],
+]);
+
+it('403s every integrations verb for a member who cannot manage integrations', function (string $method, string $name, Closure $build): void {
+    ['member' => $member, 'team' => $team] = integrationsAuthorizationFixture();
+
+    [$parameters, $body] = $build($team);
+
+    $this->actingAs($member)
+        ->{$method}(route($name, $parameters), $body)
+        ->assertForbidden();
+})->with('integrations verbs');

--- a/tests/Feature/Teams/NestedResourceTenancyTest.php
+++ b/tests/Feature/Teams/NestedResourceTenancyTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TeamRole;
+use App\Models\AuditExport;
+use App\Models\Channel;
+use App\Models\CustomEmoji;
+use App\Models\IncomingWebhook;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Models\WebhookDelivery;
+use App\Models\WebhookSubscription;
+
+/**
+ * An owner of one workspace, plus a second workspace whose rows every case below
+ * tries to reach by hanging them off the first workspace's URL.
+ *
+ * @return array{actor: User, team: Team, other: Team}
+ */
+function tenancyFixture(): array
+{
+    $team = Team::factory()->create();
+    $other = Team::factory()->create();
+    $actor = User::factory()->create();
+    $team->members()->attach($actor, ['role' => TeamRole::Owner->value]);
+
+    return ['actor' => $actor, 'team' => $team, 'other' => $other];
+}
+
+/**
+ * Every `settings/teams/{team}/…` route carrying a nested child, paired with a
+ * closure that builds that child outside the workspace in the URL.
+ *
+ * The actor administers the workspace in the URL, so authorization passes and
+ * the only thing left to refuse the request is the binding.
+ */
+dataset('a child outside the workspace', [
+    'audit export download' => ['get', 'teams.audit-exports.download', fn (Team $team, Team $other): array => [[$team->slug, AuditExport::factory()->for($other)->ready()->create()->id], []]],
+    'deleted channel restore' => ['post', 'teams.deleted-channels.restore', function (Team $team, Team $other): array {
+        $channel = Channel::factory()->for($other)->create();
+        $channel->delete();
+
+        return [[$team->slug, $channel->id], []];
+    }],
+    'custom emoji destroy' => ['delete', 'teams.emojis.destroy', fn (Team $team, Team $other): array => [[$team->slug, CustomEmoji::factory()->for($other)->create()->id], []]],
+    'user group update' => ['patch', 'teams.groups.update', fn (Team $team, Team $other): array => [[$team->slug, UserGroup::factory()->for($other)->create()->id], ['name' => 'Hijacked']]],
+    'user group destroy' => ['delete', 'teams.groups.destroy', fn (Team $team, Team $other): array => [[$team->slug, UserGroup::factory()->for($other)->create()->id], []]],
+    'user group member add' => ['post', 'teams.groups.members.store', fn (Team $team, Team $other, User $actor): array => [[$team->slug, UserGroup::factory()->for($other)->create()->id], ['user_id' => $actor->id]]],
+    'user group member remove' => ['delete', 'teams.groups.members.destroy', function (Team $team, Team $other): array {
+        $group = UserGroup::factory()->for($other)->create();
+        $stranger = User::factory()->create();
+        $other->members()->attach($stranger, ['role' => TeamRole::Member->value]);
+        $group->members()->attach($stranger);
+
+        return [[$team->slug, $group->id, $stranger->id], []];
+    }],
+    'member profile page' => ['get', 'teams.members.show', fn (Team $team, Team $other): array => [[$team->slug, teamStranger($other)->id], []]],
+    'member profile card' => ['get', 'teams.members.card', fn (Team $team, Team $other): array => [[$team->slug, teamStranger($other)->id], []]],
+    'member role update' => ['patch', 'teams.members.update', fn (Team $team, Team $other): array => [[$team->slug, teamStranger($other)->id], ['role' => TeamRole::Admin->value]]],
+    'ownership transfer' => ['post', 'teams.members.transfer-ownership', fn (Team $team, Team $other): array => [[$team->slug, teamStranger($other)->id], ['password' => 'password']]],
+    'member removal' => ['delete', 'teams.members.destroy', fn (Team $team, Team $other): array => [[$team->slug, teamStranger($other)->id], []]],
+    'invitation cancel' => ['delete', 'teams.invitations.destroy', fn (Team $team, Team $other): array => [[$team->slug, TeamInvitation::factory()->for($other)->create()->id], []]],
+    'invitation resend' => ['post', 'teams.invitations.resend', fn (Team $team, Team $other): array => [[$team->slug, TeamInvitation::factory()->for($other)->create()->id], []]],
+    'bot detail' => ['get', 'teams.integrations.bots.show', fn (Team $team, Team $other): array => [[$team->slug, User::factory()->bot($other)->create()->id], []]],
+    'bot destroy' => ['delete', 'teams.integrations.bots.destroy', fn (Team $team, Team $other): array => [[$team->slug, User::factory()->bot($other)->create()->id], []]],
+    'bot channel add' => ['post', 'teams.integrations.bots.channels.store', function (Team $team, Team $other): array {
+        $channel = Channel::factory()->for($team)->create();
+
+        return [[$team->slug, User::factory()->bot($other)->create()->id], ['channel_id' => $channel->id]];
+    }],
+    'bot channel remove' => ['delete', 'teams.integrations.bots.channels.destroy', function (Team $team, Team $other): array {
+        $bot = User::factory()->bot($other)->create();
+        $channel = Channel::factory()->for($other)->create();
+        $channel->channelMembers()->create(['user_id' => $bot->id]);
+
+        return [[$team->slug, $bot->id, $channel->id], []];
+    }],
+    'bot token mint' => ['post', 'teams.integrations.bots.tokens.store', fn (Team $team, Team $other): array => [
+        [$team->slug, User::factory()->bot($other)->create()->id],
+        ['name' => 'CI', 'abilities' => ['messages:write']],
+    ]],
+    'bot token revoke' => ['delete', 'teams.integrations.bots.tokens.destroy', function (Team $team, Team $other): array {
+        $bot = User::factory()->bot($other)->create();
+        $token = $bot->createToken('CI', ['messages:write']);
+
+        return [[$team->slug, $bot->id, $token->accessToken->getKey()], []];
+    }],
+    'incoming webhook revoke' => ['delete', 'teams.integrations.incoming-webhooks.destroy', fn (Team $team, Team $other): array => [[$team->slug, IncomingWebhook::factory()->for($other)->create()->id], []]],
+    'subscription detail' => ['get', 'teams.integrations.webhooks.show', fn (Team $team, Team $other): array => [[$team->slug, WebhookSubscription::factory()->for($other)->create()->id], []]],
+    'subscription revoke' => ['delete', 'teams.integrations.webhooks.destroy', fn (Team $team, Team $other): array => [[$team->slug, WebhookSubscription::factory()->for($other)->create()->id], []]],
+    'subscription reenable' => ['post', 'teams.integrations.webhooks.reenable', fn (Team $team, Team $other): array => [[$team->slug, WebhookSubscription::factory()->for($other)->create()->id], []]],
+    'subscription secret rotation' => ['post', 'teams.integrations.webhooks.rotate-secret', fn (Team $team, Team $other): array => [[$team->slug, WebhookSubscription::factory()->for($other)->create()->id], []]],
+    'delivery replay' => ['post', 'teams.integrations.webhooks.deliveries.replay', function (Team $team, Team $other): array {
+        $subscription = WebhookSubscription::factory()->for($other)->create();
+        $delivery = WebhookDelivery::factory()->for($subscription, 'subscription')->create();
+
+        return [[$team->slug, $subscription->id, $delivery->id], []];
+    }],
+]);
+
+/**
+ * A member of the given workspace, and of no other.
+ */
+function teamStranger(Team $team): User
+{
+    $stranger = User::factory()->create();
+    $team->members()->attach($stranger, ['role' => TeamRole::Member->value]);
+
+    return $stranger;
+}
+
+it('404s a child resource that belongs to another workspace', function (string $method, string $name, Closure $build): void {
+    ['actor' => $actor, 'team' => $team, 'other' => $other] = tenancyFixture();
+
+    [$parameters, $body] = $build($team, $other, $actor);
+
+    $this->actingAs($actor)
+        ->{$method}(route($name, $parameters), $body)
+        ->assertNotFound();
+})->with('a child outside the workspace');
+
+it('404s a grandchild that belongs to another parent in the same workspace', function (): void {
+    ['actor' => $actor, 'team' => $team] = tenancyFixture();
+
+    $subscription = WebhookSubscription::factory()->for($team)->create();
+    $sibling = WebhookSubscription::factory()->for($team)->create();
+    $delivery = WebhookDelivery::factory()->for($sibling, 'subscription')->create();
+
+    $this->actingAs($actor)
+        ->post(route('teams.integrations.webhooks.deliveries.replay', [$team->slug, $subscription->id, $delivery->id]))
+        ->assertNotFound();
+});
+
+it('refuses to move a member into a group in a workspace the URL does not name', function (): void {
+    // The hole this closes: someone who administers two workspaces used to be
+    // able to reach workspace B's group through workspace A's URL, because
+    // nothing on the route tied `{userGroup}` to `{team}` and the policy only
+    // ever looked at the group's own workspace.
+    $first = Team::factory()->create();
+    $second = Team::factory()->create();
+    $actor = User::factory()->create();
+    $first->members()->attach($actor, ['role' => TeamRole::Owner->value]);
+    $second->members()->attach($actor, ['role' => TeamRole::Owner->value]);
+
+    $recruit = User::factory()->create();
+    $first->members()->attach($recruit, ['role' => TeamRole::Member->value]);
+
+    $group = UserGroup::factory()->for($second)->create();
+
+    $this->actingAs($actor)
+        ->post(route('teams.groups.members.store', [$first->slug, $group->id]), ['user_id' => $recruit->id])
+        ->assertNotFound();
+
+    expect($group->members()->whereKey($recruit->id)->exists())->toBeFalse();
+});

--- a/tests/Feature/Teams/UserGroupTest.php
+++ b/tests/Feature/Teams/UserGroupTest.php
@@ -289,7 +289,7 @@ test('removing someone from the workspace drops them from its groups', function 
     $group->members()->attach($ada->id);
 
     $this->actingAs($owner)
-        ->delete(route('teams.members.destroy', ['team' => $team->slug, 'user' => $ada->id]))
+        ->delete(route('teams.members.destroy', ['team' => $team->slug, 'member' => $ada->id]))
         ->assertRedirect();
 
     expect($group->members()->count())->toBe(0);

--- a/tests/Feature/Webhooks/WebhookReplayTest.php
+++ b/tests/Feature/Webhooks/WebhookReplayTest.php
@@ -78,7 +78,7 @@ function replayRoute(Team $team, WebhookSubscription $subscription, WebhookDeliv
     return route('teams.integrations.webhooks.deliveries.replay', [
         'team' => $team->slug,
         'webhookSubscription' => $subscription->id,
-        'webhookDelivery' => $delivery->id,
+        'delivery' => $delivery->id,
     ]);
 }
 


### PR DESCRIPTION
Closes #1149. Child of #1142 (architecture hardening IV).

## What

Nested resources under `settings/teams/{team}/…` are now scoped to their parent by the
route, so a child belonging to another workspace 404s in `SubstituteBindings` before any
controller, FormRequest or policy runs.

1. **`->scopeBindings()` on the whole `EnsureTeamMembership` group** — not only the
   integrations sub-group. The issue's "15 call sites" span the whole group, and scoping
   one sub-group would have left the rule true of a sub-group rather than of the file.
2. **Each child parameter renamed to the relationship that owns it**, because that name
   *is* the wiring scoped binding uses: `{emoji}` → `{customEmoji}`, `{group}` →
   `{userGroup}`, `{user}` → `{member}`, `{webhookDelivery}` → `{delivery}`. A mismatch is
   a `BadMethodCallException` on the first request, not a style question.
3. **One `can:manageIntegrations,team` on the integrations group**, replacing 11
   `Gate::authorize` calls and 5 FormRequest `authorize()` bodies. `Authorize` sorts after
   `SubstituteBindings`, so a foreign child is a 404 and a forbidden actor is a 403, in
   that order.
4. **Deleted**: three verbatim copies of `ensureBotBelongsToTeam` (6 call sites),
   `ensureSubscriptionBelongsToTeam` (5 call sites), the inline `abort_unless` tenancy
   checks in `IncomingWebhook`/`TeamInvitation`/`AuditExport`/`CustomEmoji`/`UserGroup`/
   `TeamMember` controllers, and the tenancy half of `ResolvesUserGroupRoute::group()`.

`Api/V1` is left alone as the issue directs — a separate group whose parents come from the
token rather than the URL, so it needs its own answer rather than this one by rote. Noted
as follow-up territory in the ADR, along with the two `Requests/Channels/Sidebar/` sites.

## The "is any site the only guard?" check the issue asked for

**Yes, one — and it was not in the issue's list of 15.** `DELETE
settings/teams/{team}/members/{user}` had no tenancy guard at all:
`Gate::authorize('removeMember', $team)` only asked whether the actor may remove
*somebody*. `RemoveTeamMember::handle()` then ran against a user who had never been in the
workspace. The delete matched no row, but the action still emitted
`AuditAction::MemberRemoved` carrying that outsider's `member_name`, so an admin could
write a fabricated removal into their own audit log naming any user in the instance. That
is the one dataset row that was **red before this change** (302, now 404).

For the record, a hole I suspected during scoping and did **not** find: `POST
.../groups/{group}/members` looked unguarded from the controller, but
`StoreUserGroupMemberRequest` reaches it through `ResolvesUserGroupRoute::group()`, which
carried the check. That is a 16th spelling of the rule, now removed too.

## Behaviour changes (both tightenings, both tested)

- `settings/teams/{team}/members/{member}` 404s for a non-member on **every** verb, not
  just `show`/`card`/`transfer-ownership`.
- Removing a bot from a channel it is not a member of 404s instead of silently
  succeeding. `BotChannelController::destroy` keeps its `type === Standard` guard, now
  stated as the domain rule it is (this surface manages standard-channel membership,
  never a DM) rather than smuggled in beside a tenancy check.

## Tests

- `tests/Feature/Teams/NestedResourceTenancyTest.php` — walks all 26 nested routes under
  `settings/teams/{team}/…` with the child built in another workspace, asserting 404;
  plus a grandchild case (a delivery under the wrong subscription) and the group-members
  case above.
- `tests/Feature/Teams/Integrations/IntegrationsAuthorizationTest.php` — all 16
  integrations verbs, including the `store` ones that previously answered from a
  FormRequest, assert 403 for a plain member.
- `BotChannelManagementTest` gains the DM case that keeps the surviving domain guard
  honest.

## Records

- **New `dev-docs/adr/0014-nested-resource-tenancy-on-the-route.md`** (+ README index) —
  nested-resource tenancy is enforced by route binding; a hand-rolled `belongs to this
  team` check is a defect.
- `CONTEXT.md` → *Where new work goes*.

## Gate

`composer test` green at **100.0%** coverage; `lint:check`, `format:check`, `types:check`,
`test:js` (2614) and `build` all green. Local `coderabbit review --agent --base develop`:
**0 findings**.

No i18n keys added (no user-facing copy changed) and nothing operator-facing, so `docs/`
is untouched.

## Note for #1151

This removes the `team()` accessor from `StoreBotRequest` and `StoreBotTokenRequest` (dead
once `authorize()` went) and empties the `authorize()` bodies in all five
`Requests/Teams/Integrations/Store*Request.php` files — the declared collision with #1151,
which lands after.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788285374&installation_model_id=428379&pr_number=1160&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1160&signature=9fddbac8a357d4694dfb4b51a59d51ef9eeb88b8ae06a15a544cef0448754c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->