### PR TITLE
refactor: give FormRequests one route-model accessor base, 53 copies in 42 files

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,6 +187,18 @@ built; build them once, then reuse.
   `SetUserStatus`, `ClearUserStatus`, `SetPresenceOverride` — living in
   `app/Actions/Users/` beside the three scheduled sweeps that clear the same columns;
   `forceFill` appears in no controller.
+- **`RouteBoundRequest`** — route model binding hands a form request a `mixed`, and
+  narrowing it back to the model the route named (or 404ing when it bound none) is one
+  rule with one home: the base every route-bound form request extends. `channel()`,
+  `team()` and `message()` are named on it; a one-off binding — a poll, a section, a
+  scheduled message — is one line through `routeModel($key, Model::class)` rather than a
+  method on the base. **A hand-written `abort_if(! $x instanceof Y, 404)` in a form
+  request is a defect**, and so is handing `$this->route(...)` to `Gate::allows()`:
+  before #1151 the same question shipped at three levels of type safety, four requests
+  gating on an unnarrowed `mixed`. `tests/Unit/FormRequestRouteModelHomeTest.php` fails
+  if a copy comes back. `Api/V1\ApiRequest` extends it and adds only what the API adds —
+  `subject()`, the token's bot or human — and names its token-derived team
+  `subjectTeam()`, because `team()` means *the team the route bound*.
 
 ### Frontend (`resources/js/`)
 
@@ -351,6 +363,10 @@ built; build them once, then reuse.
   `AuditableActionOccurred` from it — the **domain-event seam**, next to the
   mutation.
 - New channel-member preference → the **channel membership settings** concern.
+- A form request that needs the model its route bound → extend **`RouteBoundRequest`** and
+  call `channel()` / `team()` / `message()`, or `routeModel()` for a one-off. Never a
+  hand-written `abort_if(! $x instanceof Y, 404)`, and never `$this->route(...)` straight
+  into a gate.
 - A new nested resource under `settings/teams/{team}/…` → name its route parameter after
   the relationship that owns it (`{customEmoji}` → `Team::customEmojis()`), and let the
   group's `->scopeBindings()` do the tenancy. A hand-rolled `belongs to this team` check

--- a/app/Http/Controllers/Api/V1/WebhookSubscriptionController.php
+++ b/app/Http/Controllers/Api/V1/WebhookSubscriptionController.php
@@ -48,7 +48,7 @@ class WebhookSubscriptionController extends Controller
         $channelIds = $request->validated('channel_ids');
 
         $subscription = $createWebhookSubscription->handle(
-            team: $request->team(),
+            team: $request->subjectTeam(),
             actor: $bot,
             name: $request->validated('name'),
             url: $request->validated('url'),

--- a/app/Http/Requests/Api/V1/ApiRequest.php
+++ b/app/Http/Requests/Api/V1/ApiRequest.php
@@ -2,17 +2,16 @@
 
 namespace App\Http\Requests\Api\V1;
 
-use App\Models\Channel;
-use App\Models\Message;
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\User;
-use Illuminate\Foundation\Http\FormRequest;
 
 /**
- * Shared accessors for the public-API form requests: the authenticated token
- * subject (a bot or a human personal access token) and the route-bound channel
- * / message, each narrowed to its concrete type so the subclasses stay terse.
+ * What the public-API form requests share beyond the route-bound models every
+ * request resolves through {@see RouteBoundRequest}: the authenticated token
+ * subject, a bot or a human personal access token, narrowed to its concrete
+ * type so the subclasses stay terse.
  */
-abstract class ApiRequest extends FormRequest
+abstract class ApiRequest extends RouteBoundRequest
 {
     /**
      * The authenticated subject behind the token — a bot or a human.
@@ -24,29 +23,5 @@ abstract class ApiRequest extends FormRequest
         abort_if(! $user instanceof User, 401);
 
         return $user;
-    }
-
-    /**
-     * The route-bound channel.
-     */
-    protected function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
-    }
-
-    /**
-     * The route-bound message.
-     */
-    protected function message(): Message
-    {
-        $message = $this->route('message');
-
-        abort_if(! $message instanceof Message, 404);
-
-        return $message;
     }
 }

--- a/app/Http/Requests/Api/V1/StoreChannelRequest.php
+++ b/app/Http/Requests/Api/V1/StoreChannelRequest.php
@@ -71,7 +71,7 @@ class StoreChannelRequest extends ApiRequest
                 }
 
                 $exists = Channel::query()
-                    ->where('team_id', $this->team()->id)
+                    ->where('team_id', $this->subjectTeam()->id)
                     ->where('slug', NameSlug::distinct((string) $this->input('name'), Channel::FALLBACK_SLUG))
                     ->exists();
 
@@ -84,8 +84,11 @@ class StoreChannelRequest extends ApiRequest
 
     /**
      * The team the channel is created in — the subject's acting team.
+     *
+     * Deliberately not named `team()`, which the base reserves for the team a
+     * route bound: no API route names a workspace, the token does.
      */
-    public function team(): Team
+    public function subjectTeam(): Team
     {
         return ApiChannelAccess::team($this->subject());
     }

--- a/app/Http/Requests/Api/V1/StoreWebhookSubscriptionRequest.php
+++ b/app/Http/Requests/Api/V1/StoreWebhookSubscriptionRequest.php
@@ -57,7 +57,7 @@ class StoreWebhookSubscriptionRequest extends ApiRequest
                 }
 
                 $ownedCount = Channel::query()
-                    ->where('team_id', $this->team()->id)
+                    ->where('team_id', $this->subjectTeam()->id)
                     ->whereIn('id', $channelIds)
                     ->count();
 
@@ -70,8 +70,11 @@ class StoreWebhookSubscriptionRequest extends ApiRequest
 
     /**
      * The team the subscription belongs to — the bot's own team.
+     *
+     * Deliberately not named `team()`, which the base reserves for the team a
+     * route bound: no API route names a workspace, the token does.
      */
