### PR TITLE
refactor: make team presence one module-scoped subscription, not two

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -240,6 +240,18 @@ built; build them once, then reuse.
 - **`useChannelFleetSubscription`** _(ADR-0006)_ — one engine for
   subscribing to a set of channels (sidebar badges, chimes, and the active
   channel all share it). One tested reconcile/teardown lifecycle.
+- **`useTeamPresence` + `useTeamPresenceSubscription`** _(ADR-0006)_ — the
+  `team.{id}` roster, split into the state and the lifecycle. The state is
+  **module-scoped** and the subscription is **reference-counted**: the shell and the
+  open channel page both want the roster and both land on the same cached Echo
+  channel, so the first mount joins, the rest are free, and only the last unmount
+  calls `leave()`. Every dot surface reads `presenceFor` / `isDndFor` through
+  `useTeamPresence()` at the point of use, the way a message row reads the
+  message-action context, rather than being handed them three and four hops down
+  (#1145). ADR-0006 puts realtime *lifecycles* in a composable; the refinement is
+  that realtime *state* read by more than one subtree is module-scoped, not
+  per-caller — per-caller state means N callers pay N debounced reloads, and either
+  one's teardown takes the channel down for all of them.
 - **`useDebouncedPost`** — the debounced, focus-gated, auto-teardown router POST
   used by mark-read, mark-thread-read, and draft persistence.
 - **`useAutocompleteMenu` + `AutocompleteListbox`** — the composer's one
@@ -328,7 +340,9 @@ built; build them once, then reuse.
   a one-line **alias** in `resources/js/types/`. Never hand-write the shape a second time;
   if the alias would lose a fact, sharpen the DTO (ADR-0013).
 - New realtime behaviour → a composable with a seam + a pure decision core in
-  `lib/`; never inline in a page.
+  `lib/`; never inline in a page. If more than one subtree reads the same live
+  state, the state is module-scoped and the subscription reference-counted
+  (**`useTeamPresence`**) — a second caller must be free.
 - New channel message payload → the **Message load-set scope**.
 - New "which channels can this user see" check → the **Visible-channels ACL**,
   after deciding which reading you mean: *is it mine* (`memberChannelIds`) or

--- a/resources/js/components/AvatarStack.vue
+++ b/resources/js/components/AvatarStack.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getInitials } from '@/composables/useInitials';
 import { memberAvatarStack } from '@/lib/memberAvatars';
 import type { StackMember } from '@/lib/memberAvatars';
-import type { RenderedPresence } from '@/lib/presence';
 
 const props = withDefaults(
     defineProps<{
@@ -23,24 +21,8 @@ const props = withDefaults(
          * `ring-sidebar`, `ring-sidebar-primary`).
          */
         ringClass?: string;
-        /**
-         * How each stacked member reads on the presence roster. Omitted on the
-         * stacks where presence is meaningless (a poll's voters, a group DM's
-         * fixed participant list), which then render no dots at all.
-         */
-        presenceFor?: (userId: string) => RenderedPresence;
-        /**
-         * Whether each stacked member is in do-not-disturb, driving the
-         * crescent badge on their dot. Only read when `presenceFor` is given.
-         */
-        dndFor?: (userId: string) => boolean;
-        /**
-         * Background class matching the surface behind the stack, for the hollow
-         * centre of an away dot. Pairs with `ringClass`.
-         */
-        surfaceClass?: string;
     }>(),
-    { max: 3, size: 'md', ringClass: 'ring-card', surfaceClass: 'bg-card' },
+    { max: 3, size: 'md', ringClass: 'ring-card' },
 );
 
 const stack = computed(() => memberAvatarStack(props.members, props.max));
@@ -62,21 +44,13 @@ const SIZES = {
 } as const;
 
 const dims = computed(() => SIZES[props.size]);
-
-// The avatar diameter each stack size draws, handed to PresenceDot so it owns
-// the badge geometry (diameter, ring width, corner placement, stacking).
-const DOT_SIZES = { sm: '18', md: '28' } as const;
 </script>
 
 <template>
     <span class="flex shrink-0" aria-hidden="true">
-        <!-- A member with presence gets a positioned wrapper so their dot can sit
-             on the avatar's corner; without one the avatar stacks directly, as
-             it always has. -->
         <span
             v-for="member in stack.visible"
             :key="member.id"
-            class="relative"
             :class="dims.box"
         >
             <Avatar class="size-full ring-2 select-none" :class="ringClass">
@@ -92,15 +66,6 @@ const DOT_SIZES = { sm: '18', md: '28' } as const;
                     {{ getInitials(member.name) }}
                 </AvatarFallback>
             </Avatar>
-            <PresenceDot
-                v-if="presenceFor"
-                data-test="stack-presence-dot"
-                :presence="presenceFor(member.id)"
-                :is-dnd="dndFor?.(member.id) ?? false"
-                :surface-class="surfaceClass"
-                :size="DOT_SIZES[size]"
-                :class="ringClass"
-            />
         </span>
         <span
             v-if="stack.overflow > 0"

