### PR TITLE
test: prove the mentionable group vocabulary on the read-model, not through a page

### DIFF
--- a/tests/Feature/Channels/GroupMentionTest.php
+++ b/tests/Feature/Channels/GroupMentionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
-use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
@@ -10,31 +8,6 @@ use App\Models\UserGroup;
 use App\Support\MessagePlainText;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function groupMentionTeam(): array
-{
-    $owner = User::factory()->create(['name' => 'Owner Person']);
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team as a plain member and return them.
- */
-function groupTeamMember(Team $team, ?string $name = null): User
-{
-    $user = User::factory()->create($name ? ['name' => $name] : []);
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-
-    return $user;
-}
 
 /**
  * Create a group in the team with the given members already attached.
@@ -61,12 +34,12 @@ function groupToken(UserGroup $group): string
 /**
  * Post a message to the channel as the given user and return the stored row.
  */
-function postGroupMessage(User $actor, Team $team, Channel $channel, string $body): Message
+function postGroupMessage(User $actor, Channel $channel, string $body): Message
 {
     $clientUuid = (string) Str::uuid7();
 
     test()->actingAs($actor)
-        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+        ->post(route('channels.messages.store', ['team' => $channel->team->slug, 'channel' => $channel->slug]), [
             'body' => $body,
             'client_uuid' => $clientUuid,
         ])
@@ -76,35 +49,34 @@ function postGroupMessage(User $actor, Team $team, Channel $channel, string $bod
 }
 
 test('a group mention fans out to a mention row for every member', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
-    $grace = groupTeamMember($team, 'Grace Hopper');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $grace = teamMemberInChannel($general, ['name' => 'Grace Hopper']);
     $group = userGroupWith($team, 'dev-team', [$ada, $grace]);
 
-    $message = postGroupMessage($owner, $team, $general, 'heads up '.groupToken($group));
+    $message = postGroupMessage($owner, $general, 'heads up '.groupToken($group));
 
     expect($message->mentionedUsers->pluck('id')->sort()->values()->all())
         ->toBe(collect([$ada->id, $grace->id])->sort()->values()->all());
 });
 
 test('the poster is excluded from a group they mention', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     $group = userGroupWith($team, 'dev-team', [$owner, $ada]);
 
-    $message = postGroupMessage($owner, $team, $general, 'ping '.groupToken($group));
+    $message = postGroupMessage($owner, $general, 'ping '.groupToken($group));
 
     expect($message->mentionedUsers->pluck('id')->all())->toBe([$ada->id]);
 });
 
 test('a member mentioned both individually and via a group gets one row', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     $group = userGroupWith($team, 'dev-team', [$ada]);
 
     $message = postGroupMessage(
         $owner,
-        $team,
         $general,
         "@[{$ada->name}]({$ada->id}) and ".groupToken($group),
     );
@@ -114,37 +86,35 @@ test('a member mentioned both individually and via a group gets one row', functi
 });
 
 test('a group member who has left the team is not notified', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
-    $departed = groupTeamMember($team, 'Departed Person');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $departed = teamMemberInChannel($general, ['name' => 'Departed Person']);
     $group = userGroupWith($team, 'dev-team', [$ada, $departed]);
 
     $team->memberships()->where('user_id', $departed->id)->delete();
 
-    $message = postGroupMessage($owner, $team, $general, 'ping '.groupToken($group));
+    $message = postGroupMessage($owner, $general, 'ping '.groupToken($group));
 
     expect($message->mentionedUsers->pluck('id')->all())->toBe([$ada->id]);
 });
 
 test('an empty group mention notifies nobody', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $group = userGroupWith($team, 'dev-team');
 
-    $message = postGroupMessage($owner, $team, $general, 'anyone? '.groupToken($group));
+    $message = postGroupMessage($owner, $general, 'anyone? '.groupToken($group));
 
     expect($message->mentionedUsers)->toHaveCount(0);
 });
 
 test('an unknown group id and a group from another team are both dropped', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $outsider = User::factory()->create();
-    $otherTeam = app(CreateTeam::class)->handle($outsider, 'Globex');
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+    ['owner' => $outsider, 'team' => $otherTeam] = teamWithChannel('Globex');
     $foreign = userGroupWith($otherTeam, 'dev-team', [$outsider]);
     $bogusId = (string) Str::uuid7();
 
     $message = postGroupMessage(
         $owner,
-        $team,
         $general,
         groupToken($foreign)." and @[ghosts](group:{$bogusId})",
     );
@@ -153,23 +123,23 @@ test('an unknown group id and a group from another team are both dropped', funct
 });
 
 test('a group token inside inline code does not notify', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     $group = userGroupWith($team, 'dev-team', [$ada]);
 
-    $message = postGroupMessage($owner, $team, $general, 'type `'.groupToken($group).'` to ping');
+    $message = postGroupMessage($owner, $general, 'type `'.groupToken($group).'` to ping');
 
     expect($message->mentionedUsers)->toHaveCount(0);
 });
 
 test('editing a message re-expands its group mentions', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
-    $grace = groupTeamMember($team, 'Grace Hopper');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $grace = teamMemberInChannel($general, ['name' => 'Grace Hopper']);
     $devs = userGroupWith($team, 'dev-team', [$ada]);
     $ops = userGroupWith($team, 'ops-team', [$grace]);
 
-    $message = postGroupMessage($owner, $team, $general, 'ping '.groupToken($devs));
+    $message = postGroupMessage($owner, $general, 'ping '.groupToken($devs));
     expect($message->mentionedUsers->pluck('id')->all())->toBe([$ada->id]);
 
     $this->actingAs($owner)
@@ -184,12 +154,12 @@ test('editing a message re-expands its group mentions', function (): void {
 });
 
 test('membership is snapshotted at post time, not resolved on read', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
-    $latecomer = groupTeamMember($team, 'Late Comer');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $latecomer = teamMemberInChannel($general, ['name' => 'Late Comer']);
     $group = userGroupWith($team, 'dev-team', [$ada]);
 
-    $message = postGroupMessage($owner, $team, $general, 'ping '.groupToken($group));
+    $message = postGroupMessage($owner, $general, 'ping '.groupToken($group));
 
     $group->members()->attach($latecomer->id);
 
@@ -197,11 +167,11 @@ test('membership is snapshotted at post time, not resolved on read', function ()
 });
 
 test('a group mention counts toward the sidebar mention badge like a direct one', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     $group = userGroupWith($team, 'dev-team', [$ada]);
 
-    postGroupMessage($owner, $team, $general, 'ping '.groupToken($group));
+    postGroupMessage($owner, $general, 'ping '.groupToken($group));
 
     $response = $this->actingAs($ada)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
@@ -213,11 +183,11 @@ test('a group mention counts toward the sidebar mention badge like a direct one'
 });
 
 test('a group mention makes the thread show up in the mentioned member inbox', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     $group = userGroupWith($team, 'dev-team', [$ada]);
 
-    $root = postGroupMessage($owner, $team, $general, 'thoughts?');
+    $root = postGroupMessage($owner, $general, 'thoughts?');
 
     $this->actingAs($owner)
         ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -240,24 +210,25 @@ test('a group mention makes the thread show up in the mentioned member inbox', f
 });
 
 test('the workspace groups ride along on every in-workspace request', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     userGroupWith($team, 'dev-team', [$ada]);
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertInertia(fn (Assert $page): Assert => $page
             ->has('userGroups', 1)
-            ->where('userGroups.0.slug', 'dev-team')
-            ->where('userGroups.0.membersCount', 1)
-            // The roster stays off the shared payload: resolving a pill and
-            // listing the menu only need the handle and the count.
+            // The shared payload is the *mentionable* read-model, not the full
+            // one the management page is handed: the roster stays off it,
+            // because resolving a pill and listing the menu only need the
+            // handle and the count. What each entry carries is stated on
+            // `UserGroupData` in tests/Integration/Data/UserGroupDataTest.php.
             ->where('userGroups.0.members', [])
         );
 });
 
 test('the shared groups payload is empty off the workspace', function (): void {
-    [$owner, $team] = groupMentionTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     userGroupWith($team, 'dev-team');
 
     $this->actingAs($owner)
@@ -266,11 +237,11 @@ test('the shared groups payload is empty off the workspace', function (): void {
 });
 
 test('a group mention is unwrapped to its handle for search indexing', function (): void {
-    [$owner, $team, $general] = groupMentionTeam();
-    $ada = groupTeamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     $group = userGroupWith($team, 'dev-team', [$ada]);
 
-    $message = postGroupMessage($owner, $team, $general, 'ship it '.groupToken($group));
+    $message = postGroupMessage($owner, $general, 'ship it '.groupToken($group));
 
     expect(MessagePlainText::from($message->body))->toBe('ship it @dev-team');
 });

--- a/tests/Integration/Data/UserGroupDataTest.php
+++ b/tests/Integration/Data/UserGroupDataTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Data\UserGroupData;
+use App\Models\UserGroup;
+
+/*
+|--------------------------------------------------------------------------
+| The mentionable group vocabulary (#1117)
+|--------------------------------------------------------------------------
+|
+| What the composer's `@` menu offers and what a `group:` token in a message
+| body resolves against. `UserGroupData::mentionableForTeam()` is a static call
+| over a team, so which groups it lists, in what order, and how much of each one
+| it carries can all be stated here rather than read back out of a rendered
+| `channels/Show` — `tests/Feature/Channels/GroupMentionTest.php` keeps the HTTP
+| half, that the workspace ships `userGroups` at all and that it is the
+| roster-less variant it ships.
+|
+| The groups are built from the factory inline rather than through a local
+| helper: a second global `userGroupWith()` would collide with the one that file
+| already declares, and there is nothing to arrange here but the group itself.
+|
+*/
+
+test('a group is listed by its identity and its size', function (): void {
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $group = UserGroup::factory()->for($team)->slug('dev-team')->create();
+    $group->members()->sync([$ada->id]);
+
+    $listed = UserGroupData::mentionableForTeam($team);
+
+    expect($listed)->toHaveCount(1)
+        ->and($listed[0]->id)->toBe($group->id)
+        ->and($listed[0]->name)->toBe($group->name)
+        ->and($listed[0]->slug)->toBe('dev-team')
+        ->and($listed[0]->membersCount)->toBe(1);
+});
+
+test('the roster stays off the mentionable list however many members a group has', function (): void {
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $grace = teamMemberInChannel($general, ['name' => 'Grace Hopper']);
+    UserGroup::factory()->for($team)->slug('dev-team')->create()
+        ->members()->sync([$ada->id, $grace->id]);
+
+    $listed = UserGroupData::mentionableForTeam($team);
+
+    // Resolving a pill and listing the menu only ever need the handle and the
+    // count, so the members themselves are withheld rather than shipped to
+    // every reader of every message.
+    expect($listed[0]->membersCount)->toBe(2)
+        ->and($listed[0]->members)->toBe([]);
+});
+
+test('an empty group is still mentionable', function (): void {
+    ['team' => $team] = teamWithChannel();
+    UserGroup::factory()->for($team)->slug('dev-team')->create();
+
+    $listed = UserGroupData::mentionableForTeam($team);
+
+    expect($listed)->toHaveCount(1)
+        ->and($listed[0]->membersCount)->toBe(0)
+        ->and($listed[0]->members)->toBe([]);
+});
+
+test('the list is ordered by handle, not by creation', function (): void {
+    ['team' => $team] = teamWithChannel();
+
+    foreach (['ops-team', 'dev-team', 'analytics'] as $slug) {
+        UserGroup::factory()->for($team)->slug($slug)->create();
+    }
+
+    expect(array_column(UserGroupData::mentionableForTeam($team), 'slug'))
+        ->toBe(['analytics', 'dev-team', 'ops-team']);
+});
+
+test('a group belonging to another workspace is not mentionable in this one', function (): void {
+    ['team' => $team] = teamWithChannel();
+    ['team' => $otherTeam] = teamWithChannel('Globex');
+    $ours = UserGroup::factory()->for($team)->slug('dev-team')->create();
+    UserGroup::factory()->for($otherTeam)->slug('dev-team')->create();
+
+    expect(array_column(UserGroupData::mentionableForTeam($team), 'id'))->toBe([$ours->id]);
+});


### PR DESCRIPTION
Slice 5 of #1117 — the `userGroups` prop, which the issue's own ordering puts next after slice 3.

## What moved

`tests/Feature/Channels/GroupMentionTest.php` asserted the mentionable group list by rendering `channels/Show`, booting the 44-prop shell and the whole translation catalog, and plucking one prop back out of it. `UserGroupData::mentionableForTeam()` is a static call over a team and hands the same list over on its own.

The four content assertions now live in `tests/Integration/Data/UserGroupDataTest.php`, and **two claims that were asserted nowhere at all are now stated**:

| claim | before | after |
|---|---|---|
| identity and size of a listed group | `->where('userGroups.0.slug', …)`, `->where('userGroups.0.membersCount', 1)` | `id`, `name`, `slug` and `membersCount` on the read-model |
| the roster is withheld | `->where('userGroups.0.members', [])`, one member | stated against a **two**-member group, so an empty roster cannot pass by accident |
| an empty group is still mentionable | — | new |
| the list is ordered by handle, not by creation | — | new |
| another workspace's groups are not listed | — | new |

## What stayed HTTP, and one deviation

Two tests stay, neither about the contents: that the workspace ships `userGroups` at all, and that a page outside the workspace ships none (the `$shell?->userGroups() ?? []` fallback).

The issue's sizing comment predicted **all four** content assertions would move, leaving only the `->where('userGroups', [])` fallback. I kept one more: `->where('userGroups.0.members', [])` on the retained render. It is not a content claim — it is the claim that `share()` wires the **mentionable** read-model rather than the full `forTeam()` one the management page is handed, and mutation 5 below shows the read-model test cannot catch that. Say so if you read the sizing more literally than I did.

## Mutation table

The check the issue asks each slice to record. Every mutation goes red, and the two columns barely overlap — the retained HTTP pair is not a leftover.

| # | mutation | read-model test | HTTP tests |
|---|---|---|---|
| 1 | `mentionableForTeam()` drops `orderBy('slug')` | 🔴 | 🟢 |
| 2 | `mentionableForTeam()` delegates to `forTeam()` (roster rides along) | 🔴 | 🔴 |
| 3 | `mentionableForTeam()` drops `withCount('members')` | 🔴 | 🟢 |
| 4 | `mentionableForTeam()` loses its team scoping | 🔴 | 🟢 |
| 5 | `WorkspaceShell::userGroups()` wires `forTeam()` instead | 🟢 | 🔴 |
| 6 | `share()` stops naming the prop | 🟢 | 🔴 |

1, 3 and 4 are caught only by the read-model; 5 and 6 only by the HTTP pair.

## The arrange (criterion 1)

`groupMentionTeam()` and `groupTeamMember()` are gone — both were clones of #1111's `teamWithChannel()` and `teamMemberInChannel()`. The substitution also joins each member to `#general` rather than the team alone, which is a strict superset: `SyncMentions::expandGroups()` filters on team membership, never channel membership.

`postGroupMessage()` drops the `Team` it was handed alongside the channel, for the reason `teamMemberInChannel()` gives for the same shape — the two can only ever be the one pair, and a signature accepting both can be handed a mismatched one.

`userGroupWith()` stays where it is; the read-model test builds its groups from the factory inline rather than declaring a second global that would collide with it.

## Where the sweep stands

| metric | at filing | after slice 3 | now |
| --- | --- | --- | --- |
| `assertInertia` in `tests/Feature` | 258 | 244 | 244 |
| `TeamWithGeneral` refs in `tests/Feature` | 274 | 248 | 248 |
| files declaring a local `*TeamWithGeneral()` | 37 | 22 | 22 |

None of the three move here, and that is worth being explicit about: this file's clones were named `groupMentionTeam`/`groupTeamMember`, so they never counted in the `TeamWithGeneral` grep, and its three `assertInertia` renders are all still needed — the threads-inbox one, and the two retained `userGroups` ones. What this slice buys is the four assertions that no longer boot the prop bag, and five stronger claims where there were four weaker ones.

Next slice: **4** — `teamMembers` (7 assertions, 3 files), worth pairing with moving `tests/Feature/Support/WorkspaceShellTest.php` to `tests/Integration/Support/`.

Refs #1117.

## Gate

`./vendor/bin/sail composer test` — Pint, PHPStan and Rector clean, 3367 tests green, `Total: 100.0 %`. No frontend files touched, so the JS gate is unaffected.

The local CodeRabbit pass could not run: the free tier was rate-limited on both attempts (13 then 25 minutes). Leaning on the app's review here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788348719&installation_model_id=428379&pr_number=1170&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1170&signature=4e27fe971b1d982248737bbf2f994f00cf37c7cf48eb10548e343376daec06f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->