-    public function team(): Team
+    public function subjectTeam(): Team
     {
         return $this->subject()->ownerTeam()->firstOrFail();
     }

--- a/app/Http/Requests/Channels/AddChannelMemberRequest.php
+++ b/app/Http/Requests/Channels/AddChannelMemberRequest.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use App\Rules\AddableChannelMember;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class AddChannelMemberRequest extends FormRequest
+class AddChannelMemberRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -32,17 +31,5 @@ class AddChannelMemberRequest extends FormRequest
                 new AddableChannelMember($this->channel()->team_id),
             ],
         ];
-    }
-
-    /**
-     * Get the channel the member is being added to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/AddDirectMessagePeopleRequest.php
+++ b/app/Http/Requests/Channels/AddDirectMessagePeopleRequest.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class AddDirectMessagePeopleRequest extends FormRequest
+class AddDirectMessagePeopleRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -40,17 +39,5 @@ class AddDirectMessagePeopleRequest extends FormRequest
                 Rule::exists('team_members', 'user_id')->where('team_id', $this->channel()->team_id),
             ],
         ];
-    }
-
-    /**
-     * Get the direct message people are being added to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/CancelScheduledMessageRequest.php
+++ b/app/Http/Requests/Channels/CancelScheduledMessageRequest.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\ScheduledMessage;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class CancelScheduledMessageRequest extends FormRequest
+class CancelScheduledMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -23,10 +23,6 @@ class CancelScheduledMessageRequest extends FormRequest
      */
     public function scheduledMessage(): ScheduledMessage
     {
-        $scheduled = $this->route('scheduledMessage');
-
-        abort_if(! $scheduled instanceof ScheduledMessage, 404);
-
-        return $scheduled;
+        return $this->routeModel('scheduledMessage', ScheduledMessage::class);
     }
 }

--- a/app/Http/Requests/Channels/CastVoteRequest.php
+++ b/app/Http/Requests/Channels/CastVoteRequest.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\Poll;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class CastVoteRequest extends FormRequest
+class CastVoteRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -41,26 +40,10 @@ class CastVoteRequest extends FormRequest
     }
 
     /**
-     * Get the channel the poll belongs to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
-    }
-
-    /**
      * Get the poll being voted on.
      */
     public function poll(): Poll
     {
-        $poll = $this->route('poll');
-
-        abort_if(! $poll instanceof Poll, 404);
-
-        return $poll;
+        return $this->routeModel('poll', Poll::class);
     }
 }

--- a/app/Http/Requests/Channels/ClearMessageReminderRequest.php
+++ b/app/Http/Requests/Channels/ClearMessageReminderRequest.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\MessageReminder;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class ClearMessageReminderRequest extends FormRequest
+class ClearMessageReminderRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -23,10 +23,6 @@ class ClearMessageReminderRequest extends FormRequest
      */
     public function reminder(): MessageReminder
     {
-        $reminder = $this->route('reminder');
-
-        abort_if(! $reminder instanceof MessageReminder, 404);
-
-        return $reminder;
+        return $this->routeModel('reminder', MessageReminder::class);
     }
 }

--- a/app/Http/Requests/Channels/CreateChannelRequest.php
+++ b/app/Http/Requests/Channels/CreateChannelRequest.php
@@ -3,18 +3,17 @@
 namespace App\Http\Requests\Channels;
 
 use App\Enums\ChannelVisibility;
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\Channel;
-use App\Models\Team;
 use App\Policies\TeamPolicy;
 use App\Support\NameSlug;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
-class CreateChannelRequest extends FormRequest
+class CreateChannelRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -88,17 +87,5 @@ class CreateChannelRequest extends FormRequest
                 }
             },
         ];
-    }
-
-    /**
-     * Get the team the channel is being created in.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Channels/DeleteChannelRequest.php
+++ b/app/Http/Requests/Channels/DeleteChannelRequest.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Validator;
 
-class DeleteChannelRequest extends FormRequest
+class DeleteChannelRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -62,17 +61,5 @@ class DeleteChannelRequest extends FormRequest
                 }
             },
         ];
-    }
-
-    /**
-     * Get the channel being deleted.
-     */
-    private function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/DeleteMessageRequest.php
+++ b/app/Http/Requests/Channels/DeleteMessageRequest.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Message;
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Support\Facades\Gate;
 
-class DeleteMessageRequest extends FormRequest
+class DeleteMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -14,17 +13,5 @@ class DeleteMessageRequest extends FormRequest
     public function authorize(): bool
     {
         return Gate::allows('delete', $this->message());
-    }
-
-    /**
-     * Get the message being deleted.
-     */
-    public function message(): Message
-    {
-        $message = $this->route('message');
-
-        abort_if(! $message instanceof Message, 404);
-
-        return $message;
     }
 }

--- a/app/Http/Requests/Channels/EditMessageRequest.php
+++ b/app/Http/Requests/Channels/EditMessageRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Message;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class EditMessageRequest extends FormRequest
+class EditMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -38,17 +37,5 @@ class EditMessageRequest extends FormRequest
         return [
             'body' => ['required', 'string', 'max:8000'],
         ];
-    }
-
-    /**
-     * Get the message being edited.
-     */
-    public function message(): Message
-    {
-        $message = $this->route('message');
-
-        abort_if(! $message instanceof Message, 404);
-
-        return $message;
     }
 }

