### PR TITLE
test: prove the slash-command manifest on the registry, not through a rendered page

### DIFF
--- a/tests/Feature/Channels/SlashCommandManifestTest.php
+++ b/tests/Feature/Channels/SlashCommandManifestTest.php
@@ -1,43 +1,45 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Models\Channel;
-use App\Models\User;
+use App\SlashCommands\SlashCommandRegistry;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('a channel page ships the slash-command manifest for autocomplete', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+/*
+|--------------------------------------------------------------------------
+| What is left here on purpose (#1117)
+|--------------------------------------------------------------------------
+|
+| The manifest's contents — which commands exist, their copy, their argument
+| hints, their order — are the registry's, and are asserted against it in
+| `tests/Unit/SlashCommands/SlashCommandRegistryTest.php`. Rendering a channel
+| page to read them back was proving the registry through the widest interface
+| in the application.
+|
+| These two are not about the contents. The first is that `share()` hands the
+| client every registered command with its copy resolved under the *request's*
+| locale rather than the process's — middleware behaviour the registry cannot
+| state, since it is handed an already-active translator. The second is the
+| `$shell?->slashCommands() ?? []` fallback off the workspace, which is the
+| Inertia contract for a page with no channel.
+|
+*/
+
+test('a channel page ships every registered command, translated under the request locale', function (): void {
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
+    $owner->update(['locale' => 'fr']);
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->has('slashCommands', 4)
-            ->where('slashCommands.0.name', 'shrug')
-            ->where('slashCommands.0.description', 'Append a shrug to your message')
-            ->where('slashCommands.0.argumentHint', '[message]')
-            ->where('slashCommands.1.name', 'tableflip')
-            ->where('slashCommands.2.name', 'unflip')
-            ->where('slashCommands.3.name', 'poll')
-            ->where('slashCommands.3.description', 'Create a poll in this channel')
-            ->where('slashCommands.3.argumentHint', null)
-        );
-});
-
-test('the manifest copy follows the active locale', function (): void {
-    $owner = User::factory()->create(['locale' => 'fr']);
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-
-    $this->actingAs($owner)
-        ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(fn (Assert $page): Assert => $page
+            // As many as are registered, not a hardcoded four: the count is the
+            // claim that the page ships all of them, and the registry owns which.
+            ->has('slashCommands', count(app(SlashCommandRegistry::class)->manifest()))
             ->where('slashCommands.1.description', 'Retourner la table')
         );
 });
 
 test('the manifest is omitted off the workspace', function (): void {
-    $owner = User::factory()->create();
-    app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner] = teamWithChannel();
 
     $this->actingAs($owner)
         ->get(route('profile.edit'))

--- a/tests/Unit/SlashCommands/SlashCommandRegistryTest.php
+++ b/tests/Unit/SlashCommands/SlashCommandRegistryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Data\SlashCommandData;
 use App\SlashCommands\Commands\ShrugCommand;
 use App\SlashCommands\Commands\TableflipCommand;
 use App\SlashCommands\SlashCommandRegistry;
@@ -39,4 +40,31 @@ test('the manifest is one typed dto per command in registration order', function
         ->and($manifest[0]->description)->toBe('Append a shrug to your message')
         ->and($manifest[0]->argumentHint)->toBe('[message]')
         ->and($manifest[1]->name)->toBe('tableflip');
+});
+
+/**
+ * What the composer's autocomplete actually receives, asserted where it is
+ * decided (#1117). This was four `->where('slashCommands.N.…')` chains hung off
+ * a rendered `channels/Show`, which booted the 44-prop shell and the whole
+ * translation catalog to read a list the registry hands over on its own.
+ *
+ * The set is the always-on trio plus whatever the deployment's toggles admit —
+ * `/gif` is out with no Giphy key and `/poll` is in with polls on, which is the
+ * test environment's configuration. That each toggle governs its own command is
+ * stated by {@see tests/Unit/SlashCommands/GifCommandTest.php} and
+ * {@see tests/Unit/SlashCommands/PollCommandTest.php}; what is stated here is
+ * the resulting manifest, in full, in the order the composer lists it.
+ */
+test('the registered manifest is the v1 command set, in registration order', function (): void {
+    $manifest = array_map(
+        fn (SlashCommandData $command): array => [$command->name, $command->description, $command->argumentHint],
+        app(SlashCommandRegistry::class)->manifest(),
+    );
+
+    expect($manifest)->toBe([
+        ['shrug', 'Append a shrug to your message', '[message]'],
+        ['tableflip', 'Flip the table', '[message]'],
+        ['unflip', 'Put the table back', '[message]'],
+        ['poll', 'Create a poll in this channel', null],
+    ]);
 });