--- a/resources/js/components/ChannelMasthead.actions.test.ts
+++ b/resources/js/components/ChannelMasthead.actions.test.ts
@@ -76,6 +76,12 @@ vi.mock('@/composables/useNavPanel', async () => {
     return navPanelDouble();
 });
 
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./ChannelMasthead.doubles');
+
+    return teamPresenceDouble();
+});
+
 vi.mock('@/composables/useDialog', async () => {
     const { dialogDouble } = await import('./ChannelMasthead.doubles');
 
@@ -92,6 +98,7 @@ import {
     mountMasthead,
     navigation,
     participant,
+    presence,
     resetDoubles,
     unmountAll,
 } from './ChannelMasthead.doubles';
@@ -145,13 +152,14 @@ describe('the masthead facepile', () => {
     });
 
     it('counts the active members against the roster, so away reads as present but idle', () => {
+        presence.presenceFor = (id: string) => (id === 'a' ? 'active' : 'away');
+
         const { host } = mount({
             members: [
                 member({ id: 'a' }),
                 member({ id: 'b' }),
                 member({ id: 'c' }),
             ],
-            presenceFor: (id: string) => (id === 'a' ? 'active' : 'away'),
         });
 
         expect(find(host, 'masthead-active-count')?.textContent).toContain(

--- a/resources/js/components/ChannelMasthead.connectionPill.test.ts
+++ b/resources/js/components/ChannelMasthead.connectionPill.test.ts
@@ -74,6 +74,12 @@ vi.mock('@/components/ui/tooltip', () => ({
     TooltipTrigger: stub('div'),
     TooltipContent: stub('div'),
 }));
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./ChannelMasthead.doubles');
+
+    return teamPresenceDouble();
+});
+
 vi.mock('@/composables/useDialog', async () => {
     const { ref } = await import('vue');
 
@@ -122,7 +128,6 @@ async function render(connectionPill: ConnectionPill): Promise<string> {
             h(ChannelMasthead, {
                 channel: channel(),
                 members: [],
-                presenceFor: () => 'active' as const,
                 title: 'general',
                 canManagePreferences: false,
                 canArchive: false,

--- a/resources/js/components/ChannelMasthead.doubles.ts
+++ b/resources/js/components/ChannelMasthead.doubles.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import type { App, Component } from 'vue';
 import { createApp, h, ref } from 'vue';
 import { passthrough } from '@/components/ChannelMasthead.stubs';
+import type { TeamPresence } from '@/composables/useTeamPresence';
 import { translate } from '@/lib/i18n';
 import type { RenderedPresence } from '@/lib/presence';
 import type { Channel, DmParticipant, RosterMember } from '@/types';
@@ -26,6 +27,23 @@ export function inertiaDouble(): Record<string, unknown> {
             url: '/t/acme/c/general',
             props: { auth: { user: viewer } },
         }),
+    };
+}
+
+/**
+ * The team roster the masthead's dots read. Mutable so a suite can put someone
+ * away or on do-not-disturb; set it before mounting, since the components read
+ * the accessor once in setup.
+ */
+export const presence: TeamPresence = {
+    presenceFor: () => 'active',
+    isDndFor: () => false,
+};
+
+export function teamPresenceDouble(): Record<string, unknown> {
+    return {
+        useTeamPresence: () => presence,
+        useTeamPresenceSubscription: () => {},
     };
 }
 
@@ -80,6 +98,8 @@ export function dialogDouble(): Record<string, unknown> {
 export function resetDoubles(): void {
     viewer.avatar = null;
     viewer.presence = 'active';
+    presence.presenceFor = () => 'active';
+    presence.isDndFor = () => false;
     dock.open.value = true;
     dock.setOpen.mockClear();
     navigation.isMobile.value = false;
@@ -176,8 +196,6 @@ export function mountMasthead(
             h(Masthead, {
                 channel: channel(),
                 members: [],
-                presenceFor: () => 'active' as RenderedPresence,
-                isDndFor: () => false,
                 title: 'general',
                 canManagePreferences: false,
                 canArchive: false,

--- a/resources/js/components/ChannelMasthead.identity.test.ts
+++ b/resources/js/components/ChannelMasthead.identity.test.ts
@@ -77,6 +77,12 @@ vi.mock('@/composables/useNavPanel', async () => {
     return navPanelDouble();
 });
 
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./ChannelMasthead.doubles');
+
+    return teamPresenceDouble();
+});
+
 vi.mock('@/composables/useDialog', async () => {
     const { dialogDouble } = await import('./ChannelMasthead.doubles');
 
@@ -90,6 +96,7 @@ import {
     mountMasthead,
     notificationIcon,
     participant,
+    presence,
     resetDoubles,
     unmountAll,
     viewer,
@@ -128,6 +135,8 @@ describe('the masthead title', () => {
     });
 
     it('shows the counterpart’s avatar and presence on a 1:1', () => {
+        presence.presenceFor = () => 'away';
+
         const host = mount({
             channel: channel({
                 isDirect: true,
@@ -136,7 +145,6 @@ describe('the masthead title', () => {
                 dmParticipants: [participant({ avatar: '/ada.png' })],
             }),
             title: 'Ada Lovelace',
-            presenceFor: () => 'away',
         });
 
         expect(avatarSrc(host, 'masthead-dm-avatar')).toBe('/ada.png');
@@ -149,6 +157,7 @@ describe('the masthead title', () => {
     it('falls back to the viewer’s own avatar and presence in a self-DM', () => {
         viewer.avatar = '/me.png';
         viewer.presence = 'away';
+        presence.presenceFor = () => 'offline';
 
         const host = mount({
             channel: channel({
@@ -158,7 +167,6 @@ describe('the masthead title', () => {
                 dmParticipants: [],
             }),
             title: 'You',
-            presenceFor: () => 'offline',
         });
 
         expect(avatarSrc(host, 'masthead-dm-avatar')).toBe('/me.png');
@@ -183,6 +191,8 @@ describe('the masthead title', () => {
     });
 
     it('announces a paused counterpart rather than their presence', () => {
+        presence.isDndFor = () => true;
+
         const host = mount({
             channel: channel({
                 isDirect: true,
@@ -191,7 +201,6 @@ describe('the masthead title', () => {
                 dmParticipants: [participant()],
             }),
             title: 'Ada',
-            isDndFor: () => true,
         });
 
         expect(find(host, 'masthead-dm-avatar')?.textContent).toContain(
@@ -245,13 +254,15 @@ describe('the masthead title', () => {
 
 describe('the masthead sub-lines', () => {
     it('stands the activity readout in for the facepile on a narrow viewport', () => {
+        presence.presenceFor = (id: string) =>
+            id === 'a' ? 'active' : 'offline';
+
         const host = mount({
             members: [
                 member({ id: 'a' }),
                 member({ id: 'b' }),
                 member({ id: 'c' }),
             ],
-            presenceFor: (id: string) => (id === 'a' ? 'active' : 'offline'),
         });
 
         expect(find(host, 'masthead-compact-activity')?.textContent).toContain(

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -15,7 +15,6 @@ import {
 import type { ConnectionPill } from '@/composables/useConnectionState';
 import { useMastheadSearch } from '@/composables/useMastheadSearch';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
-import type { RenderedPresence } from '@/lib/presence';
 import type {
     Channel,
     NotificationLevel,
@@ -30,10 +29,6 @@ const props = defineProps<{
      * overlapping member facepile.
      */
     members: RosterMember[];
-    /** How each team member reads on the presence roster, driving every dot here. */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether each member is in do-not-disturb, driving the crescent badge. */
-    isDndFor?: (userId: string) => boolean;
     /**
      * The viewer-relative title (self-DM reads "You"); the page also feeds it to
      * `<Head>`, so it is resolved once there and passed down.
@@ -116,8 +111,6 @@ const { isMobile, openSearch } = useMastheadSearch();
         <MastheadTitle
             :channel="props.channel"
             :members="props.members"
-            :presence-for="props.presenceFor"
-            :is-dnd-for="props.isDndFor"
             :title="props.title"
             :notification-status="props.notificationStatus"
         />
@@ -130,8 +123,6 @@ const { isMobile, openSearch } = useMastheadSearch();
             <MastheadFacepile
                 v-if="!props.channel.isDirect"
                 :members="props.members"
-                :presence-for="props.presenceFor"
-                :is-dnd-for="props.isDndFor"
             />
 
             <!-- Add people: opens the picker that grows this DM into (or reuses)

--- a/resources/js/components/DialogHost.test.ts
+++ b/resources/js/components/DialogHost.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import type { App, Component } from 'vue';
 import { createApp, defineComponent, h, nextTick, reactive } from 'vue';
 import { SHELL_DIALOG_NAMES, useDialog } from '@/composables/useDialog';
-import type { RenderedPresence } from '@/lib/presence';
 
 const page = reactive<{ props: Record<string, unknown> }>({ props: {} });
 
@@ -69,11 +68,7 @@ function mountHost(): HTMLElement {
     document.body.append(host);
 
     app = createApp({
-        render: () =>
-            h(DialogHost, {
-                presenceFor: (): RenderedPresence => 'offline',
-                isDndFor: () => false,
-            }),
+        render: () => h(DialogHost, {}),
     });
     app.config.globalProperties.$t = (key: string) => key;
     app.mount(host);

--- a/resources/js/components/DialogHost.vue
+++ b/resources/js/components/DialogHost.vue
@@ -12,7 +12,6 @@ import PendingInvitationsModal from '@/components/PendingInvitationsModal.vue';
 import QuickSwitcher from '@/components/QuickSwitcher.vue';
 import UserStatusDialog from '@/components/UserStatusDialog.vue';
 import { useDialog } from '@/composables/useDialog';
-import type { RenderedPresence } from '@/lib/presence';
 import type { RoleOption } from '@/types/teams';
 
 /**
@@ -29,13 +28,6 @@ import type { RoleOption } from '@/types/teams';
  * subscription, and subscribing a second time here would open a second channel
  * for the same roster.
  */
-defineProps<{
-    /** How a teammate's presence dot should render, for the switcher's DM rows. */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether a teammate is in do-not-disturb, for the same rows. */
-    isDndFor: (userId: string) => boolean;
-}>();
-
 const emit = defineEmits<{
     /** The switcher's "Reminders" row; the dock owns which destination is open. */
     openReminders: [];
@@ -110,8 +102,6 @@ const postRegistrationPrompt = computed(
         :members="teamMembers"
         :current-user-id="currentUserId"
         :team-slug="currentTeam.slug"
-        :presence-for="presenceFor"
-        :is-dnd-for="isDndFor"
         @open-reminders="emit('openReminders')"
     />
 

--- a/resources/js/components/MessageList.doubles.ts
+++ b/resources/js/components/MessageList.doubles.ts
@@ -11,6 +11,7 @@ import type {
     MessageActionsContext,
     MessageSubtreeContext,
 } from '@/composables/useMessageActionsContext';
+import type { TeamPresence } from '@/composables/useTeamPresence';
 import { translate } from '@/lib/i18n';
 import type { Message, MessageAuthor } from '@/types';
 
@@ -32,6 +33,22 @@ export const inertiaPageProps = {
     userGroups: [] as Array<{ id: string }>,
     frequentEmojis: [] as string[],
 };
+
+/**
+ * The team roster the author dots read. Mutable so a suite can put an author
+ * away; set it before mounting, since the list reads the accessor once in setup.
+ */
+export const presence: TeamPresence = {
+    presenceFor: () => 'offline',
+    isDndFor: () => false,
+};
+
+export function teamPresenceDouble(): Record<string, unknown> {
+    return {
+        useTeamPresence: () => presence,
+        useTeamPresenceSubscription: () => {},
+    };
+}
 
 /** Renders nothing, standing in for a leaf whose own tests cover it. */
 export function inert(name: string): Component {

--- a/resources/js/components/MessageList.timeline.test.ts
+++ b/resources/js/components/MessageList.timeline.test.ts
@@ -7,6 +7,7 @@ import {
     inertiaPageProps,
     message,
     mountWithActions,
+    presence,
     unmountAll,
 } from './MessageList.doubles';
 
@@ -25,6 +26,12 @@ vi.mock('@inertiajs/vue3', async () => {
     const { inertiaPageProps } = await import('./MessageList.doubles');
 
     return { usePage: () => ({ props: inertiaPageProps }) };
+});
+
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./MessageList.doubles');
+
+    return teamPresenceDouble();
 });
 
 vi.mock('@/composables/useIsMobile', async () => {
@@ -81,6 +88,8 @@ function texts(host: HTMLElement, selector: string): string[] {
 
 beforeEach(() => {
     inertiaPageProps.auth.user.timezone = 'UTC';
+    presence.presenceFor = () => 'offline';
+    presence.isDndFor = () => false;
 
     if (mobile.current) {
         mobile.current.value = false;
@@ -225,7 +234,9 @@ describe('an author group', () => {
     });
 
     it('announces the author’s presence once per group', () => {
-        const host = mount({ presenceFor: () => 'away' });
+        presence.presenceFor = () => 'away';
+
+        const host = mount();
 
         expect(host.querySelector('.sr-only')?.textContent?.trim()).toBe(
             'Away',
@@ -233,7 +244,7 @@ describe('an author group', () => {
         expect(host.querySelector('[data-test="presence-dot"]')).not.toBeNull();
     });
 
-    it('falls back to offline when the surface carries no presence roster', () => {
+    it('reads an author absent from the presence roster as offline', () => {
         const host = mount();
 
         expect(host.querySelector('.sr-only')?.textContent?.trim()).toBe(

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -18,11 +18,11 @@ import {
     useMessageSubtree,
 } from '@/composables/useMessageActionsContext';
 import { useMessageActionSheet } from '@/composables/useMessageActionSheet';
+import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTimelineWindow } from '@/composables/useTimelineWindow';
 import { displayAuthorName } from '@/lib/authorIdentity';
 import { formatTimeOfDay } from '@/lib/datetime';
 import { hasAnyMessageAction } from '@/lib/messageActions';
-import type { RenderedPresence } from '@/lib/presence';
 import { readersForMessage } from '@/lib/readReceipts';
 import { buildTimelineItems } from '@/lib/timeline';
 import type { TimelineGroup } from '@/lib/timeline';
@@ -46,16 +46,6 @@ const props = defineProps<{
      * reads "left the conversation" rather than "left the channel".
      */
     isDirect?: boolean;
-    /**
-     * How each author reads on the team presence roster. Absent on the surfaces
-     * that render a timeline without one, where every author reads as offline.
-     */
-    presenceFor?: (userId: string) => RenderedPresence;
-    /**
-     * Whether each author is in do-not-disturb, driving the crescent badge on
-     * their dot. Absent on the same surfaces that carry no roster.
-     */
-    isDndFor?: (userId: string) => boolean;
     highlightMessageId?: string | null;
     /**
      * The message the "New messages" divider sits above — the first unread on
@@ -112,6 +102,11 @@ const emit = defineEmits<{
 
 const scope = useMessageActionsContext();
 const subtree = useMessageSubtree();
+
+// How each author's avatar dot reads. Read here rather than handed down: a
+// timeline mounted with nothing subscribed sees an empty roster, which renders
+// every author offline — the answer the optional props used to fall back to.
+const { presenceFor, isDndFor } = useTeamPresence();
 const { contextFor } = useMessageActionGuards();
 
 /** Render timestamps in the viewer's stored zone, falling back to the browser's. */
@@ -147,20 +142,6 @@ const seenByReaders = computed<MessageAuthor[]>(() => {
         scope.currentUserId,
     );
 });
-
-/**
- * How a message author reads on the team presence roster.
- */
-function presenceOf(authorId: string): RenderedPresence {
-    return props.presenceFor?.(authorId) ?? 'offline';
-}
-
-/**
- * Whether a message author shows the crescent DND badge on their dot.
- */
-function dndOf(authorId: string): boolean {
-    return props.isDndFor?.(authorId) ?? false;
-}
 
 /**
  * The grouped, divider-interleaved render list. The grouping and boundary logic
@@ -312,8 +293,8 @@ function confirmDelete(): void {
                         :author-override="item.authorOverride"
                         :posted-via="item.postedVia"
                         :team-slug="props.teamSlug"
-                        :presence="presenceOf(item.author.id)"
-                        :is-dnd="dndOf(item.author.id)"
+                        :presence="presenceFor(item.author.id)"
+                        :is-dnd="isDndFor(item.author.id)"
                         :time="formatTime(item.leadCreatedAt)"
                         :is-mobile="isMobile"
                         @mention="(member) => subtree.mention(member)"
@@ -332,8 +313,8 @@ function confirmDelete(): void {
                             :author-override="item.authorOverride"
                             :posted-via="item.postedVia"
                             :team-slug="props.teamSlug"
-                            :presence="presenceOf(item.author.id)"
-                            :is-dnd="dndOf(item.author.id)"
+                            :presence="presenceFor(item.author.id)"
+                            :is-dnd="isDndFor(item.author.id)"
                             :time="formatTime(item.leadCreatedAt)"
                             @mention="(member) => subtree.mention(member)"
                         />

--- a/resources/js/components/QuickSwitcher.destinations.test.ts
+++ b/resources/js/components/QuickSwitcher.destinations.test.ts
@@ -83,6 +83,12 @@ vi.mock('@/components/ui/sidebar', async () => {
     return sidebarDouble();
 });
 
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./QuickSwitcher.doubles');
+
+    return teamPresenceDouble();
+});
+
 vi.mock('@/composables/useIsMobile', async () => {
     const { isMobileDouble } = await import('./QuickSwitcher.doubles');
 
@@ -117,6 +123,7 @@ import {
     mountSwitcher,
     openDirectMessage,
     person,
+    presence,
     resetDoubles,
     router,
     type,
@@ -291,12 +298,9 @@ describe('the people group', () => {
 
     it('reads out presence instead of the enter hint below the breakpoint', () => {
         isMobile.value = true;
+        presence.presenceFor = () => 'away';
 
-        const { host } = mount({
-            members,
-            currentUserId: 'me',
-            presenceFor: () => 'away',
-        });
+        const { host } = mount({ members, currentUserId: 'me' });
 
         expect(names(host, 'quick-switcher-person')[0]).toContain('Away');
     });

--- a/resources/js/components/QuickSwitcher.doubles.ts
+++ b/resources/js/components/QuickSwitcher.doubles.ts
@@ -1,8 +1,8 @@
 import { vi } from 'vitest';
 import type { App, Component, Ref } from 'vue';
 import { createApp, h, nextTick, ref } from 'vue';
+import type { TeamPresence } from '@/composables/useTeamPresence';
 import { translate } from '@/lib/i18n';
-import type { RenderedPresence } from '@/lib/presence';
 import type { MessageSearchResult } from '@/types';
 import type { Channel } from '@/types/channels';
 import type { PersonRef } from '@/types/people';
@@ -19,6 +19,22 @@ export const viewer = {
     url: '/t/acme/c/general',
     timezone: null as string | null,
 };
+
+/**
+ * The team roster the people rows read. Mutable so a suite can put someone
+ * away; set it before mounting, since the rows read the accessor once in setup.
+ */
+export const presence: TeamPresence = {
+    presenceFor: () => 'active',
+    isDndFor: () => false,
+};
+
+export function teamPresenceDouble(): Record<string, unknown> {
+    return {
+        useTeamPresence: () => presence,
+        useTeamPresenceSubscription: () => {},
+    };
+}
 
 /** Where a picked row sends the viewer. */
 export const router = { visit: vi.fn() };
@@ -126,6 +142,8 @@ export function searchActionDouble(): Record<string, unknown> {
 export function resetDoubles(): void {
     viewer.url = '/t/acme/c/general';
     viewer.timezone = null;
+    presence.presenceFor = () => 'active';
+    presence.isDndFor = () => false;
     router.visit.mockClear();
     messageSearch.results.value = [];
     messageSearch.isSearching.value = false;
@@ -229,8 +247,6 @@ export function mountSwitcher(
                 members: [person()],
                 currentUserId: 'me',
                 teamSlug: 'acme',
-                presenceFor: () => 'active' as RenderedPresence,
-                isDndFor: () => false,
                 onOpenReminders: record('openReminders'),
                 ...props,
             }),

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -28,7 +28,6 @@ import { useIsMobile } from '@/composables/useIsMobile';
 import { useOpenDirectMessage } from '@/composables/useOpenDirectMessage';
 import { useQuickSwitcherSearch } from '@/composables/useQuickSwitcherSearch';
 import { rankPeople } from '@/lib/peopleDirectory';
-import type { RenderedPresence } from '@/lib/presence';
 import type { MessageSearchResult } from '@/types';
 import type { Channel } from '@/types/channels';
 import type { PersonRef } from '@/types/people';
@@ -38,13 +37,6 @@ const props = defineProps<{
     members: PersonRef[];
     currentUserId: string;
     teamSlug: string;
-    /**
-     * How each team member reads on the presence roster, driving the mobile
-     * overlay's avatar dots and presence words.
-     */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether each member is in do-not-disturb, driving the crescent badge. */
-    isDndFor?: (userId: string) => boolean;
 }>();
 
 const open = defineModel<boolean>('open', { default: false });
@@ -183,8 +175,6 @@ function openReminders(): void {
                         :people="peopleResults"
                         :query="query"
                         :is-mobile="isMobile"
-                        :presence-for="presenceFor"
-                        :is-dnd-for="isDndFor"
                         @select="selectPerson"
                     />
 

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -20,7 +20,6 @@ import {
 } from '@/composables/useMessageActionsContext';
 import { useRailInset } from '@/composables/useRailInset';
 import { useScrollPin } from '@/composables/useScrollPin';
-import type { RenderedPresence } from '@/lib/presence';
 import type { Mention, Message, PersonRef, RosterMember } from '@/types';
 
 const props = defineProps<{
@@ -41,10 +40,6 @@ const props = defineProps<{
     // Whether the channel has a bot member, forwarded to the reply composer's
     // mention menu footnote.
     hasBots?: boolean;
-    /** How each author reads on the team presence roster, passed straight down. */
-    presenceFor?: (userId: string) => RenderedPresence;
-    /** Whether each author is in do-not-disturb, threaded through to the list. */
-    isDndFor?: (userId: string) => boolean;
     loading?: boolean;
     readOnly?: boolean;
 }>();
@@ -392,8 +387,6 @@ watch(
                     :messages="props.messages"
                     :team-slug="props.teamSlug"
                     :pending-uuids="props.pendingUuids"
-                    :presence-for="props.presenceFor"
-                    :is-dnd-for="props.isDndFor"
                     :editing-message-id="editingMessageId"
                     :reply-divider-count="isMobile ? replyCount : 0"
                     @load-older="loadOlderReplies"

--- a/resources/js/components/channel/ChannelHeader.vue
+++ b/resources/js/components/channel/ChannelHeader.vue
@@ -4,7 +4,6 @@ import PinsPanel from '@/components/PinsPanel.vue';
 import { useChannelPins } from '@/composables/useChannelPins';
 import { useChannelPreferences } from '@/composables/useChannelPreferences';
 import type { ConnectionPill } from '@/composables/useConnectionState';
-import type { RenderedPresence } from '@/lib/presence';
 import type {
     Channel,
     Message,
@@ -24,8 +23,6 @@ const props = defineProps<{
     team: { slug: string };
     channel: Channel;
     members: RosterMember[];
-    presenceFor: (userId: string) => RenderedPresence;
-    isDndFor: (userId: string) => boolean;
     /** What the channel is called from this viewer's side of it. */
     title: string;
     canManagePreferences: boolean;
@@ -105,8 +102,6 @@ defineExpose({
         <ChannelMasthead
             :channel="props.channel"
             :members="props.members"
-            :presence-for="props.presenceFor"
-            :is-dnd-for="props.isDndFor"
             :title="props.title"
             :can-manage-preferences="props.canManagePreferences"
             :can-archive="props.canArchive"

--- a/resources/js/components/channel/ChannelPane.vue
+++ b/resources/js/components/channel/ChannelPane.vue
@@ -19,7 +19,6 @@ import { useStickyDayLabel } from '@/composables/useStickyDayLabel';
 import { useUnreadDivider } from '@/composables/useUnreadDivider';
 import { useUnreadJump } from '@/composables/useUnreadJump';
 import type { TimelineRange } from '@/composables/useUnreadJump';
-import type { RenderedPresence } from '@/lib/presence';
 import { buildTimelineItems } from '@/lib/timeline';
 import type { Channel, ChannelReader, Message } from '@/types';
 
@@ -48,8 +47,6 @@ const props = defineProps<{
     queuedUuids: string[];
     /** Whether a file drop would be staged (a member of a live channel). */
     canDropFiles: boolean;
-    presenceFor: (userId: string) => RenderedPresence;
-    isDndFor: (userId: string) => boolean;
     readers: ChannelReader[];
     activeThreadRootId: string | null;
     editingMessageId: string | null;
@@ -275,8 +272,6 @@ defineExpose({
                         :pending-uuids="props.pendingUuids"
                         :queued-uuids="props.queuedUuids"
                         :is-direct="props.channel.isDirect"
-                        :presence-for="props.presenceFor"
-                        :is-dnd-for="props.isDndFor"
                         :readers="props.readers"
                         :highlight-message-id="highlightedMessageId"
                         :unread-divider-id="unreadDividerId"

--- a/resources/js/components/channel/MastheadFacepile.vue
+++ b/resources/js/components/channel/MastheadFacepile.vue
@@ -4,9 +4,9 @@ import { computed } from 'vue';
 import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getInitials } from '@/composables/useInitials';
+import { useTeamPresence } from '@/composables/useTeamPresence';
 import { MAX_MASTHEAD_AVATARS, memberAvatarStack } from '@/lib/memberAvatars';
 import { activeMemberCount } from '@/lib/presence';
-import type { RenderedPresence } from '@/lib/presence';
 import type { RosterMember } from '@/types';
 
 /**
@@ -19,11 +19,9 @@ const props = defineProps<{
      * overlapping member facepile.
      */
     members: RosterMember[];
-    /** How each team member reads on the presence roster, driving every dot here. */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether each member is in do-not-disturb, driving the crescent badge. */
-    isDndFor?: (userId: string) => boolean;
 }>();
+
+const { presenceFor, isDndFor } = useTeamPresence();
 
 /** The overlapping member avatars for the masthead's right side. */
 const mastheadAvatars = computed(() =>
@@ -32,7 +30,7 @@ const mastheadAvatars = computed(() =>
 
 /** How many of the roster are active, as the readout beside the stack says. */
 const activeCount = computed(() =>
-    activeMemberCount(props.members, props.presenceFor),
+    activeMemberCount(props.members, presenceFor),
 );
 </script>
 
@@ -79,8 +77,8 @@ const activeCount = computed(() =>
                 <PresenceDot
                     v-if="!member.isBot"
                     data-test="masthead-member-presence"
-                    :presence="props.presenceFor(member.id)"
-                    :is-dnd="props.isDndFor?.(member.id) ?? false"
+                    :presence="presenceFor(member.id)"
+                    :is-dnd="isDndFor(member.id)"
                     surface-class="bg-card"
                     size="24"
                     class="ring-card"

--- a/resources/js/components/channel/MastheadTitle.vue
+++ b/resources/js/components/channel/MastheadTitle.vue
@@ -11,6 +11,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { getInitials } from '@/composables/useInitials';
+import { useTeamPresence } from '@/composables/useTeamPresence';
 import { MAX_MASTHEAD_AVATARS } from '@/lib/memberAvatars';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
 import {
@@ -29,10 +30,6 @@ const props = defineProps<{
     channel: Channel;
     /** The team roster, which the activity readout counts. */
     members: RosterMember[];
-    /** How each team member reads on the presence roster. */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether each member is in do-not-disturb, driving the crescent badge. */
-    isDndFor?: (userId: string) => boolean;
     /**
      * The viewer-relative title (self-DM reads "You"); the page also feeds it to
      * `<Head>`, so it is resolved once there and passed down.
@@ -43,6 +40,8 @@ const props = defineProps<{
 }>();
 
 const page = usePage();
+
+const { presenceFor, isDndFor } = useTeamPresence();
 
 /** The other participant of a 1:1 DM, whose avatar the masthead shows. */
 const dmParticipant = computed(() => props.channel.dmParticipants?.[0] ?? null);
@@ -65,21 +64,19 @@ const dmAvatar = computed(() =>
 const dmPresence = computed<RenderedPresence>(() =>
     dmParticipantPresence(
         props.channel.dmUserId,
-        props.presenceFor,
+        presenceFor,
         page.props.auth.user.presence,
     ),
 );
 
 /** Whether the 1:1 counterpart shows the crescent DND badge. */
 const dmDnd = computed(
-    () =>
-        props.channel.dmUserId != null &&
-        (props.isDndFor?.(props.channel.dmUserId) ?? false),
+    () => props.channel.dmUserId != null && isDndFor(props.channel.dmUserId),
 );
 
 /** How many of the roster are active, for the compact activity readout. */
 const activeCount = computed(() =>
-    activeMemberCount(props.members, props.presenceFor),
+    activeMemberCount(props.members, presenceFor),
 );
 
 /** The group's participant count, including the viewer, for the subtitle. */

--- a/resources/js/components/navigation/ChannelsPanel.test.ts
+++ b/resources/js/components/navigation/ChannelsPanel.test.ts
@@ -85,7 +85,6 @@ vi.mock('@/components/navigation/DirectMessageGroup.vue', () => ({
 
 import { useChannelSections } from '@/composables/useChannelSections';
 import { useDialog } from '@/composables/useDialog';
-import type { RenderedPresence } from '@/lib/presence';
 import type { Channel, ChannelSection } from '@/types/channels';
 import ChannelsPanel from './ChannelsPanel.vue';
 
@@ -144,11 +143,7 @@ function mountPanel(
     document.body.append(host);
 
     app = createApp({
-        render: () =>
-            h(ChannelsPanel, {
-                presenceFor: (): RenderedPresence => 'offline',
-                isDndFor: () => false,
-            }),
+        render: () => h(ChannelsPanel, {}),
     });
     app.config.globalProperties.$t = (key: string) => key;
     app.mount(host);

--- a/resources/js/components/navigation/ChannelsPanel.vue
+++ b/resources/js/components/navigation/ChannelsPanel.vue
@@ -16,14 +16,6 @@ import { useChannelSections } from '@/composables/useChannelSections';
 import { useCollapsedSections } from '@/composables/useCollapsedSections';
 import { useDialog } from '@/composables/useDialog';
 import type { ChannelSectionGroup } from '@/lib/channelSections';
-import type { RenderedPresence } from '@/lib/presence';
-
-defineProps<{
-    /** How a teammate's presence dot should render, for the DM rows. */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether a teammate is in do-not-disturb, for the DM rows. */
-    isDndFor: (userId: string) => boolean;
-}>();
 
 const page = usePage();
 
@@ -207,8 +199,6 @@ function sectionKey(group: ChannelSectionGroup): string {
             :team-slug="currentTeam?.slug ?? ''"
             :active-channel-slug="activeChannelSlug"
             :collapsed="isSectionCollapsed('direct')"
-            :presence-for="presenceFor"
-            :is-dnd-for="isDndFor"
             @toggle="toggleSection('direct')"
         />
 

--- a/resources/js/components/navigation/DirectMessageGroup.test.ts
+++ b/resources/js/components/navigation/DirectMessageGroup.test.ts
@@ -11,6 +11,15 @@ const page = reactive<{ props: Record<string, unknown> }>({
 
 vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
 
+// The roster the rows read: u-2 is away and paused, everyone else offline.
+vi.mock('@/composables/useTeamPresence', () => ({
+    useTeamPresence: () => ({
+        presenceFor: (userId: string) =>
+            userId === 'u-2' ? 'away' : 'offline',
+        isDndFor: (userId: string) => userId === 'u-2',
+    }),
+}));
+
 vi.mock('@lucide/vue', () => ({
     ChevronRight: { render: () => h('svg') },
     Plus: { render: () => h('svg') },
@@ -74,9 +83,6 @@ function mountGroup(
                 teamSlug: 'acme',
                 activeChannelSlug: null,
                 collapsed: overrides.collapsed ?? false,
-                presenceFor: (userId: string) =>
-                    userId === 'u-2' ? 'away' : 'offline',
-                isDndFor: (userId: string) => userId === 'u-2',
                 onToggle: toggle,
             }),
     });

--- a/resources/js/components/navigation/DirectMessageGroup.vue
+++ b/resources/js/components/navigation/DirectMessageGroup.vue
@@ -10,20 +10,17 @@ import {
     SidebarGroupContent,
 } from '@/components/ui/sidebar';
 import { useDialog } from '@/composables/useDialog';
+import { useTeamPresence } from '@/composables/useTeamPresence';
 import { dmParticipantPresence } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
 import type { Channel } from '@/types/channels';
 
-const props = defineProps<{
+defineProps<{
     /** The DM conversations, already ordered by recent activity. */
     channels: Channel[];
     teamSlug: string;
     activeChannelSlug: string | null;
     collapsed: boolean;
-    /** How a teammate's presence dot should render. */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether a teammate is in do-not-disturb, for the crescent badge. */
-    isDndFor: (userId: string) => boolean;
 }>();
 
 defineEmits<{
@@ -32,6 +29,8 @@ defineEmits<{
 }>();
 
 const page = usePage();
+
+const { presenceFor, isDndFor } = useTeamPresence();
 
 /** The header's "+": the people picker the shell mounts. */
 const { open: openNewMessage } = useDialog('newMessage');
@@ -45,7 +44,7 @@ const currentUser = computed(() => page.props.auth.user);
 function presenceForRow(channel: Channel): RenderedPresence {
     return dmParticipantPresence(
         channel.dmUserId,
-        props.presenceFor,
+        presenceFor,
         currentUser.value.presence,
     );
 }

--- a/resources/js/components/switcher/SwitcherPeople.vue
+++ b/resources/js/components/switcher/SwitcherPeople.vue
@@ -3,9 +3,9 @@ import PresenceDot from '@/components/PresenceDot.vue';
 import SwitcherName from '@/components/switcher/SwitcherName.vue';
 import { CommandGroup, CommandItem } from '@/components/ui/command';
 import { getInitials } from '@/composables/useInitials';
+import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTranslations } from '@/composables/useTranslations';
 import { presenceLabelKey } from '@/lib/presence';
-import type { RenderedPresence } from '@/lib/presence';
 import type { PersonEntry } from '@/types/people';
 
 defineProps<{
@@ -15,13 +15,6 @@ defineProps<{
     query: string;
     /** Whether the palette is rendering as the mobile full-screen overlay. */
     isMobile: boolean;
-    /**
-     * How each team member reads on the presence roster, driving the mobile
-     * overlay's avatar dots and presence words.
-     */
-    presenceFor: (userId: string) => RenderedPresence;
-    /** Whether each member is in do-not-disturb, driving the crescent badge. */
-    isDndFor?: (userId: string) => boolean;
 }>();
 
 defineEmits<{
@@ -30,6 +23,8 @@ defineEmits<{
 }>();
 
 const { t } = useTranslations();
+
+const { presenceFor, isDndFor } = useTeamPresence();
 </script>
 
 <template>
@@ -53,7 +48,7 @@ const { t } = useTranslations();
                 >
                 <PresenceDot
                     :presence="presenceFor(person.id)"
-                    :is-dnd="isDndFor?.(person.id) ?? false"
+                    :is-dnd="isDndFor(person.id)"
                     surface-class="bg-sidebar"
                     size="28"
                     class="ring-sidebar"

--- a/resources/js/composables/useTeamPresence.test.ts
+++ b/resources/js/composables/useTeamPresence.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRenderer, defineComponent, nextTick, reactive } from 'vue';
+import { createRenderer, defineComponent, nextTick, reactive, ref } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 
 const reload = vi.fn();
 
@@ -16,15 +17,22 @@ const page = reactive({
     },
 });
 
-/** Roster handlers registered per presence channel, by hook name. */
+/**
+ * Roster handlers registered per presence channel, by hook name.
+ *
+ * Every hook is a *list*, because Echo caches one channel per name and each
+ * `.here()` / `.listen()` on it adds a callback rather than replacing the last —
+ * which is exactly how a second subscriber ends up doubling the work.
+ */
 type Handlers = {
-    here?: (members: { id: string; name: string }[]) => void;
-    joining?: (member: { id: string; name: string }) => void;
-    leaving?: (member: { id: string; name: string }) => void;
-    listeners: Map<string, (payload: never) => void>;
+    here: ((members: { id: string; name: string }[]) => void)[];
+    joining: ((member: { id: string; name: string }) => void)[];
+    leaving: ((member: { id: string; name: string }) => void)[];
+    listeners: Map<string, ((payload: never) => void)[]>;
 };
 
 const channels = new Map<string, Handlers>();
+const joined: string[] = [];
 const left: string[] = [];
 
 vi.mock('@inertiajs/vue3', () => ({
@@ -35,29 +43,37 @@ vi.mock('@inertiajs/vue3', () => ({
 vi.mock('@laravel/echo-vue', () => ({
     echo: () => ({
         join(name: string) {
+            joined.push(name);
+
             const handlers: Handlers = channels.get(name) ?? {
+                here: [],
+                joining: [],
+                leaving: [],
                 listeners: new Map(),
             };
             channels.set(name, handlers);
 
             const chain = {
-                here(callback: Handlers['here']) {
-                    handlers.here = callback;
+                here(callback: Handlers['here'][number]) {
+                    handlers.here.push(callback);
 
                     return chain;
                 },
-                joining(callback: Handlers['joining']) {
-                    handlers.joining = callback;
+                joining(callback: Handlers['joining'][number]) {
+                    handlers.joining.push(callback);
 
                     return chain;
                 },
-                leaving(callback: Handlers['leaving']) {
-                    handlers.leaving = callback;
+                leaving(callback: Handlers['leaving'][number]) {
+                    handlers.leaving.push(callback);
 
                     return chain;
                 },
                 listen(event: string, callback: (payload: never) => void) {
-                    handlers.listeners.set(event, callback);
+                    handlers.listeners.set(event, [
+                        ...(handlers.listeners.get(event) ?? []),
+                        callback,
+                    ]);
 
                     return chain;
                 },
@@ -65,11 +81,17 @@ vi.mock('@laravel/echo-vue', () => ({
 
             return chain;
         },
-        leave: (name: string) => left.push(name),
+        leave: (name: string) => {
+            channels.delete(name);
+            left.push(name);
+        },
     }),
 }));
 
-import { useTeamPresence } from '@/composables/useTeamPresence';
+import {
+    useTeamPresence,
+    useTeamPresenceSubscription,
+} from '@/composables/useTeamPresence';
 
 /**
  * A no-op renderer mounts a real component instance under Node (no DOM), which
@@ -89,13 +111,16 @@ const { createApp } = createRenderer<object, object>({
     setScopeId: () => {},
 });
 
-function mount() {
-    let api!: ReturnType<typeof useTeamPresence>;
-
+/**
+ * A subscriber, standing in for the shell or the channel page. The reader half
+ * is module state, so {@link useTeamPresence} answers from anywhere — the tests
+ * call it outside a component the way a deep dot component calls it inside one.
+ */
+function mount(teamId: MaybeRefOrGetter<string | undefined> = () => 'team-1') {
     const app = createApp(
         defineComponent({
             setup() {
-                api = useTeamPresence(() => 'team-1');
+                useTeamPresenceSubscription(teamId);
 
                 return () => null;
             },
@@ -104,13 +129,34 @@ function mount() {
 
     app.mount({});
 
-    return { api, unmount: () => app.unmount() };
+    return { api: useTeamPresence(), unmount: () => app.unmount() };
 }
 
 const roster = () => channels.get('team.team-1')!;
 
+/** Broadcast the roster snapshot to every `here` callback bound to the channel. */
+function here(members: { id: string; name: string }[]): void {
+    roster().here.forEach((callback) => callback(members));
+}
+
+function joining(member: { id: string; name: string }): void {
+    roster().joining.forEach((callback) => callback(member));
+}
+
+function leaving(member: { id: string; name: string }): void {
+    roster().leaving.forEach((callback) => callback(member));
+}
+
+/** Broadcast a server event to every listener bound to it, as Echo does. */
+function broadcast(event: string, payload?: unknown): void {
+    roster()
+        .listeners.get(event)!
+        .forEach((callback) => callback(payload as never));
+}
+
 beforeEach(() => {
     channels.clear();
+    joined.length = 0;
     left.length = 0;
     reload.mockClear();
     page.props.teamMembers = [];
@@ -124,7 +170,7 @@ describe('useTeamPresence', () => {
     it('reports a member absent from the roster as offline', () => {
         const { api, unmount } = mount();
 
-        roster().here!([]);
+        here([]);
 
         expect(api.presenceFor('maya')).toBe('offline');
 
@@ -134,7 +180,7 @@ describe('useTeamPresence', () => {
     it('reports a roster member with no reported state as active', () => {
         const { api, unmount } = mount();
 
-        roster().here!([{ id: 'maya', name: 'Maya' }]);
+        here([{ id: 'maya', name: 'Maya' }]);
 
         expect(api.presenceFor('maya')).toBe('active');
 
@@ -149,7 +195,7 @@ describe('useTeamPresence', () => {
 
         const { api, unmount } = mount();
 
-        roster().here!([
+        here([
             { id: 'maya', name: 'Maya' },
             { id: 'jonas', name: 'Jonas' },
         ]);
@@ -209,8 +255,8 @@ describe('useTeamPresence', () => {
     it('patches a member live when they go away, with no reload', () => {
         const { api, unmount } = mount();
 
-        roster().here!([{ id: 'maya', name: 'Maya' }]);
-        roster().listeners.get('UserPresenceChanged')!({
+        here([{ id: 'maya', name: 'Maya' }]);
+        broadcast('UserPresenceChanged', {
             id: 'maya',
             state: 'away',
         } as never);
@@ -224,12 +270,12 @@ describe('useTeamPresence', () => {
     it('patches them back to active on their next activity', () => {
         const { api, unmount } = mount();
 
-        roster().here!([{ id: 'maya', name: 'Maya' }]);
-        roster().listeners.get('UserPresenceChanged')!({
+        here([{ id: 'maya', name: 'Maya' }]);
+        broadcast('UserPresenceChanged', {
             id: 'maya',
             state: 'away',
         } as never);
-        roster().listeners.get('UserPresenceChanged')!({
+        broadcast('UserPresenceChanged', {
             id: 'maya',
             state: 'active',
         } as never);
@@ -246,8 +292,8 @@ describe('useTeamPresence', () => {
 
         const { api, unmount } = mount();
 
-        roster().here!([{ id: 'maya', name: 'Maya' }]);
-        roster().listeners.get('UserPresenceChanged')!({
+        here([{ id: 'maya', name: 'Maya' }]);
+        broadcast('UserPresenceChanged', {
             id: 'maya',
             state: 'active',
         } as never);
@@ -260,12 +306,12 @@ describe('useTeamPresence', () => {
     it('renders a member who leaves as offline, whatever they last reported', () => {
         const { api, unmount } = mount();
 
-        roster().here!([{ id: 'maya', name: 'Maya' }]);
-        roster().listeners.get('UserPresenceChanged')!({
+        here([{ id: 'maya', name: 'Maya' }]);
+        broadcast('UserPresenceChanged', {
             id: 'maya',
             state: 'away',
         } as never);
-        roster().leaving!({ id: 'maya', name: 'Maya' });
+        leaving({ id: 'maya', name: 'Maya' });
 
         expect(api.presenceFor('maya')).toBe('offline');
 
@@ -279,13 +325,13 @@ describe('useTeamPresence', () => {
 
         const { api, unmount } = mount();
 
-        roster().here!([{ id: 'maya', name: 'Maya' }]);
-        roster().listeners.get('UserPresenceChanged')!({
+        here([{ id: 'maya', name: 'Maya' }]);
+        broadcast('UserPresenceChanged', {
             id: 'maya',
             state: 'away',
         } as never);
-        roster().leaving!({ id: 'maya', name: 'Maya' });
-        roster().joining!({ id: 'maya', name: 'Maya' });
+        leaving({ id: 'maya', name: 'Maya' });
+        joining({ id: 'maya', name: 'Maya' });
 
         expect(api.presenceFor('maya')).toBe('active');
 
@@ -297,7 +343,7 @@ describe('useTeamPresence', () => {
 
         const { unmount } = mount();
 
-        roster().listeners.get('UserProfileUpdated')!(undefined as never);
+        broadcast('UserProfileUpdated', undefined as never);
 
         await vi.advanceTimersByTimeAsync(500);
         await nextTick();
@@ -313,5 +359,91 @@ describe('useTeamPresence', () => {
         unmount();
 
         expect(left).toContain('team.team-1');
+    });
+
+    it('joins the channel once however many subscribers mount', () => {
+        const first = mount();
+        const second = mount();
+
+        expect(joined).toEqual(['team.team-1']);
+
+        first.unmount();
+        second.unmount();
+    });
+
+    it('reloads once per broadcast, not once per subscriber', async () => {
+        vi.useFakeTimers();
+
+        const first = mount();
+        const second = mount();
+
+        broadcast('UserProfileUpdated');
+
+        await vi.advanceTimersByTimeAsync(500);
+        await nextTick();
+
+        expect(reload).toHaveBeenCalledTimes(1);
+
+        first.unmount();
+        second.unmount();
+    });
+
+    it('keeps the channel while another subscriber is still mounted', () => {
+        const first = mount();
+        const second = mount();
+
+        first.unmount();
+
+        expect(left).not.toContain('team.team-1');
+
+        second.unmount();
+
+        expect(left).toContain('team.team-1');
+    });
+
+    it('keeps the roster readable when one subscriber unmounts', () => {
+        const first = mount();
+        const second = mount();
+
+        here([{ id: 'maya', name: 'Maya' }]);
+        first.unmount();
+
+        expect(second.api.presenceFor('maya')).toBe('active');
+
+        second.unmount();
+    });
+
+    it('leaves the roster standing when a second subscriber arrives', () => {
+        const first = mount();
+
+        here([{ id: 'maya', name: 'Maya' }]);
+
+        const second = mount();
+
+        expect(second.api.presenceFor('maya')).toBe('active');
+
+        first.unmount();
+        second.unmount();
+    });
+
+    it('follows a team switch, leaving the old channel for the new one', async () => {
+        const teamId = ref<string | undefined>('team-1');
+        const { api, unmount } = mount(teamId);
+
+        here([{ id: 'maya', name: 'Maya' }]);
+
+        teamId.value = 'team-2';
+        await nextTick();
+
+        expect(left).toEqual(['team.team-1']);
+        expect(joined).toEqual(['team.team-1', 'team.team-2']);
+        // A stale team's presence must never bleed into the next one's roster.
+        expect(api.presenceFor('maya')).toBe('offline');
+
+        unmount();
+    });
+
+    it('reads everyone as offline before anything has subscribed', () => {
+        expect(useTeamPresence().presenceFor('maya')).toBe('offline');
     });
 });

--- a/resources/js/composables/useTeamPresence.ts
+++ b/resources/js/composables/useTeamPresence.ts
@@ -29,9 +29,231 @@ export type PresenceFlip = {
     state: App.Enums.PresenceState;
 };
 
+/** How a team's presence reads, for any surface that draws a dot. */
+export interface TeamPresence {
+    /** How the given member should render on the roster. */
+    presenceFor: (userId: string) => RenderedPresence;
+    /** Whether the given member shows the crescent do-not-disturb badge. */
+    isDndFor: (userId: string) => boolean;
+}
+
+// Ids of the members currently present, driving the online dots.
+const onlineIds = ref<Set<string>>(new Set());
+
+// Live active/away flips received since this client loaded, by user id.
+// Authoritative over the props seed, which can only be as fresh as the last
+// Inertia visit.
+const flips = ref<Map<string, App.Enums.PresenceState>>(new Map());
+
+// How many mounted subscribers are holding the channel open, and which team it
+// is currently open on.
+let subscriberCount = 0;
+let joinedTeamId: string | undefined;
+
+// A pending debounced profile-update reload, if any.
+let profileReloadTimer: ReturnType<typeof setTimeout> | undefined;
+
+// The shared roster prop, read through `usePage()` inside the computed rather
+// than beside it: this module is evaluated at import time, before Inertia has a
+// page to hand out.
+const teamMembers = computed(() => usePage().props.teamMembers ?? []);
+
 /**
- * Tracks which members of a team are reachable via the `team.{id}` Reverb
- * presence channel, and how reachable each of them is.
+ * The presence the server resolved for each teammate when these props were
+ * built — the cold-start answer for anyone who has not flipped since.
+ */
+const seeded = computed(() => {
+    const states = new Map<string, App.Enums.PresenceState>();
+
+    for (const member of teamMembers.value) {
+        if (member.presence) {
+            states.set(member.id, member.presence);
+        }
+    }
+
+    return states;
+});
+
+/**
+ * The members currently flagged as in do-not-disturb, from the shared
+ * `teamMembers` prop. No live patching layer like the presence flips:
+ * every DND change broadcasts `UserProfileUpdated`, whose debounced reload
+ * below refreshes this very prop.
+ */
+const dndIds = computed(() => {
+    const ids = new Set<string>();
+
+    for (const member of teamMembers.value) {
+        if (member.isDnd) {
+            ids.add(member.id);
+        }
+    }
+
+    return ids;
+});
+
+function channelName(id: string): string {
+    return `team.${id}`;
+}
+
+/**
+ * How the given member should render: offline unless they hold a connection,
+ * and then whatever they last reported.
+ *
+ * Anyone connected but unaccounted for reads as active — a teammate on older
+ * JS, one whose registry entry was evicted, an unreachable cache. Each of
+ * those degrades to exactly the behaviour that predates away rather than to a
+ * wrong "away".
+ */
+function presenceFor(userId: string): RenderedPresence {
+    if (!onlineIds.value.has(userId)) {
+        return 'offline';
+    }
+
+    return flips.value.get(userId) ?? seeded.value.get(userId) ?? 'active';
+}
+
+/**
+ * Whether the given member shows the crescent DND badge on their dot.
+ */
+function isDndFor(userId: string): boolean {
+    return dndIds.value.has(userId);
+}
+
+// A teammate changed their profile (avatar, custom status). Reload the
+// current page's props so every surface re-reads them, preserving scroll and
+// local state so the refresh is invisible. A teammate's timing is not the
+// viewer's, and this one reloads *every* prop, so interrupting a visit with
+// it is especially costly; see {@see backgroundVisit}. Presence deliberately
+// does not come through here — it flips far too often to pay this price.
+function scheduleProfileReload(): void {
+    clearTimeout(profileReloadTimer);
+    profileReloadTimer = setTimeout(() => {
+        router.reload({ ...backgroundVisit });
+    }, PROFILE_RELOAD_DEBOUNCE_MS);
+}
+
+function forgetFlip(id: string): void {
+    if (!flips.value.has(id)) {
+        return;
+    }
+
+    const next = new Map(flips.value);
+    next.delete(id);
+    flips.value = next;
+}
+
+function join(id: string): void {
+    echo()
+        .join(channelName(id))
+        .here((members: PresenceMember[]) => {
+            onlineIds.value = new Set(members.map((member) => member.id));
+        })
+        .joining((member: PresenceMember) => {
+            // Their last flip predates this connection and may describe a
+            // session that has since ended, so the props seed is the fresher
+            // claim until they report again.
+            forgetFlip(member.id);
+            onlineIds.value = new Set(onlineIds.value).add(member.id);
+        })
+        .leaving((member: PresenceMember) => {
+            forgetFlip(member.id);
+
+            const next = new Set(onlineIds.value);
+            next.delete(member.id);
+            onlineIds.value = next;
+        })
+        .listen('UserProfileUpdated', scheduleProfileReload)
+        .listen('UserPresenceChanged', (flip: PresenceFlip) => {
+            flips.value = new Map(flips.value).set(flip.id, flip.state);
+        });
+}
+
+/**
+ * Point the one subscription at the given team, clearing the roster so a stale
+ * team's presence never bleeds into the next.
+ *
+ * Idempotent, which is what lets every subscriber ask for the team it wants
+ * without any of them knowing whether another got there first: only a genuine
+ * change re-subscribes. `undefined` is the teardown — no team, no channel.
+ */
+function syncTo(teamId: string | undefined): void {
+    if (teamId === joinedTeamId) {
+        return;
+    }
+
+    if (joinedTeamId) {
+        echo().leave(channelName(joinedTeamId));
+    }
+
+    onlineIds.value = new Set();
+    flips.value = new Map();
+    joinedTeamId = teamId;
+
+    if (teamId) {
+        join(teamId);
+    }
+}
+
+/**
+ * Subscribe to a team's presence for as long as the calling component lives.
+ *
+ * The subscription is reference-counted rather than per-caller: the shell and
+ * the open channel page both want the roster, both would otherwise join the
+ * same cached Echo channel, and `echo().leave()` removes a channel for *every*
+ * listener bound to it — so whichever of them unmounted first used to tear down
+ * the channel the other was still rendering dots from. Here the first mount
+ * joins, the rest are free, and only the last unmount leaves.
+ *
+ * The subscription follows the given team id: switching teams leaves the old
+ * presence channel and joins the new one.
+ *
+ * Reading presence needs none of this — call {@see useTeamPresence}.
+ */
+export function useTeamPresenceSubscription(
+    teamId: MaybeRefOrGetter<string | undefined>,
+): void {
+    // Echo opens a websocket, so the channel is only ever touched from a
+    // mounted subscriber: joining during setup would run on the SSR pass and
+    // try to connect there.
+    let subscribed = false;
+
+    onMounted(() => {
+        subscribed = true;
+        subscriberCount += 1;
+        syncTo(toValue(teamId));
+    });
+
+    watch(
+        () => toValue(teamId),
+        (id) => {
+            if (subscribed) {
+                syncTo(id);
+            }
+        },
+    );
+
+    onBeforeUnmount(() => {
+        if (!subscribed) {
+            return;
+        }
+
+        subscribed = false;
+        subscriberCount -= 1;
+
+        if (subscriberCount > 0) {
+            return;
+        }
+
+        clearTimeout(profileReloadTimer);
+        profileReloadTimer = undefined;
+        syncTo(undefined);
+    });
+}
+
+/**
+ * Read which members of the team are reachable, and how reachable each of them
+ * is, at the point of use.
  *
  * Two sources are composed, because neither answers alone. The roster (`here` /
  * `joining` / `leaving`) is authoritative for *connected at all* and is instant,
@@ -41,181 +263,13 @@ export type PresenceFlip = {
  * loaded has no event history) and then patched by `UserPresenceChanged`.
  *
  * Callers get a single `presenceFor` rather than the two sources, so none of the
- * dot surfaces can compose them differently.
+ * dot surfaces can compose them differently. The state is module-scoped, so a
+ * dot four components deep reads it directly instead of being handed it — the
+ * shape {@see useMessageActionsContext} gave the message-action scope.
  *
- * The subscription follows the given team id: switching teams leaves the old
- * presence channel and joins the new one, and the channel is left on unmount.
+ * A surface that reads before anything subscribed sees an empty roster, which
+ * renders everyone offline.
  */
-export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
-    const page = usePage();
-
-    // Ids of the members currently present, driving the online dots.
-    const onlineIds = ref<Set<string>>(new Set());
-
-    // Live active/away flips received since this client loaded, by user id.
-    // Authoritative over the props seed, which can only be as fresh as the last
-    // Inertia visit.
-    const flips = ref<Map<string, App.Enums.PresenceState>>(new Map());
-
-    // A pending debounced profile-update reload, if any.
-    let profileReloadTimer: ReturnType<typeof setTimeout> | undefined;
-
-    /**
-     * The presence the server resolved for each teammate when these props were
-     * built — the cold-start answer for anyone who has not flipped since.
-     */
-    const seeded = computed(() => {
-        const states = new Map<string, App.Enums.PresenceState>();
-
-        for (const member of page.props.teamMembers ?? []) {
-            if (member.presence) {
-                states.set(member.id, member.presence);
-            }
-        }
-
-        return states;
-    });
-
-    function channelName(id: string): string {
-        return `team.${id}`;
-    }
-
-    /**
-     * How the given member should render: offline unless they hold a connection,
-     * and then whatever they last reported.
-     *
-     * Anyone connected but unaccounted for reads as active — a teammate on older
-     * JS, one whose registry entry was evicted, an unreachable cache. Each of
-     * those degrades to exactly the behaviour that predates away rather than to a
-     * wrong "away".
-     */
-    function presenceFor(userId: string): RenderedPresence {
-        if (!onlineIds.value.has(userId)) {
-            return 'offline';
-        }
-
-        return flips.value.get(userId) ?? seeded.value.get(userId) ?? 'active';
-    }
-
-    /**
-     * The members currently flagged as in do-not-disturb, from the shared
-     * `teamMembers` prop. No live patching layer like the presence flips:
-     * every DND change broadcasts `UserProfileUpdated`, whose debounced reload
-     * below refreshes this very prop.
-     */
-    const dndIds = computed(() => {
-        const ids = new Set<string>();
-
-        for (const member of page.props.teamMembers ?? []) {
-            if (member.isDnd) {
-                ids.add(member.id);
-            }
-        }
-
-        return ids;
-    });
-
-    /**
-     * Whether the given member shows the crescent DND badge on their dot.
-     */
-    function isDndFor(userId: string): boolean {
-        return dndIds.value.has(userId);
-    }
-
-    // A teammate changed their profile (avatar, custom status). Reload the
-    // current page's props so every surface re-reads them, preserving scroll and
-    // local state so the refresh is invisible. A teammate's timing is not the
-    // viewer's, and this one reloads *every* prop, so interrupting a visit with
-    // it is especially costly; see {@see backgroundVisit}. Presence deliberately
-    // does not come through here — it flips far too often to pay this price.
-    function scheduleProfileReload(): void {
-        clearTimeout(profileReloadTimer);
-        profileReloadTimer = setTimeout(() => {
-            router.reload({ ...backgroundVisit });
-        }, PROFILE_RELOAD_DEBOUNCE_MS);
-    }
-
-    function replace(ids: Iterable<string>): void {
-        onlineIds.value = new Set(ids);
-    }
-
-    function forgetFlip(id: string): void {
-        if (!flips.value.has(id)) {
-            return;
-        }
-
-        const next = new Map(flips.value);
-        next.delete(id);
-        flips.value = next;
-    }
-
-    function join(id: string): void {
-        echo()
-            .join(channelName(id))
-            .here((members: PresenceMember[]) => {
-                replace(members.map((member) => member.id));
-            })
-            .joining((member: PresenceMember) => {
-                // Their last flip predates this connection and may describe a
-                // session that has since ended, so the props seed is the fresher
-                // claim until they report again.
-                forgetFlip(member.id);
-                onlineIds.value = new Set(onlineIds.value).add(member.id);
-            })
-            .leaving((member: PresenceMember) => {
-                forgetFlip(member.id);
-
-                const next = new Set(onlineIds.value);
-                next.delete(member.id);
-                onlineIds.value = next;
-            })
-            .listen('UserProfileUpdated', scheduleProfileReload)
-            .listen('UserPresenceChanged', (flip: PresenceFlip) => {
-                flips.value = new Map(flips.value).set(flip.id, flip.state);
-            });
-    }
-
-    function leave(id: string): void {
-        echo().leave(channelName(id));
-    }
-
-    // Echo opens a websocket, so it must only be touched in the browser: joining
-    // during setup would run on the SSR pass and try to connect there.
-    onMounted(() => {
-        const id = toValue(teamId);
-
-        if (id) {
-            join(id);
-        }
-    });
-
-    // Follow the active team once mounted: re-subscribe when it changes,
-    // clearing the roster so a stale team's presence never bleeds into the next.
-    watch(
-        () => toValue(teamId),
-        (newId, oldId) => {
-            if (oldId) {
-                leave(oldId);
-            }
-
-            replace([]);
-            flips.value = new Map();
-
-            if (newId) {
-                join(newId);
-            }
-        },
-    );
-
-    onBeforeUnmount(() => {
-        clearTimeout(profileReloadTimer);
-
-        const id = toValue(teamId);
-
-        if (id) {
-            leave(id);
-        }
-    });
-
-    return { onlineIds, presenceFor, isDndFor };
+export function useTeamPresence(): TeamPresence {
+    return { presenceFor, isDndFor };
 }

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -49,7 +49,7 @@ import { useShellShortcuts } from '@/composables/useShellShortcuts';
 import { useShellStartup } from '@/composables/useShellStartup';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
-import { useTeamPresence } from '@/composables/useTeamPresence';
+import { useTeamPresenceSubscription } from '@/composables/useTeamPresence';
 import { useToastZoneHeight } from '@/composables/useToastZoneHeight';
 import type { MessageReminder } from '@/types/messages';
 
@@ -95,8 +95,10 @@ useShellShortcuts();
 const currentTeam = computed(() => page.props.currentTeam);
 const teams = computed(() => page.props.teams ?? []);
 
-/** Live presence for the current team, driving the dot on each DM row. */
-const { presenceFor, isDndFor } = useTeamPresence(() => currentTeam.value?.id);
+// The shell holds the team's presence channel open for as long as it is
+// mounted; every dot surface reads the roster through `useTeamPresence()`
+// rather than being handed it.
+useTeamPresenceSubscription(() => currentTeam.value?.id);
 
 // Report this tab's own idle state from the layout every authenticated surface
 // mounts, so someone reading a settings page still counts as here.
@@ -335,8 +337,6 @@ const { isSettingsSection, startTourIfEligible } = useShellStartup();
                         <SettingsNav v-if="isSettingsSection" />
                         <ChannelsPanel
                             v-else-if="activeDestination === 'channels'"
-                            :presence-for="presenceFor"
-                            :is-dnd-for="isDndFor"
                         />
                         <ThreadsPanel
                             v-else-if="activeDestination === 'threads'"
@@ -402,8 +402,6 @@ const { isSettingsSection, startTourIfEligible } = useShellStartup();
         </SidebarInset>
 
         <DialogHost
-            :presence-for="presenceFor"
-            :is-dnd-for="isDndFor"
             @open-reminders="openDestination('reminders')"
             @prompt-answered="startTourIfEligible(false)"
         />

--- a/resources/js/pages/channels/Show.actions.test.ts
+++ b/resources/js/pages/channels/Show.actions.test.ts
@@ -72,7 +72,10 @@ vi.mock('@/composables/useChannelRealtime', () => ({
 vi.mock('@/composables/useTeamPresence', async () => {
     const { teamPresenceDouble } = await import('./Show.doubles');
 
-    return { useTeamPresence: teamPresenceDouble };
+    return {
+        useTeamPresence: teamPresenceDouble,
+        useTeamPresenceSubscription: () => {},
+    };
 });
 
 vi.mock('@/composables/useChannelDraft', async () => {

--- a/resources/js/pages/channels/Show.doubles.ts
+++ b/resources/js/pages/channels/Show.doubles.ts
@@ -126,7 +126,7 @@ export function threadPanelDouble() {
 
 /** The team roster, with everyone offline and nobody in do-not-disturb. */
 export function teamPresenceDouble() {
-    return { presenceFor: () => 'offline', isDndFor: () => false };
+    return { presenceFor: () => 'offline' as const, isDndFor: () => false };
 }
 
 /** The per-channel draft, persisting nothing. */

--- a/resources/js/pages/channels/Show.pane.test.ts
+++ b/resources/js/pages/channels/Show.pane.test.ts
@@ -56,7 +56,10 @@ vi.mock('@/composables/useChannelRealtime', () => ({
 vi.mock('@/composables/useTeamPresence', async () => {
     const { teamPresenceDouble } = await import('./Show.doubles');
 
-    return { useTeamPresence: teamPresenceDouble };
+    return {
+        useTeamPresence: teamPresenceDouble,
+        useTeamPresenceSubscription: () => {},
+    };
 });
 
 vi.mock('@/composables/useChannelDraft', async () => {

--- a/resources/js/pages/channels/Show.timeline.test.ts
+++ b/resources/js/pages/channels/Show.timeline.test.ts
@@ -63,7 +63,10 @@ vi.mock('@/composables/useChannelRealtime', () => ({
 vi.mock('@/composables/useTeamPresence', async () => {
     const { teamPresenceDouble } = await import('./Show.doubles');
 
-    return { useTeamPresence: teamPresenceDouble };
+    return {
+        useTeamPresence: teamPresenceDouble,
+        useTeamPresenceSubscription: () => {},
+    };
 });
 
 vi.mock('@/composables/useChannelDraft', async () => {

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -23,7 +23,7 @@ import { useRailBottomInset } from '@/composables/useRailInset';
 import { useReadOnFocus } from '@/composables/useReadOnFocus';
 import { useReadPointer } from '@/composables/useReadPointer';
 import { useScrollPin } from '@/composables/useScrollPin';
-import { useTeamPresence } from '@/composables/useTeamPresence';
+import { useTeamPresenceSubscription } from '@/composables/useTeamPresence';
 import { useThreadPanel } from '@/composables/useThreadPanel';
 import { useTimezone } from '@/composables/useTimezone';
 import type {
@@ -130,11 +130,10 @@ const typing = useChannelTyping({
 
 const typingNames = typing.typingNames;
 
-/**
- * Live presence for the team, driving the dots on message avatars, the masthead
- * and the facepile. Follows the team across channel switches.
- */
-const { presenceFor, isDndFor } = useTeamPresence(() => props.team.id);
+// The page holds the team's presence channel open alongside the shell — the
+// subscription is reference-counted, so the two share one channel and only the
+// last of them to unmount leaves it.
+useTeamPresenceSubscription(() => props.team.id);
 
 const { readers, seedReaders, channelReadersList } = useChannelReaders({
     channelReaders: () => props.channelReaders,
@@ -421,8 +420,6 @@ provideMessageActions(
                 :team="props.team"
                 :channel="props.channel"
                 :members="props.members"
-                :presence-for="presenceFor"
-                :is-dnd-for="isDndFor"
                 :title="mastheadTitle"
                 :can-manage-preferences="props.canManagePreferences"
                 :can-archive="props.canArchive"
@@ -455,8 +452,6 @@ provideMessageActions(
                 :pending-uuids="pendingUuids"
                 :queued-uuids="queuedUuids"
                 :can-drop-files="props.isMember && !props.channel.isArchived"
-                :presence-for="presenceFor"
-                :is-dnd-for="isDndFor"
                 :readers="channelReadersList"
                 :active-thread-root-id="activeThreadRootId"
                 :editing-message-id="composerEditingId"
@@ -532,8 +527,6 @@ provideMessageActions(
                 :pending-uuids="threadPendingUuids"
                 :members="mentionableMembers"
                 :has-bots="channelHasBots"
-                :presence-for="presenceFor"
-                :is-dnd-for="isDndFor"
                 :loading="threadLoading"
                 :read-only="props.channel.isArchived"
                 @close="closeThread"


### PR DESCRIPTION
Closes #1145. Part of #1142, and lands after #1146 (already on `develop` as 1857345).

## What

`useTeamPresence` was a plain `export function` with **per-call state**, called twice for the same team (`MainLayout.vue`, `pages/channels/Show.vue`). Both landed on the same cached Echo channel `team.{id}`, which cost two live defects:

1. **Doubled reloads.** Each instance registered its own `UserProfileUpdated` listener and its own debounce timer, so one teammate changing an avatar fired **two** whole-page `router.reload()`s.
2. **Premature teardown.** `MainLayout` is the persistent layout, so navigating channel → settings unmounted `Show.vue` alone — and its `onBeforeUnmount` called `echo().leave('team.{id}')`, which removes the channel for *every* listener bound to it, including the shell still rendering dots from it.

And `presenceFor` / `isDndFor` were drilled three and four hops through fifteen components in five independent chains.

## How

The composable is split into its two jobs:

- **`useTeamPresenceSubscription(teamId)`** — module-scoped state plus a **reference-counted** lifecycle. `syncTo()` is idempotent, so the first mount joins, every later caller is free, and only the last unmount leaves. The `UserProfileUpdated` listener and its debounce timer are registered once per channel join, not once per caller. Both `MainLayout` and `Show.vue` still subscribe; they now share one channel.
- **`useTeamPresence()`** — the accessor, read at the point of use. `useMessageActionsContext` is the model for this half, `useDialog` / `useToast` for the module-scoped half.

Fifteen components shed their `presenceFor` / `isDndFor` prop declarations and forwards; five now read the accessor directly (`MessageList`, `MastheadTitle`, `MastheadFacepile`, `SwitcherPeople`, `DirectMessageGroup`).

`usePage()` is resolved lazily inside a computed rather than beside it: the module is evaluated at import time, before Inertia has a page to hand out.

### One deletion worth naming

`AvatarStack.vue` declared `presenceFor` / `dndFor` props and a `PresenceDot` branch that **no caller ever passed** — the dot was unreachable. Rather than re-plumb dead code through the accessor, those props, the branch and the now-orphaned `surfaceClass` are gone.

## Testing

Two red-first tests, both failing before the change:

- one `UserProfileUpdated` broadcast with two consumers mounted triggers **exactly one** `router.reload()` (was 2)
- unmounting one consumer while another is mounted leaves the channel subscribed (was torn down)

The Echo double in `useTeamPresence.test.ts` was made faithful first: a real cached channel *adds* a callback per `.here()` / `.listen()` rather than replacing the last, which is precisely how the second subscriber doubled the work. Without that the doubled-reload test passes vacuously.

Also added: joins once however many subscribers mount, the roster survives a partial teardown, a second subscriber leaves a live roster standing, a team switch leaves the old channel for the new one, and a read before anything subscribed is offline. 20 tests in the composable's suite, up from 14.

Component suites that drove presence through props now mock the composable through a shared, mutable `presence` double in each harness (`ChannelMasthead.doubles`, `MessageList.doubles`, `QuickSwitcher.doubles`, `Show.doubles`).

## Gates

- `composer test` green, coverage **Total: 100.0 %**
- `lint:check` / `format:check` / `types:check` / `build` green
- `test:js` green: 259 files, 2641 tests
- `bin/browser-tests` green: 352 passed, 1859 assertions
- local CodeRabbit against `develop`: **0 findings**

## Records

`CONTEXT.md` only, per the epic: an entry under the named frontend seams, plus a line in *Where new work goes*. No ADR — ADR-0006 already decides where realtime lives, and "shared realtime **state** is module-scoped, not per-caller" is a refinement of it.

No i18n or docs changes: no copy added, nothing operator-facing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788311467&installation_model_id=428379&pr_number=1162&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1162&signature=13d37990a954525bb54ba68920c7cfbf256996bd1084a0030710c3a95e33fa65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->