--- a/app/Http/Requests/Channels/ForwardMessageRequest.php
+++ b/app/Http/Requests/Channels/ForwardMessageRequest.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Requests\Channels;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\Channel;
-use App\Models\Message;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class ForwardMessageRequest extends FormRequest
+class ForwardMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -79,23 +78,7 @@ class ForwardMessageRequest extends FormRequest
      */
     public function sourceChannel(): Channel
     {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
-    }
-
-    /**
-     * Get the source message being forwarded.
-     */
-    public function message(): Message
-    {
-        $message = $this->route('message');
-
-        abort_if(! $message instanceof Message, 404);
-
-        return $message;
+        return $this->routeModel('channel', Channel::class);
     }
 
     /**

--- a/app/Http/Requests/Channels/GifSearchRequest.php
+++ b/app/Http/Requests/Channels/GifSearchRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class GifSearchRequest extends FormRequest
+class GifSearchRequest extends RouteBoundRequest
 {
     /**
      * Searching the picker reuses the post-message policy: if the user could not
@@ -29,17 +28,5 @@ class GifSearchRequest extends FormRequest
             // Infinite-scroll cursor (Giphy is offset-paginated).
             'offset' => ['nullable', 'integer', 'min:0'],
         ];
-    }
-
-    /**
-     * Get the channel the picker is scoped to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/HideDirectMessageRequest.php
+++ b/app/Http/Requests/Channels/HideDirectMessageRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class HideDirectMessageRequest extends FormRequest
+class HideDirectMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -30,17 +29,5 @@ class HideDirectMessageRequest extends FormRequest
             // conversation.
             'leaving' => ['sometimes', 'boolean'],
         ];
-    }
-
-    /**
-     * Get the direct message being hidden.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/OpenDirectMessageRequest.php
+++ b/app/Http/Requests/Channels/OpenDirectMessageRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class OpenDirectMessageRequest extends FormRequest
+class OpenDirectMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -41,17 +40,5 @@ class OpenDirectMessageRequest extends FormRequest
                 Rule::exists('team_members', 'user_id')->where('team_id', $this->team()->id),
             ],
         ];
-    }
-
-    /**
-     * Get the team the direct message is being opened in.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Channels/PinMessageRequest.php
+++ b/app/Http/Requests/Channels/PinMessageRequest.php
@@ -2,13 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
-use App\Models\Message;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class PinMessageRequest extends FormRequest
+class PinMessageRequest extends RouteBoundRequest
 {
     /**
      * The hard cap on how many messages a single channel may pin at once.
@@ -64,29 +62,5 @@ class PinMessageRequest extends FormRequest
                 $validator->errors()->add('message', __('This channel has reached its limit of :max pinned messages.', ['max' => self::MAX_PINS]));
             }
         });
-    }
-
-    /**
-     * Get the channel the message is being pinned in.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
-    }
-
-    /**
-     * Get the message being pinned or unpinned.
-     */
-    public function message(): Message
-    {
-        $message = $this->route('message');
-
-        abort_if(! $message instanceof Message, 404);
-
-        return $message;
     }
 }

--- a/app/Http/Requests/Channels/PostMessageRequest.php
+++ b/app/Http/Requests/Channels/PostMessageRequest.php
@@ -3,13 +3,12 @@
 namespace App\Http\Requests\Channels;
 
 use App\Enums\MessageType;
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class PostMessageRequest extends FormRequest
+class PostMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -78,17 +77,5 @@ class PostMessageRequest extends FormRequest
             // main timeline in addition to the thread.
             'sent_to_channel' => ['boolean'],
         ];
-    }
-
-    /**
-     * Get the channel the message is being posted to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/ReactionRequest.php
+++ b/app/Http/Requests/Channels/ReactionRequest.php
@@ -2,13 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
-use App\Models\Message;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class ReactionRequest extends FormRequest
+class ReactionRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -61,29 +59,5 @@ class ReactionRequest extends FormRequest
                 $fail(__('That custom emoji does not exist.'));
             }
         };
-    }
-
-    /**
-     * Get the channel the reaction is being toggled in.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
-    }
-
-    /**
-     * Get the message the reaction is being toggled on.
-     */
-    public function message(): Message
-    {
-        $message = $this->route('message');
-
-        abort_if(! $message instanceof Message, 404);
-
-        return $message;
     }
 }

--- a/app/Http/Requests/Channels/RemoveChannelMemberRequest.php
+++ b/app/Http/Requests/Channels/RemoveChannelMemberRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class RemoveChannelMemberRequest extends FormRequest
+class RemoveChannelMemberRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -27,17 +26,5 @@ class RemoveChannelMemberRequest extends FormRequest
         return [
             'user_id' => ['required', 'uuid', 'exists:users,id'],
         ];