### PR DESCRIPTION
Slice 3 of #1117 — the `slashCommands` prop, the smallest remaining read-model slice and the one the issue's own ordering puts next.

## What moved

`tests/Feature/Channels/SlashCommandManifestTest.php` went from three page renders to two. The manifest's **contents** — which commands exist, their copy, their argument hints, their order — were nine `->where('slashCommands.N.…')` assertions hung off a rendered `channels/Show`, booting the 44-prop shell and the whole translation catalog to read back a list `SlashCommandRegistry::manifest()` hands over on its own.

They are now one assertion in `tests/Unit/SlashCommands/SlashCommandRegistryTest.php`, and **stated in full rather than sampled**: the old test pinned `shrug`'s and `poll`'s copy and only the *names* of `tableflip` and `unflip`. The new one pins the name, description and argument hint of all four, in order.

## What stayed HTTP, and why

Neither retained test is about the contents:

- **the copy follows the request's locale** — middleware behaviour the registry cannot state, since it is handed an already-active translator. Its `->has('slashCommands', …)` count is read off the registry rather than hardcoded, so it claims *all of them* without re-deriving *which*.
- **the manifest is omitted off the workspace** — the `$shell?->slashCommands() ?? []` fallback in `share()`, which is the Inertia contract for a page with no channel.

## Mutation table

The check the issue asks each slice to record. Every mutation goes red, and the two columns barely overlap — which is the point: the retained HTTP tests are not leftovers.

| # | mutation | registry test | HTTP tests |
|---|---|---|---|
| 1 | provider swaps `tableflip`/`unflip` registration order | 🔴 | 🔴 |
| 2 | `TableflipCommand` description drifts to `Flip the desk` | 🔴 | 🔴 |
| 3 | `/poll` stops being registered | 🔴 | 🟢 |
| 4 | `manifest()` returns only the first command | 🔴 | 🔴 |
| 5 | `share()` ships `array_slice(…, 0, 1)` of the manifest | 🟢 | 🔴 |
| 6 | `SetLocale` ignores the user and uses `config('app.locale')` | 🟢 | 🔴 |

3 is caught only by the registry; 5 and 6 only by the HTTP pair.

## One judgement call to check

The acceptance criterion says moved assertions land **in `tests/Integration/`**. This one landed in `tests/Unit/SlashCommands/` instead: the registry is not database-backed, and [ADR-0012](../blob/develop/dev-docs/adr/0012-three-test-suites.md) defines `Integration` as "boots the application **and** the database". `tests/Pest.php` already binds `Unit/SlashCommands` to `TestCase` for precisely this shape — *"the slash-command unit tests exercise command copy through the translator, so they need the application booted (but no database)"* — and the sibling registration claims (`GifCommandTest`, `PollCommandTest`) are already there. Filing it under `Integration` would hand it `RefreshDatabase` for nothing. Say so if you read the criterion more literally than I did.

## Where the sweep stands

| metric | at filing | after slice 2 | now |
| --- | --- | --- | --- |
| `assertInertia` in `tests/Feature` | 258 | 245 | **244** |
| `TeamWithGeneral` refs in `tests/Feature` | 274 | 248 | 248 |
| files declaring a local `*TeamWithGeneral()` | 37 | 22 | 22 |

The clone counts do not move here: this file's three arranges were inline `CreateTeam` calls, not a local `*TeamWithGeneral()` — they are now `teamWithChannel()`.

Next slice: **5** — `userGroups` (5 assertions, one file, same shape as this one).

Refs #1117.

## Gate

`./vendor/bin/sail composer test` — Pint, PHPStan and Rector clean, 3362 tests green, `Total: 100.0 %`. No frontend files touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788345387&installation_model_id=428379&pr_number=1169&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1169&signature=25eaee67aab7e96c0447162d9a0fc16a0c84a4b60bf5e5bcfc2d0094965276e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->