### PR TITLE
test: prove the team roster on the shell, not through a rendered page

### DIFF
--- a/tests/Feature/Bots/BotVisibilityTest.php
+++ b/tests/Feature/Bots/BotVisibilityTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Actions\Teams\CreateTeam;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
@@ -16,12 +15,11 @@ use Inertia\Testing\AssertableInertia as Assert;
  */
 function botInGeneral(): array
 {
-    $owner = User::factory()->create(['name' => 'Zoe Owner']);
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $owner->update(['name' => 'Zoe Owner']);
 
-    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
-    $general->channelMembers()->create(['user_id' => $bot->id]);
+    $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
+    channelMembership($general, $bot);
 
     return [$owner, $team, $bot];
 }
@@ -51,16 +49,8 @@ test('a bot is excluded from the channel join member count', function (): void {
         ->assertInertia(fn (Assert $page): Assert => $page->where('memberCount', 1));
 });
 
-test('a bot is excluded from the team roster shared to the sidebar and DM picker', function (): void {
-    [$owner, $team, $bot] = botInGeneral();
-
-    $this->actingAs($owner)
-        ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(fn (Assert $page): Assert => $page
-            ->where('teamMembers', fn (Collection $members): bool => $members
-                ->doesntContain(fn (array $member): bool => $member['id'] === $bot->id))
-        );
-});
+// A bot's exclusion from the roster shared to the sidebar and DM picker is
+// stated on that roster itself, in tests/Integration/Support/WorkspaceShellTest.php.
 
 test('a bot is excluded from the team settings member list and seat count', function (): void {
     [$owner, $team, $bot] = botInGeneral();

--- a/tests/Feature/Channels/TeamMembersPropTest.php
+++ b/tests/Feature/Channels/TeamMembersPropTest.php
@@ -1,31 +1,25 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
-use App\Enums\TeamRole;
-use App\Models\Channel;
-use App\Models\User;
+use App\Support\WorkspaceShell;
 use Inertia\Testing\AssertableInertia as Assert;
 
 test('the workspace ships the team members for the DM entry points', function (): void {
-    $owner = User::factory()->create(['name' => 'Zoe Owner']);
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $member = User::factory()->create(['name' => 'Amy Member']);
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    teamMemberInChannel($general, ['name' => 'Amy Member']);
 
     $this->actingAs($owner)
-        ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->has('teamMembers', 2)
-            // Ordered by name: Amy before Zoe.
-            ->where('teamMembers.0.name', 'Amy Member')
-            ->where('teamMembers.0.id', $member->id)
-            ->where('teamMembers.1.name', 'Zoe Owner')
+            // Who the roster holds and in what order is the shell's claim
+            // (tests/Integration/Support/WorkspaceShellTest.php). What the render
+            // owes is shipping all of them, so the count is taken off the shell
+            // rather than re-derived here.
+            ->has('teamMembers', count(new WorkspaceShell($owner, $team)->teamMembers()))
         );
 });
 
 test('the team members prop is absent off the channel workspace', function (): void {
-    $owner = User::factory()->create();
-    app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner] = teamWithChannel();
 
     $this->actingAs($owner)
         ->get(route('profile.edit'))

--- a/tests/Integration/Support/WorkspaceShellTest.php
+++ b/tests/Integration/Support/WorkspaceShellTest.php
@@ -1,32 +1,32 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Data\MessageSearchCriteria;
 use App\Enums\ChannelVisibility;
 use App\Enums\MessageReminderStatus;
 use App\Enums\NavDestination;
 use App\Enums\SearchScope;
 use App\Enums\ThreadInboxFilter;
-use App\Models\Channel;
-use App\Models\Team;
 use App\Models\User;
 use App\Support\WorkspaceShell;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 
-/**
- * A viewer, their team, and its #general channel.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function shellWorkspace(): array
-{
-    $viewer = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($viewer, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
-
-    return [$viewer, $team, $general];
-}
+/*
+|--------------------------------------------------------------------------
+| The workspace shell (#1117)
+|--------------------------------------------------------------------------
+|
+| The shell takes a viewer and a team, so every read-model it exposes is
+| reachable without an HTTP round-trip — which is the whole reason it was
+| lifted out of the middleware. This file was in `tests/Feature` and named no
+| route in it; ADR-0012 puts it here.
+|
+| `teamMembers()` is stated here in full (who is listed, in what order, and
+| who is withheld). `tests/Feature/Channels/TeamMembersPropTest.php` keeps the
+| HTTP half: that a workspace render ships the prop, and that a page outside
+| the workspace ships none.
+|
+*/
 
 /**
  * A request standing on a named route, with the given bound parameters and
@@ -54,7 +54,7 @@ function shellRequest(string $routeName, array $parameters = [], ?User $user = n
 }
 
 test('a signed-in viewer on a workspace route with a bound team gets a shell', function (): void {
-    [$viewer, $team, $general] = shellWorkspace();
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $shell = WorkspaceShell::forRequest(shellRequest('channels.show', ['team' => $team], $viewer));
 
@@ -63,7 +63,7 @@ test('a signed-in viewer on a workspace route with a bound team gets a shell', f
 });
 
 test('the precondition withholds a shell for a guest, off a workspace route, or with no bound team', function (): void {
-    [$viewer, $team] = shellWorkspace();
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
 
     expect(WorkspaceShell::forRequest(shellRequest('channels.show', ['team' => $team])))->toBeNull()
         ->and(WorkspaceShell::forRequest(shellRequest('settings.profile', ['team' => $team], $viewer)))->toBeNull()
@@ -73,7 +73,7 @@ test('the precondition withholds a shell for a guest, off a workspace route, or 
 });
 
 test('the shell is constructible from a viewer and a team alone', function (): void {
-    [$viewer, $team, $general] = shellWorkspace();
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $shell = new WorkspaceShell($viewer, $team);
 
@@ -88,8 +88,34 @@ test('the shell is constructible from a viewer and a team alone', function (): v
         ->and($shell->creatableChannelVisibilities())->toContain(ChannelVisibility::Public->value);
 });
 
+test('the team roster is ordered by name and lists the viewer among the others', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $viewer->update(['name' => 'Marie Curie']);
+    teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    teamMemberInChannel($general, ['name' => 'Zoe Zulu']);
+
+    // The viewer is not held back: the people picker offers a self-DM, which
+    // renders as "You" rather than as their name.
+    expect(array_column(new WorkspaceShell($viewer, $team)->teamMembers(), 'name'))
+        ->toBe(['Ada Lovelace', 'Marie Curie', 'Zoe Zulu']);
+});
+
+test('the team roster withholds a bot and another workspace entirely', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    // A bot posts in #general and is on the channel's roster, but it is not
+    // someone you can open a DM with, so it is no part of this list.
+    $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
+    channelMembership($general, $bot);
+
+    // Nor is anyone from a workspace the viewer happens not to be looking at.
+    teamWithChannel('Other');
+
+    expect(array_column(new WorkspaceShell($viewer, $team)->teamMembers(), 'id'))->toBe([$viewer->id]);
+});
+
 test('a panel contributes its props only while its destination is the pinned one', function (): void {
-    [$viewer, $team] = shellWorkspace();
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
 
     $shell = new WorkspaceShell($viewer, $team);
     $criteria = new MessageSearchCriteria(query: 'hello', scope: SearchScope::default());


### PR DESCRIPTION
Slice 4 of #1117 — the `teamMembers` prop. Follows #1123 (`channels`), #1166 (`reminders`), #1169 (`slashCommands`) and #1170 (`userGroups`). The child stays open; the remaining slices are sized in the issue.

## What moves

`tests/Feature/Support/WorkspaceShellTest.php` moves to `tests/Integration/Support/WorkspaceShellTest.php`. It named no route and built its own `Request` by hand to construct the shell, which is exactly the shape ADR-0012 puts in `Integration`. Its local `shellWorkspace()` clone goes through `tests/Helpers.php`; `shellRequest()` stays, since standing a request on a named route without an HTTP round-trip is this file's own business.

The `teamMembers` content claims move onto `WorkspaceShell::teamMembers()` and come out stronger:

- **Ordering** was `->where('teamMembers.0.name', 'Amy Member')` / `'teamMembers.1.name' => 'Zoe Owner'` — two rows with the viewer last. It is now stated over three names that bracket the viewer, so "ordered by name" and "the viewer is listed among the others rather than pinned anywhere" are one claim.
- **Bot exclusion** was proven by rendering `channels/Show` in `Bots/BotVisibilityTest.php` and plucking `teamMembers` out of the 44-prop bag. It now sits on the roster itself, next to a **team-scoping** claim that was asserted nowhere: another workspace's members are not offered as DM partners either.

Two HTTP tests stay, neither about the contents: that a workspace render ships the prop, and that a page outside the workspace ships none. As in #1169, the retained render's `->has('teamMembers', N)` takes N off the shell instead of hardcoding 2 — it claims *all of them* without re-deriving *which*.

`Channels/MessageSearchTest.php:143`'s `->has('teamMembers', 2)` is deliberately untouched: that one claims the search destination carries the shared sidebar props, which is the HTTP contract, not the roster's contents.

`botInGeneral()` in `Bots/BotVisibilityTest.php` is rebuilt on `teamWithChannel()` + `channelMembership()`, so every assertion in that file is byte-identical apart from the deleted test.

## Mutation check

| mutation | `WorkspaceShellTest` | the HTTP pair |
| --- | --- | --- |
| drop `orderBy('name')` | **red** | green |
| withhold the viewer from their own roster | **red** (3 tests) | green |
| ignore the team scoping (every user, bots included) | **red** | green |
| `share()` stops shipping the prop | green | **red** |
| `share()` ships a truncated roster | green | **red** |

The two halves do not overlap at all, which is the point: what the roster holds is the read-model's claim, and that the page ships every row of it is the render's.

## CodeRabbit

One minor finding, **declined**: it asks the retained HTTP test to restore the identity-and-order assertions rather than compare a count. That is the duplication this child exists to remove — those claims now live on the read-model, and the table above shows the split loses nothing.

## Testing

`./vendor/bin/sail composer test` — `Total: 100.0 %`, 3368 passing. Frontend lint/format/types green; no frontend files changed. No user-facing copy, so no i18n keys; no operator-facing change, so no docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788351703&installation_model_id=428379&pr_number=1178&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1178&signature=68d9a3d2000d94e6f71753ef4c52ddadf27e07d84ee67792a159ded736b0a27d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->