-    }
-
-    /**
-     * Get the channel the member is being removed from.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/SaveChannelDraftRequest.php
+++ b/app/Http/Requests/Channels/SaveChannelDraftRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class SaveChannelDraftRequest extends FormRequest
+class SaveChannelDraftRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -32,17 +31,5 @@ class SaveChannelDraftRequest extends FormRequest
         return [
             'body' => ['nullable', 'string', 'max:8000'],
         ];
-    }
-
-    /**
-     * Get the channel whose draft is being saved.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/ScheduleMessageRequest.php
+++ b/app/Http/Requests/Channels/ScheduleMessageRequest.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class ScheduleMessageRequest extends FormRequest
+class ScheduleMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -57,17 +56,5 @@ class ScheduleMessageRequest extends FormRequest
                     ->whereNull('deleted_at'),
             ],
         ];
-    }
-
-    /**
-     * Get the channel the message is being scheduled for.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/SetMessageReminderRequest.php
+++ b/app/Http/Requests/Channels/SetMessageReminderRequest.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Requests\Channels;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\Message;
-use App\Models\Team;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class SetMessageReminderRequest extends FormRequest
+class SetMessageReminderRequest extends RouteBoundRequest
 {
     /**
      * The resolved target message, memoised so authorization and the controller
@@ -64,17 +63,5 @@ class SetMessageReminderRequest extends FormRequest
         }
 
         return $this->resolvedMessage;
-    }
-
-    /**
-     * Get the team the reminder is being set within.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Channels/StoreAttachmentRequest.php
+++ b/app/Http/Requests/Channels/StoreAttachmentRequest.php
@@ -2,16 +2,14 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use App\Rules\NotExecutableFile;
 use App\Rules\WithinStorageQuota;
 use App\Support\TeamStorage;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class StoreAttachmentRequest extends FormRequest
+class StoreAttachmentRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -59,30 +57,5 @@ class StoreAttachmentRequest extends FormRequest
         return [
             'file.max' => __('The file may not be larger than :size MB.', ['size' => (int) config('attachments.max_size_mb')]),
         ];
-    }
-
-    /**
-     * Get the channel the attachment is being uploaded to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
-    }
-
-    /**
-     * Get the workspace the attachment is being uploaded to. Read off the route
-     * (the channel is scope-bound to it) so the quota check costs no extra query.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Channels/StoreGifRequest.php
+++ b/app/Http/Requests/Channels/StoreGifRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class StoreGifRequest extends FormRequest
+class StoreGifRequest extends RouteBoundRequest
 {
     /**
      * Attaching a GIF reuses the post-message policy, exactly like uploading a
@@ -29,17 +28,5 @@ class StoreGifRequest extends FormRequest
             // re-resolves it authoritatively (never trusting a client URL).
             'id' => ['required', 'string', 'max:100'],
         ];
-    }
-
-    /**
-     * Get the channel the GIF is being attached to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/StorePollRequest.php
+++ b/app/Http/Requests/Channels/StorePollRequest.php
@@ -3,14 +3,13 @@
 namespace App\Http\Requests\Channels;
 
 use App\Enums\MessageType;
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\Poll;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class StorePollRequest extends FormRequest
+class StorePollRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -90,17 +89,5 @@ class StorePollRequest extends FormRequest
         return [
             'options.*.distinct' => __('Options must be different from each other.'),
         ];
-    }
-
-    /**
-     * Get the channel the poll is being posted to.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/StoreSlashCommandRequest.php
+++ b/app/Http/Requests/Channels/StoreSlashCommandRequest.php
@@ -3,9 +3,8 @@
 namespace App\Http\Requests\Channels;
 
 use App\Enums\MessageType;
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
@@ -17,7 +16,7 @@ use Illuminate\Validation\Rule;
  * reuses the channel's `postMessage` policy, since dispatching a command may
  * post a message on the sender's behalf.
  */
-class StoreSlashCommandRequest extends FormRequest
+class StoreSlashCommandRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -67,17 +66,5 @@ class StoreSlashCommandRequest extends FormRequest
             // in the main timeline in addition to the thread.
             'sent_to_channel' => ['boolean'],
         ];
-    }
-
-    /**
-     * Get the channel the command is being run in.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/UpdateChannelPlacementRequest.php
+++ b/app/Http/Requests/Channels/UpdateChannelPlacementRequest.php
@@ -2,14 +2,12 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class UpdateChannelPlacementRequest extends FormRequest
+class UpdateChannelPlacementRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -65,29 +63,5 @@ class UpdateChannelPlacementRequest extends FormRequest
     public function orderedIds(): array
     {
         return array_values($this->validated('ordered_ids'));
-    }
-
-    /**
-     * Get the channel being placed.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
-    }
-
-    /**
-     * Get the team the channel belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Channels/UpdateChannelPreferenceRequest.php
+++ b/app/Http/Requests/Channels/UpdateChannelPreferenceRequest.php
@@ -3,13 +3,12 @@
 namespace App\Http\Requests\Channels;
 
 use App\Enums\NotificationLevel;
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class UpdateChannelPreferenceRequest extends FormRequest
+class UpdateChannelPreferenceRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -30,17 +29,5 @@ class UpdateChannelPreferenceRequest extends FormRequest
             'muted' => ['required', 'boolean'],
             'notification_level' => ['required', Rule::enum(NotificationLevel::class)],
         ];
-    }
-
-    /**
-     * Get the channel whose preferences are being updated.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/UpdateChannelRequest.php
+++ b/app/Http/Requests/Channels/UpdateChannelRequest.php
@@ -2,16 +2,16 @@
 
 namespace App\Http\Requests\Channels;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\Channel;
 use App\Policies\ChannelPolicy;
 use App\Support\NameSlug;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Validator;
 
-class UpdateChannelRequest extends FormRequest
+class UpdateChannelRequest extends RouteBoundRequest
 {
     /**
      * The longest a channel description may be — room for a few paragraphs of
@@ -117,18 +117,6 @@ class UpdateChannelRequest extends FormRequest
                 }
             },
         ];
-    }
-
-    /**
-     * Get the channel being edited.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 
     /**

--- a/app/Http/Requests/Channels/UpdateChannelStarRequest.php
+++ b/app/Http/Requests/Channels/UpdateChannelStarRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Channels;
 
-use App\Models\Channel;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class UpdateChannelStarRequest extends FormRequest
+class UpdateChannelStarRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -27,17 +26,5 @@ class UpdateChannelStarRequest extends FormRequest
         return [
             'starred' => ['required', 'boolean'],
         ];
-    }
-
-    /**
-     * Get the channel whose star flag is being toggled.
-     */
-    public function channel(): Channel
-    {
-        $channel = $this->route('channel');
-
-        abort_if(! $channel instanceof Channel, 404);
-
-        return $channel;
     }
 }

--- a/app/Http/Requests/Channels/UpdateScheduledMessageRequest.php
+++ b/app/Http/Requests/Channels/UpdateScheduledMessageRequest.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Requests\Channels;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\ScheduledMessage;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class UpdateScheduledMessageRequest extends FormRequest
+class UpdateScheduledMessageRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -48,10 +48,6 @@ class UpdateScheduledMessageRequest extends FormRequest
      */
     public function scheduledMessage(): ScheduledMessage
     {
-        $scheduled = $this->route('scheduledMessage');
-
-        abort_if(! $scheduled instanceof ScheduledMessage, 404);
-
-        return $scheduled;
+        return $this->routeModel('scheduledMessage', ScheduledMessage::class);
     }
 }

