### PR TITLE
test: replace eleven local team arranges with the shared one

### DIFF
--- a/tests/Feature/Channels/DispatchScheduledMessageTest.php
+++ b/tests/Feature/Channels/DispatchScheduledMessageTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Actions\Channels\DispatchDueScheduledMessages;
-use App\Actions\Teams\CreateTeam;
 use App\Data\MessageData;
 use App\Enums\ScheduledMessageStatus;
 use App\Enums\TeamRole;
@@ -9,23 +8,8 @@ use App\Events\MessageSent;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\ScheduledMessage;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function dispatchTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
 
 /** Run the per-minute dispatch scan. */
 function dispatchDue(): void
@@ -36,7 +20,7 @@ function dispatchDue(): void
 test('a due scheduled message is delivered through the normal send path and broadcasts', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
         'body' => 'from the past',
         'send_at' => now()->subMinute(),
@@ -59,7 +43,7 @@ test('a due scheduled message is delivered through the normal send path and broa
 test('a scheduled message not yet due is left pending', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
         'send_at' => now()->addHour(),
     ]);
@@ -74,7 +58,7 @@ test('a scheduled message not yet due is left pending', function (): void {
 test('a cancelled scheduled message is never delivered', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     ScheduledMessage::factory()->for($general)->for($owner)->cancelled()->create([
         'send_at' => now()->subMinute(),
     ]);
@@ -88,7 +72,7 @@ test('a cancelled scheduled message is never delivered', function (): void {
 test('a due message is delivered at most once across overlapping runs', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     ScheduledMessage::factory()->for($general)->for($owner)->create([
         'send_at' => now()->subMinute(),
     ]);
@@ -101,7 +85,7 @@ test('a due message is delivered at most once across overlapping runs', function
 });
 
 test('a due message preserves the inline reply quote when its target is still live', function (): void {
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create([
         'send_at' => now()->subMinute(),
@@ -116,7 +100,7 @@ test('a due message preserves the inline reply quote when its target is still li
 });
 
 test('a due message drops a since-deleted reply target but still sends', function (): void {
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create([
         'body' => 'still worth sending',
@@ -136,7 +120,7 @@ test('a due message drops a since-deleted reply target but still sends', functio
 test('a due message for an archived channel fails instead of delivering', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create();
     $channel->channelMembers()->create(['user_id' => $owner->id]);
     $scheduled = ScheduledMessage::factory()->for($channel)->for($owner)->create([
@@ -156,7 +140,7 @@ test('a due message for an archived channel fails instead of delivering', functi
 test('a due message fails when its author is no longer a channel member', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $author = User::factory()->create();
     $team->memberships()->create(['user_id' => $author->id, 'role' => TeamRole::Member]);
     $general->channelMembers()->firstOrCreate(['user_id' => $author->id]);
@@ -173,7 +157,7 @@ test('a due message fails when its author is no longer a channel member', functi
 });
 
 test('delivering a scheduled message leaves the author current draft untouched', function (): void {
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $owner->channels()->updateExistingPivot($general->id, ['draft' => 'a fresh draft']);
     ScheduledMessage::factory()->for($general)->for($owner)->create([
         'send_at' => now()->subMinute(),
@@ -186,7 +170,7 @@ test('delivering a scheduled message leaves the author current draft untouched',
 });
 
 test('the send time is honored as a UTC instant regardless of when the scan runs', function (): void {
-    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $sendAt = now()->addMinutes(30);
     ScheduledMessage::factory()->for($general)->for($owner)->create(['send_at' => $sendAt]);
 

--- a/tests/Feature/Channels/EditDeleteMessageTest.php
+++ b/tests/Feature/Channels/EditDeleteMessageTest.php
@@ -1,29 +1,12 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
-use App\Models\Channel;
 use App\Models\Message;
-use App\Models\Team;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function editTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
 test('the author can edit their own message and edited_at is set', function (): void {
-    [$owner, $team, $general] = editTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
 
     $this->actingAs($owner)
@@ -41,7 +24,7 @@ test('the author can edit their own message and edited_at is set', function (): 
 });
 
 test('the message body is trimmed and required on edit', function (): void {
-    [$owner, $team, $general] = editTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
 
     $this->actingAs($owner)
@@ -56,7 +39,7 @@ test('the message body is trimmed and required on edit', function (): void {
 });
 
 test('a user cannot edit another members message', function (): void {
-    [$owner, $team, $general] = editTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
 
@@ -74,7 +57,7 @@ test('a user cannot edit another members message', function (): void {
 });
 
 test('the author can delete their own message', function (): void {
-    [$owner, $team, $general] = editTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     $this->actingAs($owner)
@@ -89,7 +72,7 @@ test('the author can delete their own message', function (): void {
 });
 
 test('a team admin can delete another members message', function (): void {
-    [$owner, $team, $general] = editTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $admin = User::factory()->create();
     $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
 
@@ -107,7 +90,7 @@ test('a team admin can delete another members message', function (): void {
 });
 
 test('a plain member cannot delete another members message', function (): void {
-    [$owner, $team, $general] = editTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $member = User::factory()->create();
     $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
 
@@ -125,7 +108,7 @@ test('a plain member cannot delete another members message', function (): void {
 });
 
 test('the channel page includes deleted messages as tombstones with a blanked body', function (): void {
-    [$owner, $team, $general] = editTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     Message::factory()->for($general)->for($owner)->create(['body' => 'kept']);
     $deleted = Message::factory()->for($general)->for($owner)->create(['body' => 'secret']);
     $deleted->delete();

--- a/tests/Feature/Channels/InlineReplyTest.php
+++ b/tests/Feature/Channels/InlineReplyTest.php
@@ -1,31 +1,14 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Events\MessageSent;
 use App\Models\Channel;
 use App\Models\Message;
-use App\Models\Team;
-use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function replyTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
 test('a message can reply to another message in the same channel', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'parent']);
     $clientUuid = (string) Str::uuid7();
 
@@ -45,7 +28,7 @@ test('a message can reply to another message in the same channel', function (): 
 });
 
 test('a message can reply to a poll inline', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $poll = Message::factory()->poll()->for($general)->for($owner)->create();
     $clientUuid = (string) Str::uuid7();
 
@@ -65,7 +48,7 @@ test('a message can reply to a poll inline', function (): void {
 });
 
 test('a message without a reply target persists a null reply reference', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $clientUuid = (string) Str::uuid7();
 
     $this->actingAs($owner)
@@ -81,7 +64,7 @@ test('a message without a reply target persists a null reply reference', functio
 });
 
 test('the reply target must belong to the same channel', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
     $foreign = Message::factory()->for($other)->for($owner)->create();
@@ -98,7 +81,7 @@ test('the reply target must belong to the same channel', function (): void {
 });
 
 test('a reply cannot target a deleted message', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $parent->delete();
 
@@ -112,7 +95,7 @@ test('a reply cannot target a deleted message', function (): void {
 });
 
 test('a non-uuid reply target is rejected', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -124,7 +107,7 @@ test('a non-uuid reply target is rejected', function (): void {
 });
 
 test('the channel page renders a reply as a compact quote of its parent', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'the original']);
     Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'the answer']);
 
@@ -142,7 +125,7 @@ test('the channel page renders a reply as a compact quote of its parent', functi
 });
 
 test('a reply to a deleted parent renders a deleted quote stub with a blanked body', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'secret original']);
     Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'still here']);
     $parent->delete();
@@ -158,7 +141,7 @@ test('a reply to a deleted parent renders a deleted quote stub with a blanked bo
 });
 
 test('a deleted reply carries no quote of its own', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
     $reply = Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'answer']);
     $reply->delete();
@@ -174,7 +157,7 @@ test('a deleted reply carries no quote of its own', function (): void {
 test('posting a reply broadcasts the parent quote in the MessageSent payload', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'parent body']);
     $clientUuid = (string) Str::uuid7();
 
@@ -196,7 +179,7 @@ test('posting a reply broadcasts the parent quote in the MessageSent payload', f
 });
 
 test('the reply reference survives an idempotent resend', function (): void {
-    [$owner, $team, $general] = replyTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $clientUuid = (string) Str::uuid7();
 

--- a/tests/Feature/Channels/MessageBroadcastTest.php
+++ b/tests/Feature/Channels/MessageBroadcastTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Data\MessageData;
 use App\Enums\TeamRole;
 use App\Events\MessageDeleted;
@@ -12,20 +11,6 @@ use App\Models\User;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function broadcastTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
 
 /**
  * Exercise channel authorization against a real broadcaster.
@@ -45,7 +30,7 @@ function useRealBroadcaster(): void
 test('posting a message broadcasts MessageSent on the channel private channel with the MessageData payload', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = broadcastTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $clientUuid = (string) Str::uuid7();
 
     $this->actingAs($owner)->post(route('channels.messages.store', [
@@ -71,7 +56,7 @@ test('posting a message broadcasts MessageSent on the channel private channel wi
 test('a resent message with the same client uuid broadcasts only once', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = broadcastTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $clientUuid = (string) Str::uuid7();
 
     $payload = [
@@ -95,7 +80,7 @@ test('a resent message with the same client uuid broadcasts only once', function
 test('editing a message broadcasts MessageUpdated on the channel private channel with the MessageData payload', function (): void {
     Event::fake([MessageUpdated::class]);
 
-    [$owner, $team, $general] = broadcastTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
 
     $this->actingAs($owner)->patch(route('channels.messages.update', [
@@ -119,7 +104,7 @@ test('editing a message broadcasts MessageUpdated on the channel private channel
 test('deleting a message broadcasts MessageDeleted as a tombstone with a blanked body', function (): void {
     Event::fake([MessageDeleted::class]);
 
-    [$owner, $team, $general] = broadcastTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'secret']);
 
     $this->actingAs($owner)->delete(route('channels.messages.destroy', [
@@ -142,7 +127,7 @@ test('deleting a message broadcasts MessageDeleted as a tombstone with a blanked
 test('a channel member is authorized to subscribe to the channel', function (): void {
     useRealBroadcaster();
 
-    [$owner, $team, $general] = broadcastTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post('/broadcasting/auth', [
@@ -155,7 +140,7 @@ test('a channel member is authorized to subscribe to the channel', function (): 
 test('a non-member cannot subscribe to the channel', function (): void {
     useRealBroadcaster();
 
-    [$owner, $team] = broadcastTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $stranger = User::factory()->create();
     $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);

--- a/tests/Feature/Channels/MessagePinTest.php
+++ b/tests/Feature/Channels/MessagePinTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Data\MessageData;
 use App\Enums\MessageType;
 use App\Enums\TeamRole;
@@ -13,20 +12,6 @@ use App\Models\User;
 use App\Support\AccountDeleter;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Support\Facades\Event;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function pinTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
 
 /**
  * POST the pin endpoint for the given actor.
@@ -53,7 +38,7 @@ function unpinMessage($actor, $team, $channel, $message)
 }
 
 test('pinning a message adds a pin row attributed to the pinner', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     pinMessage($owner, $team, $general, $message)->assertRedirect();
@@ -66,7 +51,7 @@ test('pinning a message adds a pin row attributed to the pinner', function (): v
 });
 
 test('pinning again is an idempotent no-op that leaves one pin row', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     pinMessage($owner, $team, $general, $message)->assertRedirect();
@@ -76,7 +61,7 @@ test('pinning again is an idempotent no-op that leaves one pin row', function ()
 });
 
 test('unpinning removes the pin, and unpinning again is a no-op', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessagePin::factory()->for($message)->for($general)->for($owner, 'pinnedBy')->create();
 
@@ -89,7 +74,7 @@ test('unpinning removes the pin, and unpinning again is a no-op', function (): v
 });
 
 test('any member can unpin a message another member pinned', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $alice = User::factory()->create();
     $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);
 
@@ -103,7 +88,7 @@ test('any member can unpin a message another member pinned', function (): void {
 });
 
 test('a non-member of a private channel cannot pin', function (): void {
-    [$owner, $team] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $stranger = User::factory()->create();
     $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
@@ -118,7 +103,7 @@ test('a non-member of a private channel cannot pin', function (): void {
 });
 
 test('messages cannot be pinned or unpinned in an archived channel', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['archived_at' => now()]);
     $channel->channelMembers()->create(['user_id' => $owner->id]);
     $message = Message::factory()->for($channel)->for($owner)->create();
@@ -132,7 +117,7 @@ test('messages cannot be pinned or unpinned in an archived channel', function ()
 });
 
 test('a system notice cannot be pinned', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create(['type' => MessageType::MemberJoined]);
 
     pinMessage($owner, $team, $general, $message)->assertForbidden();
@@ -141,7 +126,7 @@ test('a system notice cannot be pinned', function (): void {
 });
 
 test('thread replies and direct messages can be pinned', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
     $reply = Message::factory()->for($general)->for($owner)->create(['thread_root_id' => $root->id]);
 
@@ -160,7 +145,7 @@ test('thread replies and direct messages can be pinned', function (): void {
 });
 
 test('pinning is rejected once the channel is at its pin cap', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     // Fill the channel to the cap.
     $filler = Message::factory()->count(PinMessageRequest::MAX_PINS)->for($general)->for($owner)->create();
@@ -178,7 +163,7 @@ test('pinning is rejected once the channel is at its pin cap', function (): void
 });
 
 test('re-pinning an already-pinned message at the cap is still an idempotent no-op', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $messages = Message::factory()->count(PinMessageRequest::MAX_PINS)->for($general)->for($owner)->create();
     foreach ($messages as $message) {
@@ -192,7 +177,7 @@ test('re-pinning an already-pinned message at the cap is still an idempotent no-
 });
 
 test('MessageData carries the pin, and a tombstone carries none', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessagePin::factory()->for($message)->for($general)->for($owner, 'pinnedBy')->create();
 
@@ -213,7 +198,7 @@ test('MessageData carries the pin, and a tombstone carries none', function (): v
 test('pinning broadcasts MessagePinned on the channel with the pinner and count', function (): void {
     Event::fake([MessagePinned::class]);
 
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     pinMessage($owner, $team, $general, $message);
@@ -240,7 +225,7 @@ test('pinning broadcasts MessagePinned on the channel with the pinner and count'
 test('unpinning broadcasts MessagePinned with pinned false and no pinner', function (): void {
     Event::fake([MessagePinned::class]);
 
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessagePin::factory()->for($message)->for($general)->for($owner, 'pinnedBy')->create();
 
@@ -264,7 +249,7 @@ test('unpinning broadcasts MessagePinned with pinned false and no pinner', funct
 test('soft-deleting a pinned message removes the pin and broadcasts an unpin', function (): void {
     Event::fake([MessagePinned::class]);
 
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessagePin::factory()->for($message)->for($general)->for($owner, 'pinnedBy')->create();
 
@@ -280,7 +265,7 @@ test('soft-deleting a pinned message removes the pin and broadcasts an unpin', f
 });
 
 test('the channel page carries the pin count and pins most-recently-pinned first', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $older = Message::factory()->for($general)->for($owner)->create();
     $newer = Message::factory()->for($general)->for($owner)->create();
 
@@ -298,7 +283,7 @@ test('the channel page carries the pin count and pins most-recently-pinned first
 });
 
 test('deleting a user reassigns the pins they created to the tombstone', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $alice = User::factory()->create();
     $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);
 
@@ -314,7 +299,7 @@ test('deleting a user reassigns the pins they created to the tombstone', functio
 });
 
 test('force-deleting a message cascades its pin away', function (): void {
-    [$owner, $team, $general] = pinTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessagePin::factory()->for($message)->for($general)->for($owner, 'pinnedBy')->create();
 

--- a/tests/Feature/Channels/MessageReactionTest.php
+++ b/tests/Feature/Channels/MessageReactionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Data\MessageData;
 use App\Enums\TeamRole;
 use App\Events\MessageReactionChanged;
@@ -11,20 +10,6 @@ use App\Models\User;
 use App\Support\AccountDeleter;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Support\Facades\Event;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function reactionTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
 
 /**
  * POST the toggle-reaction endpoint for the given actor.
@@ -39,7 +24,7 @@ function toggleReaction($actor, $team, $channel, $message, string $emoji)
 }
 
 test('reacting adds the reaction, and reacting again with the same emoji removes it', function (): void {
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     toggleReaction($owner, $team, $general, $message, '👍')->assertRedirect();
@@ -52,7 +37,7 @@ test('reacting adds the reaction, and reacting again with the same emoji removes
 });
 
 test('a user holds at most one row per distinct emoji and can react with several emoji', function (): void {
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     toggleReaction($owner, $team, $general, $message, '👍');
@@ -70,7 +55,7 @@ test('a user holds at most one row per distinct emoji and can react with several
 });
 
 test('a non-member of a private channel cannot react', function (): void {
-    [$owner, $team] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $stranger = User::factory()->create();
     $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
@@ -85,7 +70,7 @@ test('a non-member of a private channel cannot react', function (): void {
 });
 
 test('reactions cannot be added in an archived channel', function (): void {
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['archived_at' => now()]);
     $channel->channelMembers()->create(['user_id' => $owner->id]);
     $message = Message::factory()->for($channel)->for($owner)->create();
@@ -96,7 +81,7 @@ test('reactions cannot be added in an archived channel', function (): void {
 });
 
 test('the emoji is required', function (): void {
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     $this->actingAs($owner)->post(route('channels.messages.reactions.store', [
@@ -107,7 +92,7 @@ test('the emoji is required', function (): void {
 });
 
 test('a message aggregates its reactions per emoji with reactor sets', function (): void {
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $alice = User::factory()->create(['name' => 'Alice']);
     $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);
 
@@ -134,7 +119,7 @@ test('a message aggregates its reactions per emoji with reactor sets', function 
 test('toggling a reaction broadcasts MessageReactionChanged on the channel with the fresh summary', function (): void {
     Event::fake([MessageReactionChanged::class]);
 
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
 
     // Add.
@@ -161,7 +146,7 @@ test('toggling a reaction broadcasts MessageReactionChanged on the channel with 
 });
 
 test('deleting a message removes its reactions and emits none in the tombstone payload', function (): void {
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessageReaction::factory()->for($message)->for($owner)->emoji('👍')->create();
 
@@ -178,7 +163,7 @@ test('deleting a message removes its reactions and emits none in the tombstone p
 });
 
 test('deleting a reacting user drops their reactions via the cascade', function (): void {
-    [$owner, $team, $general] = reactionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $alice = User::factory()->create();
     $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);
 

--- a/tests/Feature/Channels/ScheduleMessageTest.php
+++ b/tests/Feature/Channels/ScheduleMessageTest.php
@@ -1,35 +1,19 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ScheduledMessageStatus;
 use App\Enums\TeamRole;
 use App\Events\MessageSent;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\ScheduledMessage;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function scheduleTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
 test('a member can schedule a message for a future time', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $clientUuid = (string) Str::uuid7();
     $sendAt = now()->addHour();
 
@@ -56,7 +40,7 @@ test('a member can schedule a message for a future time', function (): void {
 });
 
 test('scheduling clears the author composer draft for the channel', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $owner->channels()->updateExistingPivot($general->id, ['draft' => 'half-typed']);
 
     $this->actingAs($owner)
@@ -70,7 +54,7 @@ test('scheduling clears the author composer draft for the channel', function ():
 });
 
 test('a scheduled message can quote a live message in the same channel', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create();
 
     $this->actingAs($owner)
@@ -85,7 +69,7 @@ test('a scheduled message can quote a live message in the same channel', functio
 });
 
 test('a non-future send time is rejected', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -99,7 +83,7 @@ test('a non-future send time is rejected', function (): void {
 });
 
 test('a missing send time is rejected', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -110,7 +94,7 @@ test('a missing send time is rejected', function (): void {
 });
 
 test('an empty body is rejected', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -122,7 +106,7 @@ test('an empty body is rejected', function (): void {
 });
 
 test('the reply target must belong to the same channel', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
     $foreign = Message::factory()->for($other)->for($owner)->create();
@@ -138,7 +122,7 @@ test('the reply target must belong to the same channel', function (): void {
 });
 
 test('the reply target cannot be a deleted message', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $parent->delete();
 
@@ -153,7 +137,7 @@ test('the reply target cannot be a deleted message', function (): void {
 });
 
 test('a non-member cannot schedule a message', function (): void {
-    [$owner, $team] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     // A private channel the team member is not a member of: the postMessage gate
     // rejects scheduling just as it would an immediate send.
     $private = Channel::factory()->for($team)->private()->create();
@@ -174,7 +158,7 @@ test('a non-member cannot schedule a message', function (): void {
 });
 
 test('a message cannot be scheduled to an archived channel', function (): void {
-    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $channel = Channel::factory()->for($team)->archived()->create();
     $channel->channelMembers()->create(['user_id' => $owner->id]);
 

--- a/tests/Feature/Channels/ScheduledMessageListTest.php
+++ b/tests/Feature/Channels/ScheduledMessageListTest.php
@@ -1,30 +1,14 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\ScheduledMessage;
-use App\Models\Team;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function scheduledListTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
 test('the channel page lists the viewer own pending scheduled messages, soonest first', function (): void {
-    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $later = ScheduledMessage::factory()->for($general)->for($owner)->create([
         'body' => 'the later one',
@@ -46,7 +30,7 @@ test('the channel page lists the viewer own pending scheduled messages, soonest 
 });
 
 test('each row carries the client uuid the composer minted, so the client can point at the row it just created', function (): void {
-    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
         'client_uuid' => '019fa561-9fc6-73d7-9166-05358afb47c9',
@@ -61,7 +45,7 @@ test('each row carries the client uuid the composer minted, so the client can po
 });
 
 test('the list excludes other members scheduled messages', function (): void {
-    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
@@ -78,7 +62,7 @@ test('the list excludes other members scheduled messages', function (): void {
 });
 
 test('the list excludes sent and cancelled scheduled messages', function (): void {
-    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     ScheduledMessage::factory()->for($general)->for($owner)->create(['body' => 'still pending']);
     ScheduledMessage::factory()->for($general)->for($owner)->sent()->create(['body' => 'already sent']);
@@ -93,7 +77,7 @@ test('the list excludes sent and cancelled scheduled messages', function (): voi
 });
 
 test('the list is scoped to the current channel', function (): void {
-    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
 
@@ -109,7 +93,7 @@ test('the list is scoped to the current channel', function (): void {
 });
 
 test('a scheduled message carries its inline reply quote', function (): void {
-    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'the original']);
     ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'scheduled answer']);
 

--- a/tests/Feature/Channels/TypingBroadcastTest.php
+++ b/tests/Feature/Channels/TypingBroadcastTest.php
@@ -1,32 +1,16 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
 use App\Events\UserTyping;
 use App\Models\Channel;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Support\Facades\Event;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function typingTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
 test('a member typing signal broadcasts UserTyping with the authenticated identity', function (): void {
     Event::fake([UserTyping::class]);
 
-    [$owner, $team, $general] = typingTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $owner->update(['name' => 'Ada Lovelace']);
 
     $this->actingAs($owner)->post(route('channels.typing', [
@@ -47,7 +31,7 @@ test('a member typing signal broadcasts UserTyping with the authenticated identi
 test('a team member who is not in the channel cannot broadcast typing', function (): void {
     Event::fake([UserTyping::class]);
 
-    [$owner, $team, $general] = typingTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $outsider = User::factory()->create();
     $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
     $private = Channel::factory()->for($team)->private()->create();
@@ -64,7 +48,7 @@ test('a team member who is not in the channel cannot broadcast typing', function
 test('typing is rejected on an archived channel', function (): void {
     Event::fake([UserTyping::class]);
 
-    [$owner, $team, $general] = typingTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $archived = Channel::factory()->for($team)->archived()->create();
     $archived->channelMembers()->firstOrCreate(['user_id' => $owner->id]);
 
@@ -79,7 +63,7 @@ test('typing is rejected on an archived channel', function (): void {
 test('a guest is redirected to login instead of broadcasting typing', function (): void {
     Event::fake([UserTyping::class]);
 
-    [, $team, $general] = typingTeamWithGeneral();
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->post(route('channels.typing', [
         'team' => $team->slug,

--- a/tests/Feature/Channels/UpdateScheduledMessageTest.php
+++ b/tests/Feature/Channels/UpdateScheduledMessageTest.php
@@ -1,29 +1,13 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ScheduledMessageStatus;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\ScheduledMessage;
-use App\Models\Team;
 use App\Models\User;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function updateScheduledTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
 test('the author can edit the body and send time of a pending scheduled message', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
         'body' => 'first draft',
         'send_at' => now()->addHour(),
@@ -49,7 +33,7 @@ test('the author can edit the body and send time of a pending scheduled message'
 });
 
 test('editing rejects a non-future send time', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
 
     $this->actingAs($owner)
@@ -65,7 +49,7 @@ test('editing rejects a non-future send time', function (): void {
 });
 
 test('editing rejects an empty body', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
 
     $this->actingAs($owner)
@@ -81,7 +65,7 @@ test('editing rejects an empty body', function (): void {
 });
 
 test('a non-author cannot edit a scheduled message', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create(['body' => 'not yours']);
@@ -101,7 +85,7 @@ test('a non-author cannot edit a scheduled message', function (): void {
 });
 
 test('an already-sent scheduled message cannot be edited', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->sent()->create();
 
     $this->actingAs($owner)
@@ -117,7 +101,7 @@ test('an already-sent scheduled message cannot be edited', function (): void {
 });
 
 test('the author can cancel a pending scheduled message', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
 
     $this->actingAs($owner)
@@ -135,7 +119,7 @@ test('the author can cancel a pending scheduled message', function (): void {
 });
 
 test('a non-author cannot cancel a scheduled message', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
@@ -152,7 +136,7 @@ test('a non-author cannot cancel a scheduled message', function (): void {
 });
 
 test('a scheduled message id from another channel is not resolvable', function (): void {
-    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
     $scheduled = ScheduledMessage::factory()->for($other)->for($owner)->create();

--- a/tests/Feature/SidebarSectionTest.php
+++ b/tests/Feature/SidebarSectionTest.php
@@ -1,23 +1,8 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function sectionTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
 
 /**
  * Read the shared `collapsedChannelSections` prop for the acting user off a
@@ -36,7 +21,7 @@ function sidebarCollapsedProp(User $user, Team $team, Channel $channel): array
 }
 
 test('a user can collapse a sidebar section', function (): void {
-    [$owner, $team, $general] = sectionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($owner)
         ->patch(route('sidebar.sections.update'), ['collapsed' => ['starred']])
@@ -47,7 +32,7 @@ test('a user can collapse a sidebar section', function (): void {
 });
 
 test('an empty payload clears every collapsed section', function (): void {
-    [$owner, $team, $general] = sectionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $owner->update(['collapsed_channel_sections' => ['starred', 'channels']]);
 
     $this->actingAs($owner)
@@ -59,14 +44,14 @@ test('an empty payload clears every collapsed section', function (): void {
 });
 
 test('collapsed sections default to empty for a fresh user', function (): void {
-    [$owner, $team, $general] = sectionTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     expect($owner->collapsed_channel_sections)->toBeNull();
     expect(sidebarCollapsedProp($owner, $team, $general))->toBe([]);
 });
 
 test('duplicate section keys are stored once', function (): void {
-    [$owner] = sectionTeamWithGeneral();
+    ['owner' => $owner] = teamWithChannel();
 
     $this->actingAs($owner)
         ->patch(route('sidebar.sections.update'), ['collapsed' => ['channels', 'channels']])
@@ -76,7 +61,7 @@ test('duplicate section keys are stored once', function (): void {
 });
 
 test('unknown section keys are rejected', function (): void {
-    [$owner] = sectionTeamWithGeneral();
+    ['owner' => $owner] = teamWithChannel();
 
     $this->actingAs($owner)
         ->patch(route('sidebar.sections.update'), ['collapsed' => ['bogus']])
@@ -86,7 +71,7 @@ test('unknown section keys are rejected', function (): void {
 });
 
 test('the collapsed payload must be present', function (): void {
-    [$owner] = sectionTeamWithGeneral();
+    ['owner' => $owner] = teamWithChannel();
 
     $this->actingAs($owner)
         ->patch(route('sidebar.sections.update'), [])


### PR DESCRIPTION
Part of #1117 — slice **7**, batch 1 of 2.

The eleven files here each declared their own `*TeamWithGeneral()`: a byte-identical
copy of what `tests/Helpers.php` has carried since #1111, under eleven different
private prefixes (`pinTeamWithGeneral`, `replyTeamWithGeneral`, `typingTeamWithGeneral`, …).
They go through `teamWithChannel()` instead.

## What is in the diff

No assertion moves in this slice — it is criterion 1 only, and the diff is provably
nothing but the substitution:

- **11** helper declarations removed, all with the same body
- **12** imports that only the removed helpers used (`CreateTeam` ×11, `Team` ×7, `User`, `Channel`)
- **105** call sites rewritten from a positional destructure onto the shared arrange's keys

Every added line in the diff is one of four shapes:

```php
['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
['owner' => $owner, 'team' => $team] = teamWithChannel();
['owner' => $owner] = teamWithChannel();
['team' => $team, 'channel' => $general] = teamWithChannel();
```

`git diff -U0 | grep '^+'` matches that set exactly, so there is no hidden edit
riding along — which is the failure mode the issue warns about, since a weakened
assertion still passes.

## Mutation check

Nothing moved onto a module here, so the thing to prove is that the shared arrange
is not *weaker* than the eleven clones it replaced. Mutating `teamWithChannel()`
and running the swept files (96 tests):

| mutation | red | files red |
| --- | --- | --- |
| the owner is not a member of the returned channel | 41 / 96 | 8 |
| the returned channel is not `#general` | 42 / 96 | 8 |
| the owner is not a member of the team | 56 / 96 | 10 |

Union: **all 11 files** go red. Each half of the arrange is load-bearing somewhere.

The three files that survive the first two mutations (`SidebarSectionTest`,
`ScheduledMessageListTest`, `UpdateScheduledMessageTest`) build their own channels on
top and only want "a team and someone who owns it" from the helper — the third mutation
catches all three. `DispatchScheduledMessageTest` is the mirror image: it drives the
dispatch action rather than an HTTP route, so no team-membership check runs, and only
the first two mutations reach it.

## Metrics

| metric | at filing | before | now |
| --- | --- | --- | --- |
| `grep -rn "TeamWithGeneral" tests/Feature` | 274 | 248 | **143** |
| files declaring a local `*TeamWithGeneral()` | 37 | 22 | **11** |
| `assertInertia` in `tests/Feature` | 258 | 243 | 243 |

`assertInertia` is unmoved by design: no renders disappear in a batch that only
replaces arranges.

## What is left

Batch 2 is the remaining 11 declarations, all of which sit beside a second clone —
an `xMember(Team, Channel)` "add someone to the team and the channel" helper that
`teamMemberInChannel()` replaces. That mapping needs reading per file rather than a
substitution, which is why it is split out. After that, slice 6 (the inline-repeater
cluster) is the last of the child, one file per PR.

## Testing

`./vendor/bin/sail composer test` green, `Total: 100.0 %`. No frontend files touched.
Local CodeRabbit pass: 0 findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788354551&installation_model_id=428379&pr_number=1179&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1179&signature=75f2a3a512718e4a4b47d7b3f50c732dbfee13c0578a6d4257bfad226882e79d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->