### PR TITLE
test: fold seven more test files onto the shared arrange

### DIFF
--- a/tests/Feature/Channels/ChannelDraftTest.php
+++ b/tests/Feature/Channels/ChannelDraftTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Actions\Channels\PostMessage;
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
 use App\Models\Channel;
@@ -9,32 +8,6 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function draftTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and the given channel, returning them.
- */
-function draftMember(Team $team, Channel $channel): User
-{
-    $user = User::factory()->create();
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
 
 /**
  * Resolve the sidebar `channels` prop entry for the channel as the acting user.
@@ -65,8 +38,8 @@ function saveDraft(User $user, Team $team, Channel $channel, ?string $body): Tes
 }
 
 test('a member can save a draft for a channel', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     saveDraft($member, $team, $general, 'a half-written thought')
         ->assertRedirect();
@@ -79,8 +52,8 @@ test('a member can save a draft for a channel', function (): void {
 });
 
 test('saving a blank draft clears it', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'stale text']);
 
     saveDraft($member, $team, $general, '   ')
@@ -97,7 +70,7 @@ test('saving a blank draft clears it', function (): void {
 ]);
 
 test('a non-member cannot save a draft for a channel', function (): void {
-    [$owner, $team] = draftTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
         'created_by' => $owner->id,
@@ -115,16 +88,16 @@ test('a non-member cannot save a draft for a channel', function (): void {
 });
 
 test('a draft cannot exceed the message length limit', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     saveDraft($member, $team, $general, str_repeat('a', 8001))
         ->assertSessionHasErrors('body');
 });
 
 test('the channel view restores the members saved draft', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'unsent words']);
 
     $response = $this->actingAs($member)->get(route('channels.show', [
@@ -137,8 +110,8 @@ test('the channel view restores the members saved draft', function (): void {
 });
 
 test('a member without a draft opens the channel with an empty composer', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $response = $this->actingAs($member)->get(route('channels.show', [
         'team' => $team->slug,
@@ -150,8 +123,8 @@ test('a member without a draft opens the channel with an empty composer', functi
 });
 
 test('the sidebar flags a channel with a draft without shipping the draft text', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'secret sauce']);
 
     expect(draftSidebarEntry($member, $team, $general))
@@ -159,16 +132,16 @@ test('the sidebar flags a channel with a draft without shipping the draft text',
 });
 
 test('the sidebar shows no draft cue when the channel has none', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     expect(draftSidebarEntry($member, $team, $general))
         ->toMatchArray(['hasDraft' => false, 'draft' => null]);
 });
 
 test('posting a message from the main composer clears the channel draft', function (): void {
-    [, $team, $general] = draftTeamWithGeneral();
-    $member = draftMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'about to send this']);
 
     app(PostMessage::class)->handle(

--- a/tests/Feature/Channels/ChannelPreferenceTest.php
+++ b/tests/Feature/Channels/ChannelPreferenceTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Actions\Channels\JoinChannel;
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ChannelVisibility;
 use App\Enums\NotificationLevel;
 use App\Enums\TeamRole;
@@ -10,32 +9,6 @@ use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Testing\TestResponse;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function prefTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and the given channel, returning them.
- */
-function prefMember(Team $team, Channel $channel, ?string $name = null): User
-{
-    $user = User::factory()->create($name ? ['name' => $name] : []);
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
 
 /**
  * Post a message to the channel, optionally mentioning a member.
@@ -82,7 +55,7 @@ function updatePreferences(User $user, Team $team, Channel $channel, bool $muted
 }
 
 test('joining a channel applies the default notification preferences', function (): void {
-    [$owner, $team] = prefTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Public,
         'created_by' => $owner->id,
@@ -101,8 +74,8 @@ test('joining a channel applies the default notification preferences', function 
 });
 
 test('a member can update their notification preferences', function (): void {
-    [, $team, $general] = prefTeamWithGeneral();
-    $member = prefMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     updatePreferences($member, $team, $general, muted: true, level: 'mentions')
         ->assertRedirect();
@@ -116,7 +89,7 @@ test('a member can update their notification preferences', function (): void {
 });
 
 test('a non-member cannot update preferences for a channel', function (): void {
-    [$owner, $team] = prefTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
         'created_by' => $owner->id,
@@ -134,16 +107,16 @@ test('a non-member cannot update preferences for a channel', function (): void {
 });
 
 test('the notification level must be one of the allowed values', function (): void {
-    [, $team, $general] = prefTeamWithGeneral();
-    $member = prefMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     updatePreferences($member, $team, $general, muted: false, level: 'sometimes')
         ->assertSessionHasErrors('notification_level');
 });
 
 test('the muted flag must be a boolean', function (): void {
-    [, $team, $general] = prefTeamWithGeneral();
-    $member = prefMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     test()->actingAs($member)->patch(route('channels.preferences.update', [
         'team' => $team->slug,
@@ -153,8 +126,8 @@ test('the muted flag must be a boolean', function (): void {
 });
 
 test('the channel view exposes the members own preferences and the level options', function (): void {
-    [, $team, $general] = prefTeamWithGeneral();
-    $member = prefMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $member->channels()->updateExistingPivot($general->id, [
         'muted' => true,
         'notification_level' => 'mentions',
@@ -178,7 +151,7 @@ test('the channel view exposes the members own preferences and the level options
 });
 
 test('a non-member viewing a public channel cannot manage preferences and sees defaults', function (): void {
-    [$owner, $team] = prefTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $public = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Public,
         'created_by' => $owner->id,
@@ -199,8 +172,8 @@ test('a non-member viewing a public channel cannot manage preferences and sees d
 });
 
 test('the notification level and mute suppress the sidebar badges', function (bool $muted, string $level, int $expectedUnread, int $expectedMention): void {
-    [$owner, $team, $general] = prefTeamWithGeneral();
-    $member = prefMember($team, $general, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
 
     // Two unread messages, one of which is a direct @mention of the member.
     prefPost($general, $owner);

--- a/tests/Feature/Channels/ChannelStarTest.php
+++ b/tests/Feature/Channels/ChannelStarTest.php
@@ -1,38 +1,11 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Testing\TestResponse;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function starTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and the given channel, returning them.
- */
-function starMember(Team $team, Channel $channel): User
-{
-    $user = User::factory()->create();
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
 
 /**
  * Resolve the sidebar `channels` prop entry for the channel as the acting user.
@@ -63,8 +36,8 @@ function setStar(User $user, Team $team, Channel $channel, bool $starred): TestR
 }
 
 test('a member can star a channel', function (): void {
-    [, $team, $general] = starTeamWithGeneral();
-    $member = starMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     setStar($member, $team, $general, true)->assertRedirect();
 
@@ -76,8 +49,8 @@ test('a member can star a channel', function (): void {
 });
 
 test('a member can unstar a channel', function (): void {
-    [, $team, $general] = starTeamWithGeneral();
-    $member = starMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $member->channels()->updateExistingPivot($general->id, ['starred' => true]);
 
     setStar($member, $team, $general, false)->assertRedirect();
@@ -90,8 +63,8 @@ test('a member can unstar a channel', function (): void {
 });
 
 test('the sidebar reflects a channel star flag', function (): void {
-    [, $team, $general] = starTeamWithGeneral();
-    $member = starMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     expect(starSidebarEntry($member, $team, $general))
         ->toMatchArray(['starred' => false]);
@@ -103,8 +76,8 @@ test('the sidebar reflects a channel star flag', function (): void {
 });
 
 test('one member starring a channel does not star it for another', function (): void {
-    [$owner, $team, $general] = starTeamWithGeneral();
-    $member = starMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     setStar($member, $team, $general, true)->assertRedirect();
 
@@ -113,7 +86,7 @@ test('one member starring a channel does not star it for another', function (): 
 });
 
 test('a non-member cannot star a channel', function (): void {
-    [$owner, $team] = starTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
         'created_by' => $owner->id,
@@ -130,8 +103,8 @@ test('a non-member cannot star a channel', function (): void {
 });
 
 test('starring requires a boolean flag', function (): void {
-    [, $team, $general] = starTeamWithGeneral();
-    $member = starMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     test()->actingAs($member)->patch(route('channels.star.update', [
         'team' => $team->slug,

--- a/tests/Feature/Channels/MessageSearchTest.php
+++ b/tests/Feature/Channels/MessageSearchTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\NavDestination;
-use App\Enums\TeamRole;
 use App\Models\Attachment;
 use App\Models\Channel;
 use App\Models\Message;
@@ -10,32 +8,6 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Testing\TestResponse;
 use Inertia\Testing\AssertableInertia as Assert;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function searchTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and the given channel, returning them.
- */
-function searchMember(Team $team, Channel $channel, ?string $name = null): User
-{
-    $user = User::factory()->create($name ? ['name' => $name] : []);
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
 
 /**
  * Open the Search destination on the team's #general as the given user.
@@ -74,8 +46,8 @@ function performSuggest(User $user, Team $team, string $query): TestResponse
 }
 
 test('a member searches messages in their channels', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     Message::factory()->for($general)->for($member)->create(['body' => 'the quokka danced at dawn']);
     Message::factory()->for($general)->for($owner)->create(['body' => 'totally unrelated chatter']);
 
@@ -93,8 +65,8 @@ test('a member searches messages in their channels', function (): void {
 });
 
 test('the panel props are absent until the destination is pinned', function (): void {
-    [, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     // A search runs a full-text query, so it must ride on `?nav=search` rather
     // than on every workspace navigation.
@@ -107,8 +79,8 @@ test('the panel props are absent until the destination is pinned', function (): 
 });
 
 test('the legacy search url redirects onto the destination carrying its facets', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     // #391's shared links have to keep working: the old page is a redirect that
     // hands its query and facets to the panel.
@@ -129,8 +101,8 @@ test('the legacy search url redirects onto the destination carrying its facets',
 });
 
 test('the search destination shares the workspace sidebar props', function (): void {
-    [, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general, 'Ada Lovelace');
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
 
     // The facet pickers read the channels and members off the same shared props
     // the conversation list feeds on.
@@ -145,14 +117,14 @@ test('the search destination shares the workspace sidebar props', function (): v
 });
 
 test('a non-member of the team cannot search it', function (): void {
-    [, $team] = searchTeamWithGeneral();
+    ['team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
 
     performSearch($outsider, $team, 'zephyr')->assertForbidden();
 });
 
 test('a jump windows the messages around the target with newer context below', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $messages = collect(range(1, 30))->map(
         fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "message {$i}"])
     );
@@ -172,7 +144,7 @@ test('a jump windows the messages around the target with newer context below', f
 });
 
 test('a jump to the newest message keeps it at the bottom of the window', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $messages = collect(range(1, 5))->map(
         fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "message {$i}"])
     );
@@ -190,7 +162,7 @@ test('a jump to the newest message keeps it at the bottom of the window', functi
 });
 
 test('a message param from another channel is ignored', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     Message::factory()->for($general)->for($owner)->create(['body' => 'only message here']);
     $other = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
     $foreign = Message::factory()->for($other)->for($owner)->create(['body' => 'elsewhere']);
@@ -206,8 +178,8 @@ test('a message param from another channel is ignored', function (): void {
 });
 
 test('the suggest endpoint returns matching messages as JSON', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     Message::factory()->for($general)->for($member)->create(['body' => 'the quokka danced at dawn']);
     Message::factory()->for($general)->for($owner)->create(['body' => 'totally unrelated chatter']);
 
@@ -221,8 +193,8 @@ test('the suggest endpoint returns matching messages as JSON', function (): void
 });
 
 test('the suggest endpoint caps results at the preview limit', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     collect(range(1, 8))->each(
         fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "zephyr note {$i}"])
     );
@@ -233,8 +205,8 @@ test('the suggest endpoint caps results at the preview limit', function (): void
 });
 
 test('the suggest endpoint honours the file facet', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $withFile = Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr with the deck']);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr without anything']);
     Attachment::factory()->for($owner)->attachedTo($withFile)->create();
@@ -249,8 +221,8 @@ test('the suggest endpoint honours the file facet', function (): void {
 });
 
 test('the suggest endpoint rejects a file facet it does not offer', function (): void {
-    [, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     test()->actingAs($member)
         ->getJson(route('search.suggest', ['team' => $team->slug, 'q' => 'zephyr', 'has' => 'audio']))
@@ -258,8 +230,8 @@ test('the suggest endpoint rejects a file facet it does not offer', function ():
 });
 
 test('the suggest endpoint is ACL-filtered to the user channels', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $private = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
     Message::factory()->for($private)->for($owner)->create(['body' => 'secret zephyr plans']);
 
@@ -269,8 +241,8 @@ test('the suggest endpoint is ACL-filtered to the user channels', function (): v
 });
 
 test('an empty suggest query returns no results without touching the engine', function (): void {
-    [$owner, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
 
     performSuggest($member, $team, '')
@@ -279,15 +251,15 @@ test('an empty suggest query returns no results without touching the engine', fu
 });
 
 test('a non-member of the team cannot use suggest', function (): void {
-    [, $team] = searchTeamWithGeneral();
+    ['team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
 
     performSuggest($outsider, $team, 'zephyr')->assertForbidden();
 });
 
 test('the suggest query cannot exceed 255 characters', function (): void {
-    [, $team, $general] = searchTeamWithGeneral();
-    $member = searchMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     performSuggest($member, $team, str_repeat('a', 256))
         ->assertJsonValidationErrorFor('q');

--- a/tests/Feature/Channels/ThreadTest.php
+++ b/tests/Feature/Channels/ThreadTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
-use App\Enums\TeamRole;
 use App\Events\MessageSent;
 use App\Events\MessageUpdated;
 use App\Models\Channel;
@@ -12,32 +10,6 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Inertia\Testing\AssertableInertia as Assert;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function threadTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and #general, returning them.
- */
-function threadMember(Team $team, Channel $channel, ?string $name = null): User
-{
-    $user = User::factory()->create($name ? ['name' => $name] : []);
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
 
 /**
  * Post a thread reply through the HTTP endpoint as the given user.
@@ -55,7 +27,7 @@ function postThreadReply(Team $team, Channel $channel, User $author, Message $ro
 }
 
 test('a reply persists against its thread root and bumps the root aggregates', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
     $clientUuid = (string) Str::uuid7();
 
@@ -75,7 +47,7 @@ test('a reply persists against its thread root and bumps the root aggregates', f
 });
 
 test('a second reply increments the root reply count', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
 
     postThreadReply($team, $general, $owner, $root);
@@ -85,7 +57,7 @@ test('a second reply increments the root reply count', function (): void {
 });
 
 test('a reply cannot target another reply (threads are one level deep)', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
     $reply = Message::factory()->for($owner)->inThread($root)->create();
 
@@ -94,7 +66,7 @@ test('a reply cannot target another reply (threads are one level deep)', functio
 });
 
 test('the thread root must belong to the same channel', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
     $foreign = Message::factory()->for($other)->for($owner)->create();
@@ -104,7 +76,7 @@ test('the thread root must belong to the same channel', function (): void {
 });
 
 test('a reply cannot start on a deleted root', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
     $root->delete();
 
@@ -115,7 +87,7 @@ test('a reply cannot start on a deleted root', function (): void {
 test('a reply persists in a thread whose root is a poll', function (): void {
     Event::fake([MessageSent::class]);
 
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->poll()->for($general)->for($owner)->create();
     $clientUuid = (string) Str::uuid7();
 
@@ -143,7 +115,7 @@ test('a reply persists in a thread whose root is a poll', function (): void {
 });
 
 test('a non-uuid thread root is rejected', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
 
     postThreadReply($team, $general, $owner, $root, ['thread_root_id' => 'not-a-uuid'])
@@ -151,7 +123,7 @@ test('a non-uuid thread root is rejected', function (): void {
 });
 
 test('sent_to_channel is ignored without a thread root', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $clientUuid = (string) Str::uuid7();
 
     $this->actingAs($owner)->post(
@@ -167,7 +139,7 @@ test('sent_to_channel is ignored without a thread root', function (): void {
 });
 
 test('the main timeline hides thread-only replies but keeps sent-to-channel replies', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
     Message::factory()->for($owner)->inThread($root)->create(['body' => 'thread only']);
     Message::factory()->for($owner)->inThread($root)->sentToChannel()->create(['body' => 'also in channel']);
@@ -184,7 +156,7 @@ test('the main timeline hides thread-only replies but keeps sent-to-channel repl
 });
 
 test('the thread prop returns the root and paginated replies newest-first, tombstones included', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
     Message::factory()->for($owner)->inThread($root)->create(['body' => 'first reply']);
     $second = Message::factory()->for($owner)->inThread($root)->create(['body' => 'second reply']);
@@ -204,7 +176,7 @@ test('the thread prop returns the root and paginated replies newest-first, tombs
 });
 
 test('the thread prop is null and replies are empty for a normal visit', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
@@ -214,7 +186,7 @@ test('the thread prop is null and replies are empty for a normal visit', functio
 });
 
 test('a long thread caps the first page of replies and offers more', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->count(51)->for($owner)->inThread($root)->create();
 
@@ -229,7 +201,7 @@ test('a long thread caps the first page of replies and offers more', function ()
 });
 
 test('the thread prop is null when the param is blank or points elsewhere', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $reply = Message::factory()->for($owner)->inThread(
         Message::factory()->for($general)->for($owner)->create(),
     )->create();
@@ -246,9 +218,9 @@ test('the thread prop is null when the param is blank or points elsewhere', func
 });
 
 test('a root exposes its distinct thread participants and survives deletion', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
-    $ada = threadMember($team, $general, 'Ada');
-    $grace = threadMember($team, $general, 'Grace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada']);
+    $grace = teamMemberInChannel($general, ['name' => 'Grace']);
 
     $root = Message::factory()->for($general)->for($owner)->create([
         'reply_count' => 3,
@@ -273,7 +245,7 @@ test('a root exposes its distinct thread participants and survives deletion', fu
 test('posting a reply broadcasts the reply and the updated root aggregate', function (): void {
     Event::fake([MessageSent::class, MessageUpdated::class]);
 
-    [$owner, $team, $general] = threadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
     $clientUuid = (string) Str::uuid7();
 
@@ -294,8 +266,8 @@ test('posting a reply broadcasts the reply and the updated root aggregate', func
 });
 
 test('a thread-only reply does not raise the channel unread badge', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
-    $member = threadMember($team, $general, 'Reader');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Reader']);
     $root = Message::factory()->for($general)->for($owner)->create();
 
     // A plain timeline message and a thread-only reply, both by someone else.
@@ -309,8 +281,8 @@ test('a thread-only reply does not raise the channel unread badge', function ():
 });
 
 test('a sent-to-channel reply raises the channel unread badge', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
-    $member = threadMember($team, $general, 'Reader');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Reader']);
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($owner)->inThread($root)->sentToChannel()->create();
 
@@ -319,8 +291,8 @@ test('a sent-to-channel reply raises the channel unread badge', function (): voi
 });
 
 test('a mention inside a thread still badges the channel', function (): void {
-    [$owner, $team, $general] = threadTeamWithGeneral();
-    $member = threadMember($team, $general, 'Reader');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Reader']);
     $root = Message::factory()->for($general)->for($owner)->create();
 
     $reply = Message::factory()->for($owner)->inThread($root)->create([

--- a/tests/Feature/Channels/UnreadBadgeTest.php
+++ b/tests/Feature/Channels/UnreadBadgeTest.php
@@ -1,41 +1,12 @@
 <?php
 
 use App\Actions\Channels\MarkChannelRead;
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function unreadTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and the given channel, returning them.
- */
-function unreadChannelMember(Team $team, Channel $channel, ?string $name = null): User
-{
-    $user = User::factory()->create($name ? ['name' => $name] : []);
-    // Joining the team auto-adds the user to #general via the membership observer,
-    // so create the channel pivot idempotently for any other channel.
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
 
 /**
  * Post a message to the channel authored by the given user.
@@ -81,8 +52,8 @@ function sidebarChannel(User $user, Team $team, Channel $channel): array
 }
 
 test('unread count reflects only the messages posted after last_read', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
 
     $messages = collect(range(1, 5))->map(fn (): Message => unreadPost($general, $owner));
     markReadUpTo($member, $general, $messages[2]);
@@ -92,8 +63,8 @@ test('unread count reflects only the messages posted after last_read', function 
 });
 
 test('a null last_read means every message in the channel is unread', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     collect(range(1, 3))->each(fn (): Message => unreadPost($general, $owner));
 
@@ -101,8 +72,8 @@ test('a null last_read means every message in the channel is unread', function (
 });
 
 test('a member does not see their own messages as unread', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     unreadPost($general, $owner);
     unreadPost($general, $member);
@@ -112,8 +83,8 @@ test('a member does not see their own messages as unread', function (): void {
 });
 
 test('soft-deleted messages are excluded from the unread count', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     unreadPost($general, $owner);
     $deleted = unreadPost($general, $owner);
@@ -123,8 +94,8 @@ test('soft-deleted messages are excluded from the unread count', function (): vo
 });
 
 test('system notices are ambient and never advance the unread or mention badge', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
 
     $read = unreadPost($general, $owner);
     markReadUpTo($member, $general, $read);
@@ -138,8 +109,8 @@ test('system notices are ambient and never advance the unread or mention badge',
 });
 
 test('a poll badges the channel like any other user-authored message', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
 
     $read = unreadPost($general, $owner);
     markReadUpTo($member, $general, $read);
@@ -154,8 +125,8 @@ test('a poll badges the channel like any other user-authored message', function 
 });
 
 test('a poll that mentions the user raises the mention badge', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general, 'Grace Hopper');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Grace Hopper']);
 
     $poll = Message::factory()->for($general)->for($owner)->poll()->create();
     $poll->mentionedUsers()->attach($member->id);
@@ -165,8 +136,8 @@ test('a poll that mentions the user raises the mention badge', function (): void
 });
 
 test('the mention count only counts unread messages that mention the user', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general, 'Grace Hopper');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Grace Hopper']);
 
     $readMention = unreadPost($general, $owner, $member);
     markReadUpTo($member, $general, $readMention);
@@ -180,9 +151,9 @@ test('the mention count only counts unread messages that mention the user', func
 });
 
 test('a mention of another member does not inflate the users mention count', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general);
-    $other = unreadChannelMember($team, $general, 'Someone Else');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
+    $other = teamMemberInChannel($general, ['name' => 'Someone Else']);
 
     unreadPost($general, $owner, $other);
 
@@ -190,8 +161,8 @@ test('a mention of another member does not inflate the users mention count', fun
 });
 
 test('MarkChannelRead advances last_read to the latest message and clears the badge', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general, 'Alan Turing');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Alan Turing']);
 
     unreadPost($general, $owner, $member);
     $latest = unreadPost($general, $owner);
@@ -209,8 +180,8 @@ test('MarkChannelRead advances last_read to the latest message and clears the ba
 });
 
 test('MarkChannelRead leaves the pointer untouched when the channel has no messages', function (): void {
-    [, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     app(MarkChannelRead::class)->handle($general, $member);
 
@@ -222,13 +193,13 @@ test('MarkChannelRead leaves the pointer untouched when the channel has no messa
 });
 
 test('MarkChannelRead is a no-op for a user who is not a channel member', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
         'created_by' => $owner->id,
     ]);
     // A plain team member is auto-joined to #general but not to the private channel.
-    $outsider = unreadChannelMember($team, $general);
+    $outsider = teamMemberInChannel($general);
 
     Message::factory()->for($private)->for($owner)->create();
 
@@ -241,8 +212,8 @@ test('MarkChannelRead is a no-op for a user who is not a channel member', functi
 });
 
 test('hitting the read endpoint advances the pointer and clears the badges', function (): void {
-    [$owner, $team, $general] = unreadTeamWithGeneral();
-    $member = unreadChannelMember($team, $general, 'Katherine Johnson');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Katherine Johnson']);
 
     unreadPost($general, $owner, $member);
     $latest = unreadPost($general, $owner);
@@ -266,7 +237,7 @@ test('hitting the read endpoint advances the pointer and clears the badges', fun
 });
 
 test('the read endpoint is forbidden on a private channel the user cannot view', function (): void {
-    [$owner, $team] = unreadTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
         'created_by' => $owner->id,

--- a/tests/Feature/Support/MessageSearchPanelTest.php
+++ b/tests/Feature/Support/MessageSearchPanelTest.php
@@ -24,32 +24,6 @@ use Illuminate\Http\Request;
  */
 
 /**
- * A team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function panelTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and the given channel, returning them.
- */
-function panelMember(Team $team, Channel $channel, ?string $name = null): User
-{
-    $user = User::factory()->create($name ? ['name' => $name] : []);
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
-
-/**
  * The panel the shell would build for these facets on the URL.
  *
  * @param  array<string, mixed>  $params
@@ -73,8 +47,8 @@ function panelBodies(array $results): array
 }
 
 test('a member matches messages in their channels, shaped for the client', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     Message::factory()->for($general)->for($member)->create(['body' => 'the quokka danced at dawn']);
     Message::factory()->for($general)->for($owner)->create(['body' => 'totally unrelated chatter']);
 
@@ -91,8 +65,8 @@ test('a member matches messages in their channels, shaped for the client', funct
 });
 
 test('a result carries a highlighted snippet, with mention tokens unwrapped', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'the quokka danced at dawn']);
 
     expect(panelFor($member, $team, ['q' => 'quokka'])->results()[0]->snippet)
@@ -107,9 +81,9 @@ test('a result carries a highlighted snippet, with mention tokens unwrapped', fu
 });
 
 test('the author facet limits matches to messages from that user', function (): void {
-    [, $team, $general] = panelTeamWithGeneral();
-    $ada = panelMember($team, $general, 'Ada');
-    $bob = panelMember($team, $general, 'Bob');
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $ada = teamMemberInChannel($general, ['name' => 'Ada']);
+    $bob = teamMemberInChannel($general, ['name' => 'Bob']);
     Message::factory()->for($general)->for($ada)->create(['body' => 'zephyr from ada']);
     Message::factory()->for($general)->for($bob)->create(['body' => 'zephyr from bob']);
 
@@ -118,7 +92,7 @@ test('the author facet limits matches to messages from that user', function (): 
 });
 
 test('the channel facet limits matches to that channel', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
     $other->channelMembers()->firstOrCreate(['user_id' => $owner->id]);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr in general']);
@@ -129,8 +103,8 @@ test('the channel facet limits matches to that channel', function (): void {
 });
 
 test('the date facets limit matches to the created-at range', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr old', 'created_at' => now()->subDays(10)]);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr new', 'created_at' => now()->subDay()]);
 
@@ -141,8 +115,8 @@ test('the date facets limit matches to the created-at range', function (): void 
 });
 
 test('the file facet limits matches to messages still carrying an attachment', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $withFile = Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr with the deck']);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr without anything']);
     $attachment = Attachment::factory()->for($owner)->attachedTo($withFile)->create();
@@ -158,8 +132,8 @@ test('the file facet limits matches to messages still carrying an attachment', f
 });
 
 test('matches come back newest first regardless of engine relevance order', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr one', 'created_at' => now()->subDays(3)]);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr two', 'created_at' => now()->subDay()]);
 
@@ -168,8 +142,8 @@ test('matches come back newest first regardless of engine relevance order', func
 });
 
 test('no facet widens the channel ACL', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $private = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
     $secret = Message::factory()->for($private)->for($owner)->create(['body' => 'secret zephyr deck']);
     Attachment::factory()->for($owner)->attachedTo($secret)->create();
@@ -181,8 +155,8 @@ test('no facet widens the channel ACL', function (): void {
 });
 
 test('matches never cross into another team the viewer also belongs to', function (): void {
-    [, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $otherOwner = User::factory()->create();
     $otherTeam = app(CreateTeam::class)->handle($otherOwner, 'Beta');
@@ -194,8 +168,8 @@ test('matches never cross into another team the viewer also belongs to', functio
 });
 
 test('a soft-deleted message drops out, and an edit changes what matches', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $deleted = Message::factory()->for($general)->for($owner)->create(['body' => 'deletable zephyr note']);
     $deleted->delete();
@@ -208,7 +182,7 @@ test('a soft-deleted message drops out, and an edit changes what matches', funct
 });
 
 test('a team member who belongs to no channel matches nothing', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $loner = User::factory()->create();
     $team->memberships()->create(['user_id' => $loner->id, 'role' => TeamRole::Member]);
     // The observer joins new members to #general, so drop that membership to
@@ -220,8 +194,8 @@ test('a team member who belongs to no channel matches nothing', function (): voi
 });
 
 test('an empty query matches nothing without touching the search engine', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
 
     expect(panelFor($member, $team, ['q' => ''])->results())->toBe([])
@@ -229,8 +203,8 @@ test('an empty query matches nothing without touching the search engine', functi
 });
 
 test('a query longer than the engine accepts runs no search at all', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     Message::factory()->for($general)->for($owner)->create(['body' => str_repeat('a', 300)]);
 
     // Dropped, not truncated: half a query is a different search, and the panel
@@ -239,8 +213,8 @@ test('a query longer than the engine accepts runs no search at all', function ()
 });
 
 test('a malformed facet is dropped rather than rejecting the shell', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr note']);
 
     // The panel's criteria are resolved in the shared props of whatever workspace
@@ -265,8 +239,8 @@ test('a malformed facet is dropped rather than rejecting the shell', function ()
 });
 
 test('the criteria are echoed back as the client writes them onto the URL', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
-    $member = panelMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     expect(panelFor($member, $team, ['q' => 'zephyr', 'has' => 'file', 'from' => $owner->id, 'after' => '2026-01-02'])->criteria())
         ->toMatchArray([
@@ -284,7 +258,7 @@ test('the criteria are echoed back as the client writes them onto the URL', func
 });
 
 test('a direct message match is named after the viewer\'s counterpart', function (): void {
-    [$owner, $team] = panelTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $counterpart = User::factory()->create(['name' => 'Grace Hopper']);
     $team->memberships()->create(['user_id' => $counterpart->id, 'role' => TeamRole::Member]);
     $dm = app(OpenDirectMessage::class)->handle($team, $owner, $counterpart);
@@ -300,7 +274,7 @@ test('a direct message match is named after the viewer\'s counterpart', function
 });
 
 test('a group direct message match joins the other participants as its name', function (): void {
-    [$owner, $team] = panelTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $ada = User::factory()->create(['name' => 'Ada Lovelace']);
     $grace = User::factory()->create(['name' => 'Grace Hopper']);
     $team->memberships()->create(['user_id' => $ada->id, 'role' => TeamRole::Member]);
@@ -314,7 +288,7 @@ test('a group direct message match joins the other participants as its name', fu
 });
 
 test('a self direct message match shows the viewer their own name', function (): void {
-    [$owner, $team] = panelTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $selfDm = app(OpenDirectMessage::class)->handle($team, $owner, $owner);
     Message::factory()->for($selfDm)->for($owner)->create(['body' => 'note to self: quokka']);
 
@@ -324,7 +298,7 @@ test('a self direct message match shows the viewer their own name', function ():
 });
 
 test('the channel facet union spans every workspace the viewer belongs to', function (): void {
-    [$owner, $team, $general] = panelTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $otherTeam = app(CreateTeam::class)->handle($owner, 'Beta');
     $otherGeneral = Channel::where('team_id', $otherTeam->id)->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
 


### PR DESCRIPTION
Part of #1117 — slice **7**, batch 2. Independent of #1179 (no overlapping files); either can merge first.

Each of these seven files declared **two** clones: a `*TeamWithGeneral()` and an
`xMember(Team, Channel, ?string $name)` that adds someone to the team and the channel.
They become `teamWithChannel()` and `teamMemberInChannel()` from `tests/Helpers.php`.

## Why seven and not the remaining eleven

Batch 1 was a blanket substitution because all eleven helpers were byte-identical. Here
the member clone is the variable, and only seven of the eleven fold mechanically. The
other four each raise a real question and are deferred to batch 3 rather than being
waved through in a diff this size:

| file | why it is not in this batch |
| --- | --- |
| `ReadReceiptsTest` | `receiptsMember()` joins a **pre-existing** user; three call sites build it with the `withoutReadReceipts()` factory **state**, which `teamMemberInChannel()`'s attributes array cannot carry without naming `share_read_receipts` in the test |
| `CrossDeviceReadSyncTest` | same shape, same factory state |
| `MentionTest` | `teamMember()` joins the **team only**, not the channel — a different claim on its face (see the mutation note below, which settles it) |
| `CrossTeamSearchTest` | `addToTeam()` joins an existing user to a **second** team and returns that team's `#general`; the shared helper creates the user, so it cannot express this |

## What is in the diff

7 arrange declarations, 7 member declarations, 8 now-unused imports, and 97 call sites.
Every added line is one of two shapes:

```php
['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
$member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
```

`git diff -U0 | grep '^+'` filtered against that set comes back empty, so nothing rode
along. Every one of the 60 member call sites passed the same `($team, $general)` pair —
the pair `teamMemberInChannel()` derives from the channel itself — so no call site
changes meaning by dropping the team argument.

## Mutation check

Two shared helpers are load-bearing here, so both were mutated. 96 tests:

| mutation | red | files red |
| --- | --- | --- |
| D — `teamMemberInChannel`: the member is not joined to the channel | **0 / 96** | 0 |
| E — `teamMemberInChannel`: the member is not added to the team | 47 / 96 | 6 |
| F — `teamMemberInChannel`: the requested attributes are ignored | 3 / 96 | 2 |
| A — `teamWithChannel`: the owner is not in the returned channel | 11 / 96 | 3 |

E, F and A cover **all 7 files** between them.

**D killing nothing is the interesting one, and it is not a weakening.** Joining a team
auto-adds the user to `#general` through the membership observer, so the explicit channel
join is a no-op at every call site in this batch — all of which use `#general`. The
clones did the identical no-op (`channelMembers()->firstOrCreate(...)`), and the comment
inside the removed `unreadChannelMember()` said so in as many words. It is only
load-bearing for a channel that is *not* `#general`, which no test here uses.

That result also settles the `MentionTest` question above: on `#general`, "add to the
team" and "add to the team and the channel" are the same operation, so `teamMember()`
folds onto `teamMemberInChannel()` without weakening anything. It is still held back to
batch 3 so that claim can be reviewed on its own rather than inside a 97-call-site diff.

F is weak (3 red) because most `['name' => …]` arguments are there for readability rather
than for an assertion. Pre-existing — the clones passed the same value to the same
`User::factory()->create()`.

## Metrics

On this branch, measured off `develop`:

| metric | at filing | before | this branch | with #1179 too |
| --- | --- | --- | --- | --- |
| `grep -rn "TeamWithGeneral" tests/Feature` | 274 | 248 | **151** | **46** |
| files declaring a local `*TeamWithGeneral()` | 37 | 22 | **15** | **4** |
| `assertInertia` in `tests/Feature` | 258 | 243 | 243 | 243 |

`assertInertia` is unmoved by design: no renders disappear in a batch that only replaces
arranges.

## Testing

`./vendor/bin/sail composer test` green, `Total: 100.0 %`. No frontend files touched.
Local CodeRabbit pass: 0 findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788355459&installation_model_id=428379&pr_number=1181&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1181&signature=791d4f14cca941a9ffb29f41eb2d1391f00272a6f3e199666183d5dea2b6de07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->