--- a/app/Http/Requests/RouteBoundRequest.php
+++ b/app/Http/Requests/RouteBoundRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * The base every form request bound to a route model extends. Route model
+ * binding hands the request a `mixed`, and narrowing it back to the model the
+ * route named — or 404ing when it did not bind one — is a rule the requests
+ * copied 53 times before #1151.
+ *
+ * Accessors are named for the recurring three (channel, team, message); a
+ * one-off binding reaches the same rule in one line through {@see routeModel()}
+ * rather than earning a method here.
+ */
+abstract class RouteBoundRequest extends FormRequest
+{
+    /**
+     * The route-bound channel.
+     */
+    public function channel(): Channel
+    {
+        return $this->routeModel('channel', Channel::class);
+    }
+
+    /**
+     * The route-bound team.
+     */
+    public function team(): Team
+    {
+        return $this->routeModel('team', Team::class);
+    }
+
+    /**
+     * The route-bound message.
+     */
+    public function message(): Message
+    {
+        return $this->routeModel('message', Message::class);
+    }
+
+    /**
+     * The model the given route parameter bound, 404ing when the route bound
+     * nothing of that type.
+     *
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $model
+     * @return TModel
+     */
+    protected function routeModel(string $key, string $model): Model
+    {
+        $bound = $this->route($key);
+
+        abort_if(! $bound instanceof $model, 404);
+
+        return $bound;
+    }
+}

--- a/app/Http/Requests/Sidebar/DeleteChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/DeleteChannelSectionRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Sidebar;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\ChannelSection;
-use App\Models\Team;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class DeleteChannelSectionRequest extends FormRequest
+class DeleteChannelSectionRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -28,22 +27,6 @@ class DeleteChannelSectionRequest extends FormRequest
      */
     public function section(): ChannelSection
     {
-        $section = $this->route('section');
-
-        abort_if(! $section instanceof ChannelSection, 404);
-
-        return $section;
-    }
-
-    /**
-     * Get the team the section belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
+        return $this->routeModel('section', ChannelSection::class);
     }
 }

--- a/app/Http/Requests/Sidebar/ReorderChannelSectionsRequest.php
+++ b/app/Http/Requests/Sidebar/ReorderChannelSectionsRequest.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Requests\Sidebar;
 
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class ReorderChannelSectionsRequest extends FormRequest
+class ReorderChannelSectionsRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -36,17 +35,5 @@ class ReorderChannelSectionsRequest extends FormRequest
                     ->where('team_id', $this->team()->id),
             ],
         ];
-    }
-
-    /**
-     * Get the team whose sections are being reordered.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Sidebar/StoreChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/StoreChannelSectionRequest.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Requests\Sidebar;
 
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 
-class StoreChannelSectionRequest extends FormRequest
+class StoreChannelSectionRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -40,17 +39,5 @@ class StoreChannelSectionRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:50'],
         ];
-    }
-
-    /**
-     * Get the team the section is being created in.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Sidebar/UpdateChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/UpdateChannelSectionRequest.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Requests\Sidebar;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\ChannelSection;
-use App\Models\Team;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
-class UpdateChannelSectionRequest extends FormRequest
+class UpdateChannelSectionRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -57,22 +56,6 @@ class UpdateChannelSectionRequest extends FormRequest
      */
     public function section(): ChannelSection
     {
-        $section = $this->route('section');
-
-        abort_if(! $section instanceof ChannelSection, 404);
-
-        return $section;
-    }
-
-    /**
-     * Get the team the section belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
+        return $this->routeModel('section', ChannelSection::class);
     }
 }

--- a/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
+++ b/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Teams;
 
 use App\Enums\TeamRole;
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use App\Rules\UniqueTeamInvitation;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class CreateTeamInvitationRequest extends FormRequest
+class CreateTeamInvitationRequest extends RouteBoundRequest
 {
     /**
      * Get the validation rules that apply to the request.
@@ -18,12 +19,8 @@ class CreateTeamInvitationRequest extends FormRequest
      */
     public function rules(): array
     {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
         return [
-            'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($team)],
+            'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($this->team())],
             'role' => ['required', 'string', Rule::enum(TeamRole::class)],
         ];
     }

--- a/app/Http/Requests/Teams/DeleteTeamRequest.php
+++ b/app/Http/Requests/Teams/DeleteTeamRequest.php
@@ -2,21 +2,20 @@
 
 namespace App\Http\Requests\Teams;
 
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Validator;
 
-class DeleteTeamRequest extends FormRequest
+class DeleteTeamRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
-        return Gate::allows('delete', $this->route('team'));
+        return Gate::allows('delete', $this->team());
     }
 
     /**
@@ -45,17 +44,5 @@ class DeleteTeamRequest extends FormRequest
                 }
             },
         ];
-    }
-
-    /**
-     * Get the team associated with the request.
-     */
-    private function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Teams/Integrations/StoreBotChannelRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreBotChannelRequest.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace App\Http\Requests\Teams\Integrations;
 
 use App\Enums\ChannelType;
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\User;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 /**
@@ -17,7 +16,7 @@ use Illuminate\Validation\Rule;
  * surface. The bot may join any standard channel in its own team (public or
  * private) — direct messages are never a valid target.
  */
-class StoreBotChannelRequest extends FormRequest
+class StoreBotChannelRequest extends RouteBoundRequest
 {
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
@@ -41,26 +40,10 @@ class StoreBotChannelRequest extends FormRequest
     }
 
     /**
-     * The team the bot belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
-    }
-
-    /**
      * The bot whose channel membership is being changed.
      */
     public function bot(): User
     {
-        $bot = $this->route('bot');
-
-        abort_if(! $bot instanceof User, 404);
-
-        return $bot;
+        return $this->routeModel('bot', User::class);
     }
 }

--- a/app/Http/Requests/Teams/Integrations/StoreIncomingWebhookRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreIncomingWebhookRequest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Teams\Integrations;
 
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 /**
@@ -14,7 +13,7 @@ use Illuminate\Validation\Rule;
  * channel as a bot) from the settings surface. The channel and bot must both
  * belong to the team; the action re-checks that the bot can post to the channel.
  */
-class StoreIncomingWebhookRequest extends FormRequest
+class StoreIncomingWebhookRequest extends RouteBoundRequest
 {
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
@@ -39,17 +38,5 @@ class StoreIncomingWebhookRequest extends FormRequest
             ],
             'with_signing_secret' => ['boolean'],
         ];
-    }
-
-    /**
-     * The team the webhook belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Teams/Integrations/StoreWebhookSubscriptionRequest.php
+++ b/app/Http/Requests/Teams/Integrations/StoreWebhookSubscriptionRequest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace App\Http\Requests\Teams\Integrations;
 
 use App\Enums\WebhookEvent;
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\Channel;
-use App\Models\Team;
 use App\Rules\PublicWebhookUrl;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
@@ -19,7 +18,7 @@ use Illuminate\Validation\Validator;
  * surface. An optional channel allow-list narrows delivery; every listed channel
  * must belong to the team (omit the list to receive events from every channel).
  */
-class StoreWebhookSubscriptionRequest extends FormRequest
+class StoreWebhookSubscriptionRequest extends RouteBoundRequest
 {
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
@@ -77,17 +76,5 @@ class StoreWebhookSubscriptionRequest extends FormRequest
         }
 
         return array_values(array_unique($channelIds));
-    }
-
-    /**
-     * The team the subscription belongs to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Teams/RequestAuditExportRequest.php
+++ b/app/Http/Requests/Teams/RequestAuditExportRequest.php
@@ -4,13 +4,12 @@ namespace App\Http\Requests\Teams;
 
 use App\Enums\AuditExportFormat;
 use App\Enums\AuditExportLogType;
-use App\Models\Team;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class RequestAuditExportRequest extends FormRequest
+class RequestAuditExportRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user may export the requested log for this workspace.
@@ -21,9 +20,7 @@ class RequestAuditExportRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        $team = $this->route('team');
-
-        return $team instanceof Team && Gate::allows($this->gate(), $team);
+        return Gate::allows($this->gate(), $this->team());
     }
 
     /**

--- a/app/Http/Requests/Teams/StoreCustomEmojiRequest.php
+++ b/app/Http/Requests/Teams/StoreCustomEmojiRequest.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Requests\Teams;
 
+use App\Http\Requests\RouteBoundRequest;
 use App\Models\CustomEmoji;
-use App\Models\Team;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class StoreCustomEmojiRequest extends FormRequest
+class StoreCustomEmojiRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -65,17 +64,5 @@ class StoreCustomEmojiRequest extends FormRequest
             'name.unique' => __('An emoji with this name already exists in this workspace.'),
             'image.dimensions' => __('The image must be square and at most 128×128 pixels.'),
         ];
-    }
-
-    /**
-     * Get the team the emoji is being added to.
-     */
-    public function team(): Team
-    {
-        $team = $this->route('team');
-
-        abort_if(! $team instanceof Team, 404);
-
-        return $team;
     }
 }

--- a/app/Http/Requests/Teams/ViewAnalyticsRequest.php
+++ b/app/Http/Requests/Teams/ViewAnalyticsRequest.php
@@ -3,19 +3,19 @@
 namespace App\Http\Requests\Teams;
 
 use App\Enums\AnalyticsRange;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class ViewAnalyticsRequest extends FormRequest
+class ViewAnalyticsRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to view the workspace analytics.
      */
     public function authorize(): bool
     {
-        return Gate::allows('viewAnalytics', $this->route('team'));
+        return Gate::allows('viewAnalytics', $this->team());
     }
 
     /**

--- a/app/Http/Requests/Teams/ViewAuditLogRequest.php
+++ b/app/Http/Requests/Teams/ViewAuditLogRequest.php
@@ -3,19 +3,19 @@
 namespace App\Http\Requests\Teams;
 
 use App\Enums\AuditAction;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class ViewAuditLogRequest extends FormRequest
+class ViewAuditLogRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to view the workspace's audit log.
      */
     public function authorize(): bool
     {
-        return Gate::allows('viewAudit', $this->route('team'));
+        return Gate::allows('viewAudit', $this->team());
     }
 
     /**

--- a/app/Http/Requests/Teams/ViewSecurityLogRequest.php
+++ b/app/Http/Requests/Teams/ViewSecurityLogRequest.php
@@ -3,19 +3,19 @@
 namespace App\Http\Requests\Teams;
 
 use App\Enums\SecurityEventType;
+use App\Http\Requests\RouteBoundRequest;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
-class ViewSecurityLogRequest extends FormRequest
+class ViewSecurityLogRequest extends RouteBoundRequest
 {
     /**
      * Determine if the user is authorized to view the workspace's security log.
      */
     public function authorize(): bool
     {
-        return Gate::allows('viewSecurityLog', $this->route('team'));
+        return Gate::allows('viewSecurityLog', $this->team());
     }
 
     /**

--- a/tests/Integration/Http/RouteBoundRequestTest.php
+++ b/tests/Integration/Http/RouteBoundRequestTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Requests\RouteBoundRequest;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * "Resolve the model this route bound, or 404" was a five-line guard copied into
+ * 42 of the 79 files under `app/Http/Requests/` before #1151. It now has one
+ * home, {@see RouteBoundRequest}, and this is the test the copies never had.
+ *
+ * The base is reachable without an HTTP round-trip — a form request is just a
+ * request with a route resolver — so the resolve-or-404 rule is stated here
+ * directly rather than inferred from whichever endpoint happened to exercise it.
+ */
+
+/**
+ * A request of the base's type, bound to a route carrying the given parameters.
+ *
+ * @param  array<string, mixed>  $parameters
+ */
+function routeBoundRequest(array $parameters): RouteBoundRequest
+{
+    $request = new class extends RouteBoundRequest {};
+
+    $route = new Route('GET', '/{model}', []);
+    $route->bind(Request::create('/'));
+
+    foreach ($parameters as $key => $value) {
+        $route->setParameter($key, $value);
+    }
+
+    $request->setRouteResolver(fn (): Route => $route);
+
+    return $request;
+}
+
+/**
+ * The recurring three, each keyed by the accessor and the route parameter it
+ * reads. `channel` and `message` are the two `Api/V1\ApiRequest` already had;
+ * `team` is the one the web subtree copied fifteen times.
+ *
+ * @return array<string, array{string, string, Model}>
+ */
+dataset('recurring route models', fn (): array => [
+    'channel' => ['channel', 'channel', new Channel],
+    'team' => ['team', 'team', new Team],
+    'message' => ['message', 'message', new Message],
+]);
+
+test('each accessor returns the model the route bound', function (string $accessor, string $key, Model $model): void {
+    expect(routeBoundRequest([$key => $model])->{$accessor}())->toBe($model);
+})->with('recurring route models');
+
+test('a route that bound the wrong type of model still 404s', function (string $accessor, string $key): void {
+    $request = routeBoundRequest([$key => new stdClass]);
+
+    expect(fn () => $request->{$accessor}())
+        ->toThrow(NotFoundHttpException::class);
+})->with('recurring route models');
+
+test('a route that bound nothing at all still 404s', function (string $accessor): void {
+    expect(fn () => routeBoundRequest([])->{$accessor}())
+        ->toThrow(NotFoundHttpException::class);
+})->with('recurring route models');
+
+/**
+ * The named accessors are one line each over a generic resolver, so a one-off
+ * binding — a poll, a section, a scheduled message — gets the same rule without
+ * earning a method on the base. This is the shape those call sites take.
+ */
+test('the resolver narrows any bound model, not just the recurring three', function (): void {
+    $team = new Team;
+
+    $request = new class extends RouteBoundRequest
+    {
+        public function owner(): Team
+        {
+            return $this->routeModel('owner', Team::class);
+        }
+    };
+
+    $route = new Route('GET', '/{owner}', []);
+    $route->bind(Request::create('/'));
+    $route->setParameter('owner', $team);
+    $request->setRouteResolver(fn (): Route => $route);
+
+    expect($request->owner())->toBe($team);
+});

--- a/tests/Unit/FormRequestRouteModelHomeTest.php
+++ b/tests/Unit/FormRequestRouteModelHomeTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * "Resolve the model this route bound, or 404" is one rule, and before #1151 it
+ * was written out 53 times across 42 of the 79 files under
+ * `app/Http/Requests/` — roughly 250 lines of identical guard, and the reason
+ * those files ran 80 to 170 lines when their actual rules were ten.
+ *
+ * It was not even uniform. Three levels of type safety shipped side by side for
+ * the same question: the five-line `abort_if` guard, a `$team instanceof Team &&
+ * Gate::allows(...)` inline in `authorize()`, and four requests handing
+ * `$this->route('team')` — a `mixed` — straight to the gate.
+ *
+ * There is now one home, `App\Http\Requests\RouteBoundRequest`, and this test is
+ * what keeps a fifty-fourth copy from being written: each of the three shapes
+ * fails here rather than in review. See `CONTEXT.md`.
+ */
+$sourceRoot = dirname(__DIR__, 2);
+
+/**
+ * The three shapes route-model resolution took in a form request, each keyed by
+ * the copy it came from.
+ *
+ * @return array<string, string>
+ */
+function routeModelSpellingPatterns(): array
+{
+    return [
+        // The five-line accessor, copied 53 times.
+        'hand-written guard' => '/\$\w+\s*=\s*\$this->route\([^)]*\);\s*abort_if\(\s*!\s*\$\w+\s+instanceof/',
+        // `Teams\RequestAuditExportRequest` — the same question, guarded inline.
+        'inline instanceof gate' => '/instanceof\s+\w+\s*&&\s*Gate::/',
+        // `Teams\DeleteTeamRequest` and the three log-viewing requests — a `mixed`
+        // handed to the gate, which is the guard skipped entirely.
+        'unguarded gate' => '/Gate::\w+\([^;]*\$this->route\(/',
+    ];
+}
+
+/**
+ * Every form request spelling the given shape out, as repository-relative paths.
+ *
+ * @return array<int, string>
+ */
+$spellings = function (string $pattern) use ($sourceRoot): array {
+    $files = (new Finder)->files()->in($sourceRoot.'/app/Http/Requests')->name('*.php');
+
+    $found = [];
+
+    foreach ($files as $file) {
+        if (preg_match($pattern, $file->getContents()) === 1) {
+            $found[] = str_replace($sourceRoot.'/', '', $file->getPathname());
+        }
+    }
+
+    sort($found);
+
+    return $found;
+};
+
+/**
+ * The base resolves the model, so it is the one file that still spells the guard
+ * out — every other form request reaches the rule through it.
+ */
+test('route-model resolution is spelled in exactly one place', function () use ($spellings): void {
+    $patterns = routeModelSpellingPatterns();
+
+    expect($spellings($patterns['hand-written guard']))->toBe(['app/Http/Requests/RouteBoundRequest.php']);
+});
+
+/**
+ * The two shapes that skipped the guard leave nothing behind at all: a form
+ * request never hands the gate an unresolved route parameter.
+ */
+test('no form request hands a route parameter straight to the gate', function () use ($spellings): void {
+    $patterns = routeModelSpellingPatterns();
+
+    expect($spellings($patterns['inline instanceof gate']))->toBe([])
+        ->and($spellings($patterns['unguarded gate']))->toBe([]);
+});
+
+/**
+ * A guard nothing can trip proves nothing, and these are regular expressions
+ * over source: a typo makes one match nothing and the suite stays green. Each
+ * shape #1151 removed is replayed here verbatim.
+ */
+test('each pattern still catches the copy it was written for', function (string $shape, string $source): void {
+    expect(preg_match(routeModelSpellingPatterns()[$shape], $source))->toBe(1);
+})->with([
+    'the five-line accessor' => ['hand-written guard', <<<'PHP'
+        public function channel(): Channel
+        {
+            $channel = $this->route('channel');
+
+            abort_if(! $channel instanceof Channel, 404);
+
+            return $channel;
+        }
+    PHP],
+    'the same guard inline in rules()' => ['hand-written guard', <<<'PHP'
+            $team = $this->route('team');
+            abort_if(! $team instanceof Team, 404);
+    PHP],
+    'the inline instanceof gate' => ['inline instanceof gate', <<<'PHP'
+            return $team instanceof Team && Gate::allows($this->gate(), $team);
+    PHP],
+    'the unguarded gate' => ['unguarded gate', <<<'PHP'
+            return Gate::allows('viewAudit', $this->route('team'));
+    PHP],
+]);
+
+/**
+ * The other half of a trustworthy tripwire: what it must stay quiet about. A
+ * route parameter that is not a bound model, and a gate reached through the
+ * accessor, are both what this change produced — flagging either would make the
+ * guard noise someone silences.
+ */
+test('each pattern leaves the converted shape alone', function (string $source): void {
+    foreach (routeModelSpellingPatterns() as $pattern) {
+        expect(preg_match($pattern, $source))->toBe(0);
+    }
+})->with([
+    // The shape every converted request now takes.
+    'a gate reached through the accessor' => ["return Gate::allows('delete', \$this->team());"],
+    // `Teams\SaveTeamRequest` — asking whether the route is nested at all.
+    'a presence check on the parameter' => ["return \$this->route('team') !== null;"],
+    // `Api/V1\AddReactionRequest` — a scalar route segment, not a bound model.
+    'a scalar route segment' => ["'emoji' => \$this->route('emoji'),"],
+    // Narrowing something that is not a route parameter, which is what
+    // `Api/V1\ApiRequest::subject()` still does with the authenticated user.
+    'a guard over the authenticated user' => [<<<'PHP'
+            $user = $this->user();
+
+            abort_if(! $user instanceof User, 401);
+    PHP],
+]);


### PR DESCRIPTION
Closes #1151. Part of #1142 — the last child, per the epic's declared merge order.

## What

"Resolve the model this route bound, or 404" was a five-line guard copied 53 times across 42 of the 79 files under `app/Http/Requests/`. It now has one home.

- **`app/Http/Requests/RouteBoundRequest.php`** — named `channel()` / `team()` / `message()` for the recurring three (22x, 15x, 6x), each one line over a generic `routeModel($key, Model::class)` that holds the only `abort_if(! $bound instanceof $model, 404)` left. A one-off binding — poll, section, scheduled message, reminder, bot — reaches the same rule in one line rather than earning a method on the base.
- **42 requests converted.** The recurring three inherit outright; the one-offs collapse to a one-liner. ~250 lines of pure duplication gone.

## The type holes

The copy was not uniform, and the same question shipped at three levels of type safety. All three are closed:

- Four requests handed `Gate::allows()` an unnarrowed `mixed` — `Teams/DeleteTeamRequest`, `Teams/ViewAuditLogRequest`, `Teams/ViewAnalyticsRequest` and `Teams/ViewSecurityLogRequest`. The issue named two; the other two are the same hole in files written since.
- `Teams/RequestAuditExportRequest` guarded the same value inline with `instanceof && Gate::allows(...)`.

Each now goes through `$this->team()`, so a route that bound no team 404s rather than reaching a policy with a `mixed`.

## `Api/V1\ApiRequest` extends the base too

The seam already existed for one subtree; leaving it there would have left the rule with two homes rather than one. `ApiRequest` now extends `RouteBoundRequest` and keeps only what the API adds — `subject()`, the token's bot or human.

That surfaced one honest conflict: `Api/V1\StoreChannelRequest::team()` and `Api/V1\StoreWebhookSubscriptionRequest::team()` derive the team from the **token**, not the route. Inheriting a name that means something else is exactly what this epic exists to remove, so both are now `subjectTeam()` (one controller call site updated). No behaviour change.

## Tests

`app/Http/Requests/` had zero dedicated tests across 79 files. It now has two:

- **`tests/Integration/Http/RouteBoundRequestTest.php`** — the base's own. A form request is just a request with a route resolver, so the rule is stated directly: each accessor returns the bound model, a wrong-type binding 404s, an absent binding 404s, for Channel, Team and Message; and the resolver narrows any bound model, not only the named three.
- **`tests/Unit/FormRequestRouteModelHomeTest.php`** — the tripwire, in the shape of `VisibleChannelsAclHomeTest`. Route-model resolution must be spelled in exactly one file, and no form request may hand a route parameter to a gate. Both halves are pinned: each pattern is replayed against the copy it was written for (so a typo cannot make it silently match nothing), and against four legitimate lookalikes it must stay quiet about — a gate reached through the accessor, `$this->route('team') !== null`, a scalar route segment, and `ApiRequest::subject()`'s 401 guard over the authenticated user.

## Notes

- **No behaviour change** beyond the type holes, which only differ where route model binding already failed.
- `Teams/CreateTeamInvitationRequest` gained `declare(strict_types=1)` — Rector's `SafeDeclareStrictTypesRector` asks for it once the guard leaves the file, and the gate fails without it.
- No ADR: mechanical, and `ApiRequest` had already established the pattern in-repo. `CONTEXT.md` gains the seam entry and a "where new work goes" line, per the epic.
- No user-facing copy, so no i18n; nothing operator-facing, so no docs.
- Unblocks #1150.

## Testing

`composer test` green with coverage **Total: 100.0 %**; `npm run lint:check`, `format:check`, `types:check` and `build` all green. Local CodeRabbit pass against `develop`: 0 findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788314579&installation_model_id=428379&pr_number=1163&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1163&signature=91197e55d6dea625705cd13fd53f7dfc4345ec8e30b847464adecef2f42d2b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->