### PR TITLE
test: finish the read-model sweep and retire the page-plucking helpers

### DIFF
--- a/tests/Feature/Channels/BrowseAndJoinChannelTest.php
+++ b/tests/Feature/Channels/BrowseAndJoinChannelTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Actions\Channels\JoinChannel;
-use App\Actions\Teams\CreateTeam;
 use App\Enums\MessageType;
 use App\Events\MessageSent;
 use App\Models\Channel;
@@ -10,8 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Inertia\Testing\AssertableInertia as Assert;
 
 test('browsing lists joinable public channels only', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
 
     $joinable = Channel::factory()->for($team)->create(['name' => 'Marketing', 'slug' => 'marketing']);
     Channel::factory()->for($team)->private()->create(['name' => 'Secret', 'slug' => 'secret']);
@@ -30,9 +28,8 @@ test('browsing lists joinable public channels only', function (): void {
 });
 
 test('browsing does not leak channels from other teams', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $otherTeam = app(CreateTeam::class)->handle(User::factory()->create(), 'Globex');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
+    ['team' => $otherTeam] = teamWithChannel('Globex');
     Channel::factory()->for($otherTeam)->create(['name' => 'Marketing', 'slug' => 'marketing']);
 
     $this->actingAs($user)
@@ -42,8 +39,7 @@ test('browsing does not leak channels from other teams', function (): void {
 });
 
 test('a team member can join a public channel', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['name' => 'Marketing', 'slug' => 'marketing']);
 
     $this->actingAs($user)
@@ -54,8 +50,7 @@ test('a team member can join a public channel', function (): void {
 });
 
 test('joining a channel is idempotent', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['slug' => 'marketing']);
     app(JoinChannel::class)->handle($channel, $user);
 
@@ -67,8 +62,7 @@ test('joining a channel is idempotent', function (): void {
 });
 
 test('joining a channel posts a member_joined system notice authored by the joiner', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['slug' => 'marketing']);
 
     app(JoinChannel::class)->handle($channel, $user);
@@ -81,8 +75,7 @@ test('joining a channel posts a member_joined system notice authored by the join
 });
 
 test('re-joining a channel posts no second notice', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['slug' => 'marketing']);
 
     app(JoinChannel::class)->handle($channel, $user);
@@ -94,8 +87,7 @@ test('re-joining a channel posts no second notice', function (): void {
 test('the join notice broadcasts MessageSent so it appears live', function (): void {
     Event::fake([MessageSent::class]);
 
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['slug' => 'marketing']);
 
     app(JoinChannel::class)->handle($channel, $user);
@@ -105,8 +97,7 @@ test('the join notice broadcasts MessageSent so it appears live', function (): v
 });
 
 test('a private channel cannot be joined by browsing', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
 
     $this->actingAs($user)
@@ -117,8 +108,7 @@ test('a private channel cannot be joined by browsing', function (): void {
 });
 
 test('an archived channel cannot be joined', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->archived()->create(['slug' => 'old']);
 
     $this->actingAs($user)
@@ -127,9 +117,8 @@ test('an archived channel cannot be joined', function (): void {
 });
 
 test('a non-team-member cannot join a channel', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->create(['slug' => 'marketing']);
 
     $this->actingAs($outsider)

--- a/tests/Feature/Channels/ChannelDraftTest.php
+++ b/tests/Feature/Channels/ChannelDraftTest.php
@@ -10,20 +10,13 @@ use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 
 /**
- * Resolve the sidebar `channels` prop entry for the channel as the acting user.
+ * The sidebar `channels` row for the channel, as the acting user.
  *
  * @return array<string, mixed>
  */
 function draftSidebarEntry(User $user, Team $team, Channel $channel): array
 {
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
-
-    $channels = $response->viewData('page')['props']['channels'];
-
-    return collect($channels)->firstWhere('slug', $channel->slug);
+    return sidebarRow($user, $team, $channel)->toArray();
 }
 
 /**

--- a/tests/Feature/Channels/ChannelPlacementTest.php
+++ b/tests/Feature/Channels/ChannelPlacementTest.php
@@ -1,29 +1,26 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ChannelVisibility;
-use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\ChannelSection;
 use App\Models\Team;
 use App\Models\User;
-use Illuminate\Support\Collection;
+use App\Support\SidebarChannels;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function placementTeam(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
+/*
+|--------------------------------------------------------------------------
+| Channel placement (#1117)
+|--------------------------------------------------------------------------
+|
+| The endpoint that files a channel under a section and reorders the sidebar,
+| and who may reach it. What the sidebar then renders off those two columns is
+| stated against `SidebarChannels` in
+| `tests/Integration/Support/SidebarChannelsTest.php`, so the one claim left
+| here that reaches past the pivot reads the read-model rather than a page.
+|
+*/
 
 /**
  * Create a public channel in the team the user is a member of.
@@ -36,7 +33,7 @@ function placementChannel(User $user, Team $team, string $name): Channel
         'visibility' => ChannelVisibility::Public,
         'created_by' => $user->id,
     ]);
-    $channel->channelMembers()->create(['user_id' => $user->id]);
+    channelMembership($channel, $user);
 
     return $channel;
 }
@@ -54,23 +51,8 @@ function placeChannel(User $user, Team $team, Channel $channel, array $payload):
     ]), $payload);
 }
 
-/**
- * The acting user's sidebar `channels` prop, keyed by slug.
- *
- * @return Collection<string, array<string, mixed>>
- */
-function placementSidebar(User $user, Team $team, Channel $channel): Collection
-{
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
-
-    return collect($response->viewData('page')['props']['channels'])->keyBy('slug');
-}
-
 test('a member can move a channel into a custom section', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
     placeChannel($owner, $team, $general, [
@@ -85,12 +67,10 @@ test('a member can move a channel into a custom section', function (): void {
         'position' => 0,
     ]);
 
-    expect(placementSidebar($owner, $team, $general)[$general->slug])
-        ->toMatchArray(['sectionId' => $section->id, 'position' => 0]);
 });
 
 test('a member can move a channel back to the default group with a null section', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
 
@@ -107,7 +87,7 @@ test('a member can move a channel back to the default group with a null section'
 });
 
 test('a pure reorder leaves the section assignment untouched', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
 
@@ -124,7 +104,7 @@ test('a pure reorder leaves the section assignment untouched', function (): void
 });
 
 test('reordering persists channel positions and drives the sidebar order', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $alpha = placementChannel($owner, $team, 'Alpha');
     $beta = placementChannel($owner, $team, 'Beta');
 
@@ -137,15 +117,13 @@ test('reordering persists channel positions and drives the sidebar order', funct
         ->and($alpha->fresh()->channelMembers()->where('user_id', $owner->id)->value('position'))->toBe(1)
         ->and($general->fresh()->channelMembers()->where('user_id', $owner->id)->value('position'))->toBe(2);
 
-    $order = placementSidebar($owner, $team, $general)->keys()->all();
-    expect($order)->toBe(['beta', 'alpha', 'general']);
+    expect(array_column(new SidebarChannels($owner, $team)->forSidebar(), 'slug'))
+        ->toBe(['beta', 'alpha', 'general']);
 });
 
 test('placement only touches the acting user own rows', function (): void {
-    [$owner, $team, $general] = placementTeam();
-    $member = User::factory()->create();
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
-    $general->channelMembers()->firstOrCreate(['user_id' => $member->id]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     placeChannel($owner, $team, $general, [
         'ordered_ids' => [$general->id],
@@ -157,7 +135,7 @@ test('placement only touches the acting user own rows', function (): void {
 });
 
 test('a member cannot place a channel into another user section', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $other = User::factory()->create();
     $theirs = ChannelSection::factory()->for($other)->for($team)->create();
 
@@ -168,13 +146,12 @@ test('a member cannot place a channel into another user section', function (): v
 });
 
 test('a non-member cannot place a channel', function (): void {
-    [$owner, $team] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
         'created_by' => $owner->id,
     ]);
-    $stranger = User::factory()->create();
-    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+    $stranger = teamMemberInChannel($general);
 
     placeChannel($stranger, $team, $private, [
         'ordered_ids' => [$private->id],
@@ -182,13 +159,13 @@ test('a non-member cannot place a channel', function (): void {
 });
 
 test('placement requires the ordered ids payload', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     placeChannel($owner, $team, $general, [])->assertSessionHasErrors('ordered_ids');
 });
 
 test('placement rejects a channel id the user does not belong to', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $foreign = Channel::factory()->for($team)->create();
 
     placeChannel($owner, $team, $general, [
@@ -197,7 +174,7 @@ test('placement rejects a channel id the user does not belong to', function (): 
 });
 
 test('a guest cannot place a channel', function (): void {
-    [$owner, $team, $general] = placementTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->patch(route('channels.placement.update', ['team' => $team->slug, 'channel' => $general->slug]), [
         'ordered_ids' => [$general->id],

--- a/tests/Feature/Channels/ChannelPolicyTest.php
+++ b/tests/Feature/Channels/ChannelPolicyTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\ChannelCreationPolicy;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
@@ -8,16 +7,13 @@ use App\Models\Channel;
 use App\Models\User;
 
 test('the #general channel cannot be archived by anyone', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
 
     expect($owner->can('archive', $general))->toBeFalse();
 });
 
 test('the channel creator can archive a regular channel', function (): void {
-    $creator = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($creator, 'Acme');
+    ['owner' => $creator, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create([
         'created_by' => $creator->id,
         'visibility' => 'public',
@@ -27,10 +23,8 @@ test('the channel creator can archive a regular channel', function (): void {
 });
 
 test('a plain member who did not create a channel cannot archive it', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create([
         'created_by' => $owner->id,
@@ -41,18 +35,14 @@ test('a plain member who did not create a channel cannot archive it', function (
 });
 
 test('the #general channel cannot be deleted by anyone', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
 
     expect($owner->can('delete', $general))->toBeFalse();
 });
 
 test('a team admin can delete a regular channel they did not create', function (): void {
-    $owner = User::factory()->create();
-    $admin = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
 
     $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
 
@@ -60,10 +50,8 @@ test('a team admin can delete a regular channel they did not create', function (
 });
 
 test('an admin can restore a deleted channel but has nothing to restore on a live one', function (): void {
-    $owner = User::factory()->create();
-    $admin = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
 
     $channel = Channel::factory()->for($team)->create();
 
@@ -75,10 +63,8 @@ test('an admin can restore a deleted channel but has nothing to restore on a liv
 });
 
 test('a plain member cannot restore a deleted channel', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create();
     $channel->delete();
@@ -87,59 +73,50 @@ test('a plain member cannot restore a deleted channel', function (): void {
 });
 
 test('a user who is not a team member cannot archive a channel', function (): void {
-    $owner = User::factory()->create();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
 
     expect($outsider->can('archive', $channel))->toBeFalse();
 });
 
 test('an already-archived channel cannot be archived again', function (): void {
-    $creator = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($creator, 'Acme');
+    ['owner' => $creator, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->archived()->create(['created_by' => $creator->id]);
 
     expect($creator->can('archive', $channel))->toBeFalse();
 });
 
 test('a team member can view a public channel but a non-member cannot', function (): void {
-    $owner = User::factory()->create();
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
 
     expect($owner->can('view', $general))->toBeTrue()
         ->and($outsider->can('view', $general))->toBeFalse();
 });
 
 test('a private channel is only viewable by its members', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $private = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
-    $private->channelMembers()->create(['user_id' => $owner->id]);
+    channelMembership($private, $owner);
 
     expect($owner->can('view', $private))->toBeTrue()
         ->and($member->can('view', $private))->toBeFalse();
 });
 
 test('any team member can create a channel but an outsider cannot', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
 
     expect($member->can('create', [Channel::class, $team]))->toBeTrue()
         ->and($outsider->can('create', [Channel::class, $team]))->toBeFalse();
 });
 
 test('a public channel is joinable by a team member but a private one is not', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $public = Channel::factory()->for($team)->create();
     $private = Channel::factory()->for($team)->private()->create();
 
@@ -148,25 +125,20 @@ test('a public channel is joinable by a team member but a private one is not', f
 });
 
 test('an archived public channel is not joinable', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $archived = Channel::factory()->for($team)->archived()->create();
 
     expect($owner->can('join', $archived))->toBeFalse();
 });
 
 test('a private channel member or admin may manage its membership', function (): void {
-    $owner = User::factory()->create();
-    $channelMember = User::factory()->create();
-    $admin = User::factory()->create();
-    $plainMember = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $channelMember->id, 'role' => TeamRole::Member]);
-    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
-    $team->memberships()->create(['user_id' => $plainMember->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $channelMember = teamMemberInChannel($general);
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
+    $plainMember = teamMemberInChannel($general);
 
     $private = Channel::factory()->for($team)->private()->create();
-    $private->channelMembers()->create(['user_id' => $channelMember->id]);
+    channelMembership($private, $channelMember);
 
     expect($channelMember->can('addMember', $private))->toBeTrue()
         ->and($admin->can('addMember', $private))->toBeTrue()
@@ -176,13 +148,11 @@ test('a private channel member or admin may manage its membership', function ():
 });
 
 test('only channel members may post a message', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create();
-    $channel->channelMembers()->create(['user_id' => $owner->id]);
+    channelMembership($channel, $owner);
 
     // $owner is a channel member; $member belongs to the team but not the channel.
     expect($owner->can('postMessage', $channel))->toBeTrue()
@@ -190,28 +160,25 @@ test('only channel members may post a message', function (): void {
 });
 
 test('a channel member cannot post to an archived channel', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->archived()->create();
-    $channel->channelMembers()->create(['user_id' => $owner->id]);
+    channelMembership($channel, $owner);
 
     expect($owner->can('postMessage', $channel))->toBeFalse();
 });
 
 test('membership cannot be managed on a public channel', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $public = Channel::factory()->for($team)->create();
-    $public->channelMembers()->create(['user_id' => $owner->id]);
+    channelMembership($public, $owner);
 
     expect($owner->can('addMember', $public))->toBeFalse()
         ->and($owner->can('removeMember', $public))->toBeFalse();
 });
 
 test('a non-team-member cannot manage a private channel membership', function (): void {
-    $owner = User::factory()->create();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $private = Channel::factory()->for($team)->private()->create();
 
     expect($outsider->can('addMember', $private))->toBeFalse()
@@ -219,15 +186,13 @@ test('a non-team-member cannot manage a private channel membership', function ()
 });
 
 test('changing your own membership is granted only to channel members', function (): void {
-    $channelMember = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($channelMember, 'Acme');
+    ['owner' => $channelMember, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create();
-    $channel->channelMembers()->create(['user_id' => $channelMember->id]);
+    channelMembership($channel, $channelMember);
 
     // A team member who never joined this channel — the team branch of the
     // shared isMember predicate is true, the membership branch is false.
-    $teamMember = User::factory()->create();
-    $team->memberships()->create(['user_id' => $teamMember->id, 'role' => TeamRole::Member]);
+    $teamMember = teamMemberInChannel($general);
 
     // An outsider who does not belong to the team at all — the team branch is
     // false, so the predicate short-circuits before touching membership.
@@ -239,20 +204,16 @@ test('changing your own membership is granted only to channel members', function
 });
 
 test('any team member may create either kind of channel while both policies stay open', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     expect($member->can('create', [Channel::class, $team, ChannelVisibility::Public]))->toBeTrue()
         ->and($member->can('create', [Channel::class, $team, ChannelVisibility::Private]))->toBeTrue();
 });
 
 test('reserving public channels for admins leaves private channels open to members', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $team->update(['public_channel_creation_policy' => ChannelCreationPolicy::Admins]);
 
     expect($member->can('create', [Channel::class, $team, ChannelVisibility::Public]))->toBeFalse()
@@ -261,10 +222,8 @@ test('reserving public channels for admins leaves private channels open to membe
 });
 
 test('reserving private channels for admins leaves public channels open to members', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $team->update(['private_channel_creation_policy' => ChannelCreationPolicy::Admins]);
 
     expect($member->can('create', [Channel::class, $team, ChannelVisibility::Private]))->toBeFalse()
@@ -273,19 +232,16 @@ test('reserving private channels for admins leaves public channels open to membe
 });
 
 test('an outsider can never create a channel however open the policies are', function (): void {
-    $owner = User::factory()->create();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
     expect($outsider->can('create', [Channel::class, $team, ChannelVisibility::Public]))->toBeFalse()
         ->and($outsider->can('create', [Channel::class, $team]))->toBeFalse();
 });
 
 test('asking without a visibility answers whether either kind of channel is creatable', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     expect($member->can('create', [Channel::class, $team]))->toBeTrue();
 

--- a/tests/Feature/Channels/ChannelPreferenceTest.php
+++ b/tests/Feature/Channels/ChannelPreferenceTest.php
@@ -27,20 +27,13 @@ function prefPost(Channel $channel, User $author, ?User $mention = null): Messag
 }
 
 /**
- * Resolve the sidebar `channels` prop entry for the channel as the acting user.
+ * The sidebar `channels` row for the channel, as the acting user.
  *
  * @return array<string, mixed>
  */
 function prefSidebarEntry(User $user, Team $team, Channel $channel): array
 {
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
-
-    $channels = $response->viewData('page')['props']['channels'];
-
-    return collect($channels)->firstWhere('slug', $channel->slug);
+    return sidebarRow($user, $team, $channel)->toArray();
 }
 
 /**

--- a/tests/Feature/Channels/ChannelStarTest.php
+++ b/tests/Feature/Channels/ChannelStarTest.php
@@ -8,20 +8,13 @@ use App\Models\User;
 use Illuminate\Testing\TestResponse;
 
 /**
- * Resolve the sidebar `channels` prop entry for the channel as the acting user.
+ * The sidebar `channels` row for the channel, as the acting user.
  *
  * @return array<string, mixed>
  */
 function starSidebarEntry(User $user, Team $team, Channel $channel): array
 {
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
-
-    $channels = $response->viewData('page')['props']['channels'];
-
-    return collect($channels)->firstWhere('slug', $channel->slug);
+    return sidebarRow($user, $team, $channel)->toArray();
 }
 
 /**

--- a/tests/Feature/Channels/ChannelTest.php
+++ b/tests/Feature/Channels/ChannelTest.php
@@ -35,9 +35,8 @@ test('the team owner is auto-joined to #general on team creation', function (): 
 });
 
 test('a new team member is auto-joined to #general when accepting an invitation', function (): void {
-    $owner = User::factory()->create();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
     $invitation = TeamInvitation::factory()->create([
         'team_id' => $team->id,
@@ -48,15 +47,11 @@ test('a new team member is auto-joined to #general when accepting an invitation'
 
     $this->actingAs($invitedUser)->get(route('invitations.accept', $invitation));
 
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
     expect($general->members()->whereKey($invitedUser->id)->exists())->toBeTrue();
 });
 
 test('the channel page lists the current user\'s channels in the sidebar', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
@@ -71,8 +66,7 @@ test('the channel page lists the current user\'s channels in the sidebar', funct
 });
 
 test('the CreateChannel action creates a channel, strips a leading # and joins the creator', function (): void {
-    $creator = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($creator, 'Acme');
+    ['owner' => $creator, 'team' => $team] = teamWithChannel();
 
     $channel = app(CreateChannel::class)->handle($team, '#Marketing', ChannelVisibility::Private, $creator);
 
@@ -84,8 +78,7 @@ test('the CreateChannel action creates a channel, strips a leading # and joins t
 });
 
 test('a bare team URL redirects to the #general channel', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($user)
         ->get(route('channels.index', ['team' => $team->slug]))
@@ -93,8 +86,7 @@ test('a bare team URL redirects to the #general channel', function (): void {
 });
 
 test('a bare team URL carries its query string onto #general so a ?nav= deep link survives', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($user)
         ->get(route('channels.index', ['team' => $team->slug]).'?nav=search&q=budget')
@@ -107,8 +99,7 @@ test('a bare team URL carries its query string onto #general so a ?nav= deep lin
 });
 
 test('a bare team URL cannot be sent to another channel through its query string', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    ['owner' => $user, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($user)
         ->get(route('channels.index', ['team' => $team->slug]).'?channel=elsewhere')
@@ -116,9 +107,7 @@ test('a bare team URL cannot be sent to another channel through its query string
 });
 
 test('a member viewing a public channel is marked isMember with the channel member count', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
@@ -130,10 +119,8 @@ test('a member viewing a public channel is marked isMember with the channel memb
 });
 
 test('a non-member viewing a public channel is marked not isMember so the join CTA renders', function (): void {
-    $owner = User::factory()->create();
-    $viewer = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $viewer->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $viewer = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create(['name' => 'Design', 'slug' => 'design']);
     app(JoinChannel::class)->handle($channel, $owner);
@@ -149,10 +136,8 @@ test('a non-member viewing a public channel is marked not isMember so the join C
 });
 
 test('joining a public channel from its view adds membership and makes the composer available', function (): void {
-    $owner = User::factory()->create();
-    $viewer = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $viewer->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $viewer = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create(['slug' => 'design']);
 
@@ -166,9 +151,8 @@ test('joining a public channel from its view adds membership and makes the compo
 });
 
 test('a user who is not a team member cannot view the team\'s channels', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
     $this->actingAs($outsider)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'general']))
@@ -176,9 +160,7 @@ test('a user who is not a team member cannot view the team\'s channels', functio
 });
 
 test('the channel page exposes the viewer\'s read pointer for the new-messages divider', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $messages = Message::factory()->count(3)->for($general)->for($user)->create();
     $user->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $messages[1]->id]);
@@ -192,9 +174,7 @@ test('the channel page exposes the viewer\'s read pointer for the new-messages d
 });
 
 test('the read pointer is null on a channel the viewer has never read', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     Message::factory()->for($general)->for($user)->create();
 
@@ -205,9 +185,7 @@ test('the read pointer is null on a channel the viewer has never read', function
 });
 
 test('opening a channel with more unread than a page windows the initial page around the read boundary', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     // Authorship is irrelevant to the id-based window; only the read pointer is.
     $messages = collect(range(1, 100))->map(
@@ -232,9 +210,7 @@ test('opening a channel with more unread than a page windows the initial page ar
 });
 
 test('opening a channel with unread within a page keeps the default newest window', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $messages = collect(range(1, 60))->map(
         fn (int $i) => Message::factory()->for($general)->for($user)->create(['body' => "message {$i}"])
@@ -256,9 +232,7 @@ test('opening a channel with unread within a page keeps the default newest windo
 });
 
 test('a never-read channel with a long backlog still opens at newest', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     // Auto-joined with a null read pointer: there is no last-read boundary to
     // anchor, so #76 deliberately leaves the default newest window in place
@@ -278,9 +252,7 @@ test('a never-read channel with a long backlog still opens at newest', function 
 });
 
 test('a fully-read channel opens at newest without a window', function (): void {
-    $user = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($user, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $messages = collect(range(1, 60))->map(
         fn (int $i) => Message::factory()->for($general)->for($user)->create(['body' => "message {$i}"])

--- a/tests/Feature/Channels/CreateChannelTest.php
+++ b/tests/Feature/Channels/CreateChannelTest.php
@@ -8,8 +8,7 @@ use App\Models\Channel;
 use App\Models\User;
 
 test('a team member can create a channel and is redirected to it', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.store', ['team' => $team->slug]), [
@@ -30,10 +29,8 @@ test('a team member can create a channel and is redirected to it', function (): 
 });
 
 test('a plain team member can create a channel', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $this->actingAs($member)
         ->post(route('channels.store', ['team' => $team->slug]), [
@@ -46,8 +43,7 @@ test('a plain team member can create a channel', function (): void {
 });
 
 test('a channel name must be unique within the team', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     Channel::factory()->for($team)->create(['name' => 'Marketing', 'slug' => 'marketing']);
 
     $this->actingAs($owner)
@@ -61,8 +57,9 @@ test('a channel name must be unique within the team', function (): void {
 });
 
 test('the same channel name may exist in different teams', function (): void {
-    $owner = User::factory()->create();
-    $teamA = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $teamA] = teamWithChannel('Acme');
+    // The second team is the same owner's, so the claim is about the team the
+    // channel lands in and not about who is asking.
     $teamB = app(CreateTeam::class)->handle($owner, 'Globex');
     Channel::factory()->for($teamA)->create(['name' => 'Marketing', 'slug' => 'marketing']);
 
@@ -77,8 +74,7 @@ test('the same channel name may exist in different teams', function (): void {
 });
 
 test('a channel named in a non-Latin script stays reachable', function (string $name): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.store', ['team' => $team->slug]), [
@@ -103,8 +99,7 @@ test('a channel named in a non-Latin script stays reachable', function (string $
 ]);
 
 test('two channels named in a non-Latin script coexist in one team', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     foreach (['日本語', '中文'] as $name) {
         $this->actingAs($owner)
@@ -122,8 +117,7 @@ test('two channels named in a non-Latin script coexist in one team', function ()
 });
 
 test('a repeated non-Latin channel name is still reported as already existing', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.store', ['team' => $team->slug]), [
@@ -143,8 +137,7 @@ test('a repeated non-Latin channel name is still reported as already existing', 
 });
 
 test('creating a channel requires a valid visibility', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.store', ['team' => $team->slug]), [
@@ -155,8 +148,7 @@ test('creating a channel requires a valid visibility', function (): void {
 });
 
 test('creating a channel requires a name', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($owner)
         ->post(route('channels.store', ['team' => $team->slug]), [
@@ -167,9 +159,8 @@ test('creating a channel requires a name', function (): void {
 });
 
 test('a user who is not a team member cannot create a channel', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team] = teamWithChannel();
     $outsider = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
     $this->actingAs($outsider)
         ->post(route('channels.store', ['team' => $team->slug]), [
@@ -182,10 +173,8 @@ test('a user who is not a team member cannot create a channel', function (): voi
 });
 
 test('a plain member is refused the visibility their workspace reserves for admins', function (string $reserved, string $stillOpen): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $team->update([$reserved.'_channel_creation_policy' => ChannelCreationPolicy::Admins]);
 
     $this->actingAs($member)
@@ -212,10 +201,8 @@ test('a plain member is refused the visibility their workspace reserves for admi
 ]);
 
 test('an admin still creates the visibility the workspace reserves for admins', function (): void {
-    $owner = User::factory()->create();
-    $admin = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
     $team->update(['public_channel_creation_policy' => ChannelCreationPolicy::Admins]);
 
     $this->actingAs($admin)

--- a/tests/Feature/Channels/CrossDeviceReadSyncTest.php
+++ b/tests/Feature/Channels/CrossDeviceReadSyncTest.php
@@ -2,47 +2,19 @@
 
 use App\Actions\Channels\MarkChannelRead;
 use App\Actions\Channels\OpenDirectMessage;
-use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
 use App\Events\MessageRead;
 use App\Events\ReadStateAdvanced;
-use App\Models\Channel;
 use App\Models\Message;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Support\Facades\Event;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function readSyncTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and the given channel, returning them.
- */
-function readSyncMember(Team $team, Channel $channel, User $user): User
-{
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
-
 test('advancing the read pointer signals the reader other devices', function (): void {
     Event::fake([ReadStateAdvanced::class]);
 
-    [$owner, $team, $general] = readSyncTeamWithGeneral();
-    $member = readSyncMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     Message::factory()->for($general)->for($owner)->create();
 
@@ -55,8 +27,8 @@ test('advancing the read pointer signals the reader other devices', function ():
 test('a reader who hides read receipts still syncs their own devices', function (): void {
     Event::fake([ReadStateAdvanced::class, MessageRead::class]);
 
-    [$owner, $team, $general] = readSyncTeamWithGeneral();
-    $member = readSyncMember($team, $general, User::factory()->withoutReadReceipts()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = joinTeamAndChannel($general, User::factory()->withoutReadReceipts()->create());
 
     Message::factory()->for($general)->for($owner)->create();
 
@@ -71,8 +43,8 @@ test('a reader who hides read receipts still syncs their own devices', function 
 test('a read that advances nothing signals nothing', function (): void {
     Event::fake([ReadStateAdvanced::class]);
 
-    [$owner, $team, $general] = readSyncTeamWithGeneral();
-    $member = readSyncMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     Message::factory()->for($general)->for($owner)->create();
 
@@ -88,8 +60,8 @@ test('a read that advances nothing signals nothing', function (): void {
 test('a read with nothing to point at signals nothing', function (): void {
     Event::fake([ReadStateAdvanced::class]);
 
-    [$owner, $team, $general] = readSyncTeamWithGeneral();
-    $member = readSyncMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $outsider = User::factory()->create();
     $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
     $general->channelMembers()->where('user_id', $outsider->id)->delete();
@@ -108,8 +80,8 @@ test('a read with nothing to point at signals nothing', function (): void {
 test('the read endpoint signals the reader other devices for a channel', function (): void {
     Event::fake([ReadStateAdvanced::class]);
 
-    [$owner, $team, $general] = readSyncTeamWithGeneral();
-    $member = readSyncMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     Message::factory()->for($general)->for($owner)->create();
 
@@ -124,8 +96,8 @@ test('the read endpoint signals the reader other devices for a channel', functio
 test('the read endpoint signals the reader other devices for a direct message', function (): void {
     Event::fake([ReadStateAdvanced::class]);
 
-    [$owner, $team, $general] = readSyncTeamWithGeneral();
-    $member = readSyncMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $dm = app(OpenDirectMessage::class)->handle($team, $owner, $member);
     Message::factory()->for($dm)->for($owner)->create();
@@ -141,8 +113,8 @@ test('the read endpoint signals the reader other devices for a direct message', 
 test('the signal skips the very device that did the reading', function (): void {
     Event::fake([ReadStateAdvanced::class]);
 
-    [$owner, $team, $general] = readSyncTeamWithGeneral();
-    $member = readSyncMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     Message::factory()->for($general)->for($owner)->create();
 

--- a/tests/Feature/Channels/CrossTeamSearchTest.php
+++ b/tests/Feature/Channels/CrossTeamSearchTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\NavDestination;
-use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
@@ -10,32 +8,6 @@ use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Testing\TestResponse;
 use Inertia\Testing\AssertableInertia as Assert;
-
-/**
- * Create a team owned by a fresh user with its #general channel.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function crossTeamWithGeneral(string $name): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, $name);
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add an existing user to a team and its #general, returning the channel.
- */
-function addToTeam(User $user, Team $team): Channel
-{
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-    $team->memberships()->firstOrCreate(['user_id' => $user->id], ['role' => TeamRole::Member]);
-    $general->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $general;
-}
 
 /**
  * Open the Search destination on the team's #general with the given facets.
@@ -54,9 +26,9 @@ function crossTeamSearch(User $user, Team $team, array $params): TestResponse
 }
 
 test('memberChannelIdsAcrossTeams unions the channels of every team the user is in but never one they are not in', function (): void {
-    [$member, $teamA, $generalA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
-    $generalB = addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA, 'channel' => $generalA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
     // A private channel in team B the member is NOT a member of.
     $privateB = Channel::factory()->for($teamB)->private()->create(['created_by' => $ownerB->id]);
 
@@ -70,9 +42,9 @@ test('memberChannelIdsAcrossTeams unions the channels of every team the user is 
 });
 
 test('scope=all searches the union of the user teams', function (): void {
-    [$member, $teamA, $generalA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
-    $generalB = addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA, 'channel' => $generalA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
     Message::factory()->for($generalA)->for($member)->create(['body' => 'zephyr in acme']);
     Message::factory()->for($generalB)->for($ownerB)->create(['body' => 'zephyr in beta']);
 
@@ -81,9 +53,9 @@ test('scope=all searches the union of the user teams', function (): void {
 });
 
 test('scope=team stays within the current team', function (): void {
-    [$member, $teamA, $generalA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
-    $generalB = addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA, 'channel' => $generalA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
     Message::factory()->for($generalA)->for($member)->create(['body' => 'zephyr in acme']);
     Message::factory()->for($generalB)->for($ownerB)->create(['body' => 'zephyr in beta']);
 
@@ -95,9 +67,9 @@ test('scope=team stays within the current team', function (): void {
 });
 
 test('scope defaults to the current team when omitted', function (): void {
-    [$member, $teamA, $generalA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
-    $generalB = addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA, 'channel' => $generalA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
     Message::factory()->for($generalA)->for($member)->create(['body' => 'zephyr in acme']);
     Message::factory()->for($generalB)->for($ownerB)->create(['body' => 'zephyr in beta']);
 
@@ -106,8 +78,8 @@ test('scope defaults to the current team when omitted', function (): void {
 });
 
 test('scope=all never surfaces a team the user does not belong to', function (): void {
-    [$member, $teamA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB, $generalB] = crossTeamWithGeneral('Beta');
+    ['owner' => $member, 'team' => $teamA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'channel' => $generalB] = teamWithChannel('Beta');
     // The member is NOT in team B.
     Message::factory()->for($generalB)->for($ownerB)->create(['body' => 'zephyr in beta']);
 
@@ -116,9 +88,9 @@ test('scope=all never surfaces a team the user does not belong to', function ():
 });
 
 test('scope=all never leaks a private channel the user is not in', function (): void {
-    [$member, $teamA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
-    addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
     $privateB = Channel::factory()->for($teamB)->private()->create(['created_by' => $ownerB->id]);
     Message::factory()->for($privateB)->for($ownerB)->create(['body' => 'secret zephyr']);
 
@@ -127,9 +99,9 @@ test('scope=all never leaks a private channel the user is not in', function (): 
 });
 
 test('a cross-team result carries its own team for tagging and jump links', function (): void {
-    [$member, $teamA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
-    $generalB = addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
     Message::factory()->for($generalB)->for($ownerB)->create(['body' => 'zephyr in beta']);
 
     crossTeamSearch($member, $teamA, ['q' => 'zephyr', 'scope' => 'all'])
@@ -142,9 +114,9 @@ test('a cross-team result carries its own team for tagging and jump links', func
 });
 
 test('an unknown scope falls back to the current team', function (): void {
-    [$member, $teamA, $generalA] = crossTeamWithGeneral('Acme');
-    [$ownerB, $teamB] = crossTeamWithGeneral('Beta');
-    $generalB = addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA, 'channel' => $generalA] = teamWithChannel('Acme');
+    ['owner' => $ownerB, 'team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
     Message::factory()->for($generalA)->for($member)->create(['body' => 'zephyr in acme']);
     Message::factory()->for($generalB)->for($ownerB)->create(['body' => 'zephyr in beta']);
 
@@ -156,9 +128,9 @@ test('an unknown scope falls back to the current team', function (): void {
 });
 
 test('the panel exposes the cross-team channel union for the global-mode facet', function (): void {
-    [$member, $teamA, $generalA] = crossTeamWithGeneral('Acme');
-    [, $teamB] = crossTeamWithGeneral('Beta');
-    $generalB = addToTeam($member, $teamB);
+    ['owner' => $member, 'team' => $teamA, 'channel' => $generalA] = teamWithChannel('Acme');
+    ['team' => $teamB, 'channel' => $generalB] = teamWithChannel('Beta');
+    joinTeamAndChannel($generalB, $member);
 
     crossTeamSearch($member, $teamA, ['q' => 'zephyr', 'scope' => 'all'])
         ->assertInertia(fn (Assert $page): Assert => $page

--- a/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
+++ b/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
@@ -9,21 +9,22 @@ use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Collection;
+use Inertia\Testing\AssertableInertia as Assert;
 
 /**
- * The `teams` shared prop entry for the given team, as the acting user sees it
- * from inside their current workspace.
+ * The workspace-switcher entry for the given team, as the viewer sees it.
+ *
+ * Read off `User::toUserTeams()`, which is what `share()` hands the `teams`
+ * prop, rather than by rendering a page to pluck that prop back out (#1117).
+ * The HTTP half — that a workspace render still ships it — is stated once, in
+ * the last test in this file.
  *
  * @return array{unreadCount: int, mentionCount: int}
  */
 function workspaceBadge(User $user, Team $team): array
 {
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $user->currentTeam->slug,
-        'channel' => Channel::GENERAL_SLUG,
-    ]))->assertOk();
-
-    $entry = collect($response->viewData('page')['props']['teams'])->firstWhere('id', $team->id);
+    $entry = collect($user->toUserTeams(includeCurrent: true))->firstWhere('id', $team->id);
 
     expect($entry)->toBeInstanceOf(UserTeam::class);
 
@@ -38,12 +39,9 @@ function workspaceBadge(User $user, Team $team): array
  */
 function otherWorkspace(User $viewer): array
 {
-    $author = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($author, 'Nord & Bureau');
-    $general = Channel::where('team_id', $team->id)->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+    ['owner' => $author, 'team' => $team, 'channel' => $general] = teamWithChannel('Nord & Bureau');
 
-    $team->memberships()->create(['user_id' => $viewer->id, 'role' => TeamRole::Member]);
-    $general->channelMembers()->firstOrCreate(['user_id' => $viewer->id]);
+    joinTeamAndChannel($general, $viewer);
 
     return [$team, $general, $author];
 }
@@ -218,4 +216,25 @@ test('another member unread traffic never leaks into the viewer counts', functio
 
     expect(workspaceBadge($viewer, $team))
         ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 0]);
+});
+
+test('a workspace render ships the switcher its badge counts', function (): void {
+    ['owner' => $viewer, 'team' => $home, 'channel' => $homeGeneral] = teamWithChannel('Home');
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author, $viewer);
+
+    $badge = workspaceBadge($viewer, $team);
+    expect($badge)->toMatchArray(['unreadCount' => 1, 'mentionCount' => 1]);
+
+    // The one HTTP claim the `teams` prop needs: a render still carries the
+    // switcher, with the counts the read-model above is asserted on.
+    $this->actingAs($viewer)
+        ->get(route('channels.show', ['team' => $home->slug, 'channel' => $homeGeneral->slug]))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('teams', fn (Collection $teams): bool => $teams->contains(
+                fn (array $entry): bool => $entry['id'] === $team->id
+                    && $entry['unreadCount'] === $badge['unreadCount']
+                    && $entry['mentionCount'] === $badge['mentionCount']))
+            ->etc());
 });

--- a/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
+++ b/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Data\UserTeam;
 use App\Enums\MessageType;
 use App\Enums\NotificationLevel;

--- a/tests/Feature/Channels/MentionTest.php
+++ b/tests/Feature/Channels/MentionTest.php
@@ -1,39 +1,10 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Data\MessageData;
-use App\Enums\TeamRole;
-use App\Models\Channel;
 use App\Models\Message;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
-
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function mentionTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team as a plain member and return them.
- */
-function teamMember(Team $team, ?string $name = null): User
-{
-    $user = User::factory()->create($name ? ['name' => $name] : []);
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-
-    return $user;
-}
 
 /**
  * Build a mention token the composer inserts and the parser round-trips.
@@ -44,8 +15,8 @@ function mentionToken(User $user): string
 }
 
 test('posting a message persists a mention row for a real team member', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $mentioned = teamMember($team, 'Ada Lovelace');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $mentioned = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
 
     $this->actingAs($owner)
         ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -64,8 +35,8 @@ test('posting a message persists a mention row for a real team member', function
 });
 
 test('parsing resolves only real team members, ignoring non-members and unknown ids', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $member = teamMember($team, 'Real Member');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Real Member']);
     $stranger = User::factory()->create(['name' => 'Outsider']);
     $bogusId = (string) Str::uuid7();
 
@@ -85,8 +56,8 @@ test('parsing resolves only real team members, ignoring non-members and unknown 
 });
 
 test('a user mentioned twice in one message is persisted once', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $mentioned = teamMember($team);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $mentioned = teamMemberInChannel($general);
 
     $this->actingAs($owner)
         ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -99,9 +70,9 @@ test('a user mentioned twice in one message is persisted once', function (): voi
 });
 
 test('a mention token inside inline code does not notify', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $inCode = teamMember($team, 'Code Only');
-    $real = teamMember($team, 'Real Ping');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $inCode = teamMemberInChannel($general, ['name' => 'Code Only']);
+    $real = teamMemberInChannel($general, ['name' => 'Real Ping']);
 
     // Matches the client: a `@[Name](id)` token inside a `code` span renders
     // inert, so it must not create a mention. The one outside the span still does.
@@ -119,9 +90,9 @@ test('a mention token inside inline code does not notify', function (): void {
 });
 
 test('editing a message re-syncs mentions: adds new and removes stale', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $first = teamMember($team, 'First Person');
-    $second = teamMember($team, 'Second Person');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $first = teamMemberInChannel($general, ['name' => 'First Person']);
+    $second = teamMemberInChannel($general, ['name' => 'Second Person']);
 
     $message = Message::factory()->for($general)->for($owner)->create([
         'body' => 'ping '.mentionToken($first),
@@ -142,8 +113,8 @@ test('editing a message re-syncs mentions: adds new and removes stale', function
 });
 
 test('the mention payload rides the MessageData on the channel page', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $mentioned = teamMember($team, 'Grace Hopper');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $mentioned = teamMemberInChannel($general, ['name' => 'Grace Hopper']);
 
     $message = Message::factory()->for($general)->for($owner)->create([
         'body' => 'hi '.mentionToken($mentioned),
@@ -160,8 +131,8 @@ test('the mention payload rides the MessageData on the channel page', function (
 });
 
 test('the mention payload rides the broadcast MessageData', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $mentioned = teamMember($team, 'Alan Turing');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $mentioned = teamMemberInChannel($general, ['name' => 'Alan Turing']);
     $clientUuid = (string) Str::uuid7();
 
     $this->actingAs($owner)->post(route('channels.messages.store', [
@@ -179,8 +150,8 @@ test('the mention payload rides the broadcast MessageData', function (): void {
 });
 
 test('a deleted message blanks its mentions in the tombstone payload', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    $mentioned = teamMember($team);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $mentioned = teamMemberInChannel($general);
 
     $message = Message::factory()->for($general)->for($owner)->create();
     $message->mentionedUsers()->sync([$mentioned->id]);
@@ -193,8 +164,8 @@ test('a deleted message blanks its mentions in the tombstone payload', function 
 });
 
 test('the channel page exposes team members for the composer autocomplete', function (): void {
-    [$owner, $team, $general] = mentionTeamWithGeneral();
-    teamMember($team, 'Bea Member');
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    teamMemberInChannel($general, ['name' => 'Bea Member']);
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))

--- a/tests/Feature/Channels/ReadReceiptsTest.php
+++ b/tests/Feature/Channels/ReadReceiptsTest.php
@@ -1,48 +1,20 @@
 <?php
 
 use App\Actions\Channels\MarkChannelRead;
-use App\Actions\Teams\CreateTeam;
 use App\Data\UserData;
 use App\Enums\TeamRole;
 use App\Events\MessageRead;
-use App\Models\Channel;
 use App\Models\Message;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Support\Facades\Event;
 use Inertia\Testing\AssertableInertia as Assert;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function receiptsTeamWithGeneral(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and #general, returning them.
- */
-function receiptsMember(Team $team, Channel $channel, User $user): User
-{
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
-
 test('MarkChannelRead broadcasts the advance for a user who shares read receipts', function (): void {
     Event::fake([MessageRead::class]);
 
-    [$owner, $team, $general] = receiptsTeamWithGeneral();
-    $member = receiptsMember($team, $general, User::factory()->create(['name' => 'Ada Lovelace']));
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
 
     Message::factory()->for($general)->for($owner)->create();
     $latest = Message::factory()->for($general)->for($owner)->create();
@@ -58,8 +30,8 @@ test('MarkChannelRead broadcasts the advance for a user who shares read receipts
 test('MarkChannelRead does not broadcast for a user who opted out of read receipts', function (): void {
     Event::fake([MessageRead::class]);
 
-    [$owner, $team, $general] = receiptsTeamWithGeneral();
-    $member = receiptsMember($team, $general, User::factory()->withoutReadReceipts()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = joinTeamAndChannel($general, User::factory()->withoutReadReceipts()->create());
 
     $latest = Message::factory()->for($general)->for($owner)->create();
 
@@ -79,8 +51,8 @@ test('MarkChannelRead does not broadcast for a user who opted out of read receip
 test('MarkChannelRead does not re-broadcast when the pointer is already at the tail', function (): void {
     Event::fake([MessageRead::class]);
 
-    [$owner, $team, $general] = receiptsTeamWithGeneral();
-    $member = receiptsMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     Message::factory()->for($general)->for($owner)->create();
 
@@ -95,8 +67,8 @@ test('MarkChannelRead does not re-broadcast when the pointer is already at the t
 test('MarkChannelRead does not broadcast on an empty channel', function (): void {
     Event::fake([MessageRead::class]);
 
-    [, $team, $general] = receiptsTeamWithGeneral();
-    $member = receiptsMember($team, $general, User::factory()->create());
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     app(MarkChannelRead::class)->handle($general, $member);
 
@@ -106,7 +78,7 @@ test('MarkChannelRead does not broadcast on an empty channel', function (): void
 test('MarkChannelRead does not broadcast for a non-member', function (): void {
     Event::fake([MessageRead::class]);
 
-    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $outsider = User::factory()->create();
     $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
     $general->channelMembers()->where('user_id', $outsider->id)->delete();
@@ -121,8 +93,8 @@ test('MarkChannelRead does not broadcast for a non-member', function (): void {
 test('the read endpoint broadcasts the advance for a sharing member', function (): void {
     Event::fake([MessageRead::class]);
 
-    [$owner, $team, $general] = receiptsTeamWithGeneral();
-    $member = receiptsMember($team, $general, User::factory()->create());
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $latest = Message::factory()->for($general)->for($owner)->create();
 
@@ -134,7 +106,7 @@ test('the read endpoint broadcasts the advance for a sharing member', function (
 });
 
 test('MessageRead broadcasts on the channel private channel with the reader and pointer', function (): void {
-    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $message = Message::factory()->for($general)->for($owner)->create();
     $event = new MessageRead($general, UserData::fromUser($owner), $message->id);
@@ -147,10 +119,10 @@ test('MessageRead broadcasts on the channel private channel with the reader and 
 });
 
 test('the channel page seeds channelReaders with sharing members, excluding the viewer and opt-outs', function (): void {
-    [$owner, $team, $general] = receiptsTeamWithGeneral();
-    $viewer = receiptsMember($team, $general, User::factory()->create(['name' => 'Viewer']));
-    $sharer = receiptsMember($team, $general, User::factory()->create(['name' => 'Sharer']));
-    $optedOut = receiptsMember($team, $general, User::factory()->withoutReadReceipts()->create(['name' => 'Quiet']));
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $viewer = teamMemberInChannel($general, ['name' => 'Viewer']);
+    $sharer = teamMemberInChannel($general, ['name' => 'Sharer']);
+    $optedOut = joinTeamAndChannel($general, User::factory()->withoutReadReceipts()->create(['name' => 'Quiet']));
 
     $message = Message::factory()->for($general)->for($owner)->create();
     $sharer->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $message->id]);

--- a/tests/Feature/Channels/ThreadReadTest.php
+++ b/tests/Feature/Channels/ThreadReadTest.php
@@ -2,71 +2,46 @@
 
 use App\Actions\Channels\MarkChannelRead;
 use App\Actions\Channels\MarkThreadRead;
-use App\Actions\Teams\CreateTeam;
 use App\Enums\NotificationLevel;
-use App\Enums\TeamRole;
+use App\Data\MessageData;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\ThreadRead;
 use App\Models\User;
+use App\Support\ChannelTimelineWindow;
 use Inertia\Testing\AssertableInertia as Assert;
 
 /**
- * Create a team with its owner already a member of #general.
+ * The root message's payload on the main timeline, as the viewer sees it.
  *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function threadReadSetup(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Add a user to the team and #general, returning them.
- */
-function threadReadMember(Team $team, Channel $channel): User
-{
-    $user = User::factory()->create();
-    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
-    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
-
-    return $user;
-}
-
-/**
- * Load the channel as the given user and return the root message's payload from
- * the main timeline (thread-only replies are excluded, so a lone root sits at 0).
+ * Read off {@see ChannelTimelineWindow}, which is what builds the `messages`
+ * prop, rather than by rendering `channels/Show` to pluck that prop back out
+ * (#1117). Thread-only replies are excluded from the main timeline, so a lone
+ * root sits there alone. The HTTP half — that a render still ships the prop —
+ * is stated by the last test in this file.
  *
  * @return array<string, mixed>
  */
-function rootPayload(User $viewer, Team $team, Channel $channel, Message $root): array
+function rootPayload(User $viewer, Channel $channel, Message $root): array
 {
-    $captured = [];
+    $payload = collect(new ChannelTimelineWindow($channel, $viewer)->messages()->items())
+        ->firstWhere('id', $root->id);
 
-    test()->actingAs($viewer)
-        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]))
-        ->assertInertia(function (Assert $page) use (&$captured, $root): void {
-            $page->has('messages.data');
-            $data = $page->toArray()['props']['messages']['data'];
-            $captured = collect($data)->firstWhere('id', $root->id);
-        });
+    expect($payload)->toBeInstanceOf(MessageData::class);
 
-    return $captured;
+    /** @var MessageData $payload */
+    return $payload->toArray();
 }
 
 test('a followed thread with an unseen reply raises the root unread flag', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    $payload = rootPayload($owner, $team, $general, $root);
+    $payload = rootPayload($owner, $general, $root);
 
     expect($payload['threadFollowed'])->toBeTrue()
         ->and($payload['threadUnread'])->toBeTrue()
@@ -74,14 +49,14 @@ test('a followed thread with an unseen reply raises the root unread flag', funct
 });
 
 test('a non-participant who was never mentioned does not follow the thread', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
-    $bob = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
+    $bob = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    $payload = rootPayload($bob, $team, $general, $root);
+    $payload = rootPayload($bob, $general, $root);
 
     expect($payload['threadFollowed'])->toBeFalse()
         ->and($payload['threadUnread'])->toBeFalse()
@@ -91,63 +66,63 @@ test('a non-participant who was never mentioned does not follow the thread', fun
 });
 
 test('replying in a thread makes the user a follower', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
-    $bob = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
+    $bob = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($bob)->inThread($root)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    $payload = rootPayload($bob, $team, $general, $root);
+    $payload = rootPayload($bob, $general, $root);
 
     expect($payload['threadFollowed'])->toBeTrue()
         ->and($payload['threadUnread'])->toBeTrue();
 });
 
 test('a mention inside a reply makes the user a follower', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
-    $bob = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
+    $bob = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     $reply = Message::factory()->for($general)->for($alice)->inThread($root)->create();
     $reply->mentionedUsers()->attach($bob->id);
 
-    $payload = rootPayload($bob, $team, $general, $root);
+    $payload = rootPayload($bob, $general, $root);
 
     expect($payload['threadFollowed'])->toBeTrue()
         ->and($payload['threadUnread'])->toBeTrue();
 });
 
 test('a user\'s own replies never raise their unread flag', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($owner)->inThread($root)->create();
 
-    $payload = rootPayload($owner, $team, $general, $root);
+    $payload = rootPayload($owner, $general, $root);
 
     expect($payload['threadFollowed'])->toBeTrue()
         ->and($payload['threadUnread'])->toBeFalse();
 });
 
 test('a soft-deleted reply does not count as unread', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create(['deleted_at' => now()]);
 
-    $payload = rootPayload($owner, $team, $general, $root);
+    $payload = rootPayload($owner, $general, $root);
 
     expect($payload['threadFollowed'])->toBeTrue()
         ->and($payload['threadUnread'])->toBeFalse();
 });
 
 test('marking the thread read clears the unread flag and persists the pointer', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     $reply = Message::factory()->for($general)->for($alice)->inThread($root)->create();
@@ -159,31 +134,31 @@ test('marking the thread read clears the unread flag and persists the pointer', 
     expect(ThreadRead::where('thread_root_id', $root->id)->where('user_id', $owner->id)->value('last_read_reply_id'))
         ->toBe($reply->id);
 
-    $payload = rootPayload($owner, $team, $general, $root);
+    $payload = rootPayload($owner, $general, $root);
 
     expect($payload['threadUnread'])->toBeFalse();
 });
 
 test('a newer reply after the read pointer raises the flag again', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     $first = Message::factory()->for($general)->for($alice)->inThread($root)->create();
     ThreadRead::factory()->for($root, 'root')->for($owner)->upTo($first)->create();
 
     // Read up to the first reply: nothing unread yet.
-    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeFalse();
+    expect(rootPayload($owner, $general, $root)['threadUnread'])->toBeFalse();
 
     // A later reply lands after the pointer.
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeTrue();
+    expect(rootPayload($owner, $general, $root)['threadUnread'])->toBeTrue();
 });
 
 test('thread read state is independent of the channel read pointer', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
@@ -191,7 +166,7 @@ test('thread read state is independent of the channel read pointer', function ()
     // Marking the whole channel read must not clear the thread's unread flag.
     app(MarkChannelRead::class)->handle($general, $owner);
 
-    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeTrue();
+    expect(rootPayload($owner, $general, $root)['threadUnread'])->toBeTrue();
 
     // And marking the thread read must not move the channel's read pointer.
     $channelPointer = $general->channelMembers()->where('user_id', $owner->id)->value('last_read_message_id');
@@ -203,23 +178,23 @@ test('thread read state is independent of the channel read pointer', function ()
 });
 
 test('a muted channel suppresses the thread unread flag', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $general->channelMembers()->where('user_id', $owner->id)->update(['muted' => true]);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    $payload = rootPayload($owner, $team, $general, $root);
+    $payload = rootPayload($owner, $general, $root);
 
     expect($payload['threadFollowed'])->toBeTrue()
         ->and($payload['threadUnread'])->toBeFalse();
 });
 
 test('a notification level below all suppresses the thread unread flag', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $general->channelMembers()->where('user_id', $owner->id)
         ->update(['notification_level' => NotificationLevel::Mentions]);
@@ -227,12 +202,12 @@ test('a notification level below all suppresses the thread unread flag', functio
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeFalse();
+    expect(rootPayload($owner, $general, $root)['threadUnread'])->toBeFalse();
 });
 
 test('a mention inside a thread raises its dot on a mentions-level channel', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $general->channelMembers()->where('user_id', $owner->id)
         ->update(['notification_level' => NotificationLevel::Mentions]);
@@ -243,15 +218,15 @@ test('a mention inside a thread raises its dot on a mentions-level channel', fun
 
     // The "mentions" level silences ordinary traffic, never a mention — the one
     // thread the viewer was explicitly pulled into is the last one to go quiet.
-    $payload = rootPayload($owner, $team, $general, $root);
+    $payload = rootPayload($owner, $general, $root);
 
     expect($payload['threadUnread'])->toBeTrue()
         ->and($payload['threadUnreadReplyCount'])->toBe(1);
 });
 
 test('the reply count on a mentions-level channel counts only the mentions', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $general->channelMembers()->where('user_id', $owner->id)
         ->update(['notification_level' => NotificationLevel::Mentions]);
@@ -263,12 +238,12 @@ test('the reply count on a mentions-level channel counts only the mentions', fun
 
     // At this level the ordinary reply alerts nobody, so counting it would
     // promise a dot's worth of news the channel itself refuses to badge.
-    expect(rootPayload($owner, $team, $general, $root)['threadUnreadReplyCount'])->toBe(1);
+    expect(rootPayload($owner, $general, $root)['threadUnreadReplyCount'])->toBe(1);
 });
 
 test('muting a channel silences a mention inside a thread', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $general->channelMembers()->where('user_id', $owner->id)->update(['muted' => true]);
 
@@ -276,12 +251,12 @@ test('muting a channel silences a mention inside a thread', function (): void {
     Message::factory()->for($general)->for($alice)->inThread($root)->create()
         ->mentionedUsers()->attach($owner->id);
 
-    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeFalse();
+    expect(rootPayload($owner, $general, $root)['threadUnread'])->toBeFalse();
 });
 
 test('the nothing level silences a mention inside a thread', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $general->channelMembers()->where('user_id', $owner->id)
         ->update(['notification_level' => NotificationLevel::Nothing]);
@@ -290,12 +265,12 @@ test('the nothing level silences a mention inside a thread', function (): void {
     Message::factory()->for($general)->for($alice)->inThread($root)->create()
         ->mentionedUsers()->attach($owner->id);
 
-    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeFalse();
+    expect(rootPayload($owner, $general, $root)['threadUnread'])->toBeFalse();
 });
 
 test('the thread panel root carries the viewer follow and unread state', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
-    $alice = threadReadMember($team, $general);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $alice = teamMemberInChannel($general);
 
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
@@ -308,7 +283,7 @@ test('the thread panel root carries the viewer follow and unread state', functio
 });
 
 test('marking read is a no-op for a thread with no replies', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $root = Message::factory()->for($general)->for($owner)->create();
 
@@ -318,11 +293,11 @@ test('marking read is a no-op for a thread with no replies', function (): void {
 });
 
 test('marking a thread read requires permission to view the channel', function (): void {
-    [$owner, $team, $general] = threadReadSetup();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $root = Message::factory()->for($general)->for($owner)->create();
 
     $private = Channel::factory()->for($team)->create(['visibility' => 'private']);
-    $outsider = threadReadMember($team, $general);
+    $outsider = teamMemberInChannel($general);
     $privateRoot = Message::factory()->for($private)->for($owner)->create();
 
     $this->actingAs($outsider)

--- a/tests/Feature/Channels/ThreadReadTest.php
+++ b/tests/Feature/Channels/ThreadReadTest.php
@@ -2,11 +2,10 @@
 
 use App\Actions\Channels\MarkChannelRead;
 use App\Actions\Channels\MarkThreadRead;
-use App\Enums\NotificationLevel;
 use App\Data\MessageData;
+use App\Enums\NotificationLevel;
 use App\Models\Channel;
 use App\Models\Message;
-use App\Models\Team;
 use App\Models\ThreadRead;
 use App\Models\User;
 use App\Support\ChannelTimelineWindow;

--- a/tests/Feature/Channels/ThreadTest.php
+++ b/tests/Feature/Channels/ThreadTest.php
@@ -308,19 +308,13 @@ test('a mention inside a thread still badges the channel', function (): void {
 });
 
 /**
- * Resolve the sidebar `channels` prop entry for the given channel as the user.
+ * The sidebar `channels` row's badge counts for the channel, as the acting user.
  *
  * @return array{unreadCount: int, mentionCount: int}
  */
 function threadSidebarEntry(User $user, Team $team, Channel $channel): array
 {
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
+    $row = sidebarRow($user, $team, $channel);
 
-    $entry = collect($response->viewData('page')['props']['channels'])
-        ->firstWhere('slug', $channel->slug);
-
-    return ['unreadCount' => $entry['unreadCount'], 'mentionCount' => $entry['mentionCount']];
+    return ['unreadCount' => $row->unreadCount, 'mentionCount' => $row->mentionCount];
 }

--- a/tests/Feature/Channels/UnreadBadgeTest.php
+++ b/tests/Feature/Channels/UnreadBadgeTest.php
@@ -33,22 +33,15 @@ function markReadUpTo(User $user, Channel $channel, ?Message $message): void
 }
 
 /**
- * Resolve the sidebar `channels` prop entry for the given channel as the acting user.
+ * The sidebar `channels` row's badge counts for the channel, as the acting user.
  *
  * @return array{unreadCount: int, mentionCount: int}
  */
 function sidebarChannel(User $user, Team $team, Channel $channel): array
 {
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
+    $row = sidebarRow($user, $team, $channel);
 
-    $channels = $response->viewData('page')['props']['channels'];
-
-    $entry = collect($channels)->firstWhere('slug', $channel->slug);
-
-    return ['unreadCount' => $entry['unreadCount'], 'mentionCount' => $entry['mentionCount']];
+    return ['unreadCount' => $row->unreadCount, 'mentionCount' => $row->mentionCount];
 }
 
 test('unread count reflects only the messages posted after last_read', function (): void {

--- a/tests/Feature/Sidebar/ChannelSectionTest.php
+++ b/tests/Feature/Sidebar/ChannelSectionTest.php
@@ -1,42 +1,25 @@
 <?php
 
 use App\Actions\Teams\CreateTeam;
-use App\Enums\TeamRole;
-use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\ChannelSection;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Testing\TestResponse;
+use Inertia\Testing\AssertableInertia as Assert;
 
-/**
- * Create a team with its owner already a member of #general.
- *
- * @return array{0: User, 1: Team, 2: Channel}
- */
-function sectionCrudTeam(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
-
-    return [$owner, $team, $general];
-}
-
-/**
- * Read the shared `channelSections` prop for the acting user off a channel page.
- *
- * @return array<int, array<string, mixed>>
- */
-function sidebarSectionsProp(User $user, Team $team, Channel $channel): array
-{
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
-
-    return $response->viewData('page')['props']['channelSections'];
-}
+/*
+|--------------------------------------------------------------------------
+| Sidebar section endpoints (#1117)
+|--------------------------------------------------------------------------
+|
+| The endpoints that create, rename, collapse, reorder and delete a section,
+| and who may reach them. What the sidebar then *lists* — whose sections, in
+| what order, carrying what state — is stated against `WorkspaceShell::
+| channelSections()` in `tests/Integration/Support/WorkspaceShellTest.php`;
+| one render below keeps the Inertia half, that `share()` ships the prop.
+|
+*/
 
 /**
  * Create a section for the user via the endpoint.
@@ -48,8 +31,8 @@ function createSection(User $user, Team $team, string $name): TestResponse
     ]);
 }
 
-test('a member can create a custom section', function (): void {
-    [$owner, $team, $general] = sectionCrudTeam();
+test('a member can create a custom section and the sidebar is sent it', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     createSection($owner, $team, 'My Projects')->assertRedirect();
 
@@ -60,14 +43,16 @@ test('a member can create a custom section', function (): void {
         'collapsed' => false,
     ]);
 
-    expect(sidebarSectionsProp($owner, $team, $general))
-        ->toHaveCount(1)
-        ->and(sidebarSectionsProp($owner, $team, $general)[0])
-        ->toMatchArray(['name' => 'My Projects', 'collapsed' => false]);
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('channelSections', 1)
+            ->where('channelSections.0.name', 'My Projects')
+            ->etc());
 });
 
 test('new sections are appended after existing ones', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     createSection($owner, $team, 'First')->assertRedirect();
     createSection($owner, $team, 'Second')->assertRedirect();
@@ -79,7 +64,7 @@ test('new sections are appended after existing ones', function (): void {
 });
 
 test('the section name is trimmed and required', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     createSection($owner, $team, '   Trimmed   ')->assertRedirect();
     $this->assertDatabaseHas('channel_sections', ['name' => 'Trimmed']);
@@ -88,13 +73,13 @@ test('the section name is trimmed and required', function (): void {
 });
 
 test('a section name is capped at 50 characters', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     createSection($owner, $team, str_repeat('a', 51))->assertSessionHasErrors('name');
 });
 
 test('a non-member cannot create a section in the team', function (): void {
-    [, $team] = sectionCrudTeam();
+    ['team' => $team] = teamWithChannel();
     $stranger = User::factory()->create();
 
     createSection($stranger, $team, 'Nope')->assertForbidden();
@@ -103,7 +88,7 @@ test('a non-member cannot create a section in the team', function (): void {
 });
 
 test('a member can rename their section', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create(['name' => 'Old']);
 
     $this->actingAs($owner)
@@ -114,7 +99,7 @@ test('a member can rename their section', function (): void {
 });
 
 test('a member can collapse their section', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
     $this->actingAs($owner)
@@ -125,7 +110,7 @@ test('a member can collapse their section', function (): void {
 });
 
 test('an empty section update is rejected', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
     $this->actingAs($owner)
@@ -134,9 +119,8 @@ test('an empty section update is rejected', function (): void {
 });
 
 test('a member cannot update another user section', function (): void {
-    [$owner, $team] = sectionCrudTeam();
-    $other = User::factory()->create();
-    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $other = teamMemberInChannel($general);
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
     $this->actingAs($other)
@@ -147,7 +131,7 @@ test('a member cannot update another user section', function (): void {
 });
 
 test('a section from another team cannot be updated through this team', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $otherTeam = app(CreateTeam::class)->handle($owner, 'Other');
     $section = ChannelSection::factory()->for($owner)->for($otherTeam)->create();
 
@@ -157,7 +141,7 @@ test('a section from another team cannot be updated through this team', function
 });
 
 test('a member can delete their section and its channels fall back to the default group', function (): void {
-    [$owner, $team, $general] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
 
@@ -174,9 +158,8 @@ test('a member can delete their section and its channels fall back to the defaul
 });
 
 test('a member cannot delete another user section', function (): void {
-    [$owner, $team] = sectionCrudTeam();
-    $other = User::factory()->create();
-    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $other = teamMemberInChannel($general);
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
     $this->actingAs($other)
@@ -187,7 +170,7 @@ test('a member cannot delete another user section', function (): void {
 });
 
 test('a member can reorder their sections', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $a = ChannelSection::factory()->for($owner)->for($team)->position(0)->create(['name' => 'A']);
     $b = ChannelSection::factory()->for($owner)->for($team)->position(1)->create(['name' => 'B']);
     $c = ChannelSection::factory()->for($owner)->for($team)->position(2)->create(['name' => 'C']);
@@ -204,7 +187,7 @@ test('a member can reorder their sections', function (): void {
 });
 
 test('reordering rejects a section the user does not own', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $mine = ChannelSection::factory()->for($owner)->for($team)->create();
     $other = User::factory()->create();
     $theirs = ChannelSection::factory()->for($other)->for($team)->create();
@@ -217,26 +200,15 @@ test('reordering rejects a section the user does not own', function (): void {
 });
 
 test('the sections payload must be present to reorder', function (): void {
-    [$owner, $team] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     $this->actingAs($owner)
         ->patch(route('channels.sections.reorder', ['team' => $team->slug]), [])
         ->assertSessionHasErrors('sections');
 });
 
-test('sections are scoped per user in the sidebar prop', function (): void {
-    [$owner, $team, $general] = sectionCrudTeam();
-    ChannelSection::factory()->for($owner)->for($team)->create(['name' => 'Mine']);
-    $other = User::factory()->create();
-    ChannelSection::factory()->for($other)->for($team)->create(['name' => 'Theirs']);
-
-    $names = collect(sidebarSectionsProp($owner, $team, $general))->pluck('name');
-
-    expect($names)->toContain('Mine')->not->toContain('Theirs');
-});
-
 test('a section and its channel memberships relate both ways', function (): void {
-    [$owner, $team, $general] = sectionCrudTeam();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
 
@@ -249,7 +221,7 @@ test('a section and its channel memberships relate both ways', function (): void
 });
 
 test('a guest cannot manage sections', function (): void {
-    [, $team] = sectionCrudTeam();
+    ['team' => $team] = teamWithChannel();
 
     $this->post(route('channels.sections.store', ['team' => $team->slug]), ['name' => 'X'])
         ->assertRedirect(route('login'));

--- a/tests/Feature/SidebarSectionTest.php
+++ b/tests/Feature/SidebarSectionTest.php
@@ -1,38 +1,33 @@
 <?php
 
-use App\Models\Channel;
-use App\Models\Team;
-use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
 
-/**
- * Read the shared `collapsedChannelSections` prop for the acting user off a
- * channel page (where the workspace sidebar is rendered).
- *
- * @return array<int, string>
- */
-function sidebarCollapsedProp(User $user, Team $team, Channel $channel): array
-{
-    $response = test()->actingAs($user)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => $channel->slug,
-    ]))->assertOk();
-
-    return $response->viewData('page')['props']['collapsedChannelSections'];
-}
+/*
+|--------------------------------------------------------------------------
+| Collapsed sidebar sections (#1117)
+|--------------------------------------------------------------------------
+|
+| `collapsedChannelSections` has no read-model of its own: `share()` ships
+| `$user->collapsed_channel_sections ?? []` verbatim, so what the endpoint
+| wrote is what the page carries. Each test below therefore states its claim
+| against the column, and one HTTP test states the Inertia half — that the
+| prop is shipped, and that a viewer who never collapsed anything gets `[]`
+| rather than the column's null.
+|
+*/
 
 test('a user can collapse a sidebar section', function (): void {
-    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    ['owner' => $owner] = teamWithChannel();
 
     $this->actingAs($owner)
         ->patch(route('sidebar.sections.update'), ['collapsed' => ['starred']])
         ->assertRedirect();
 
     expect($owner->refresh()->collapsed_channel_sections)->toBe(['starred']);
-    expect(sidebarCollapsedProp($owner, $team, $general))->toBe(['starred']);
 });
 
 test('an empty payload clears every collapsed section', function (): void {
-    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    ['owner' => $owner] = teamWithChannel();
     $owner->update(['collapsed_channel_sections' => ['starred', 'channels']]);
 
     $this->actingAs($owner)
@@ -40,14 +35,23 @@ test('an empty payload clears every collapsed section', function (): void {
         ->assertRedirect();
 
     expect($owner->refresh()->collapsed_channel_sections)->toBe([]);
-    expect(sidebarCollapsedProp($owner, $team, $general))->toBe([]);
 });
 
-test('collapsed sections default to empty for a fresh user', function (): void {
+test('the workspace ships the collapsed sections, empty for a user who never collapsed one', function (): void {
     ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $show = route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]);
 
+    // The column starts null, and `share()` is what turns that into an empty
+    // list the sidebar can render without a guard.
     expect($owner->collapsed_channel_sections)->toBeNull();
-    expect(sidebarCollapsedProp($owner, $team, $general))->toBe([]);
+
+    $this->actingAs($owner)->get($show)
+        ->assertInertia(fn (Assert $page): Assert => $page->where('collapsedChannelSections', [])->etc());
+
+    $owner->update(['collapsed_channel_sections' => ['starred']]);
+
+    $this->actingAs($owner)->get($show)
+        ->assertInertia(fn (Assert $page): Assert => $page->where('collapsedChannelSections', ['starred'])->etc());
 });
 
 test('duplicate section keys are stored once', function (): void {

--- a/tests/Feature/Teams/DefaultChannelsTest.php
+++ b/tests/Feature/Teams/DefaultChannelsTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Actions\Sso\ProvisionSsoUser;
-use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\TeamInvitation;
@@ -10,9 +9,8 @@ use Illuminate\Support\Collection;
 use Inertia\Testing\AssertableInertia as Assert;
 
 test('accepting an invitation joins the newcomer to every default channel', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team] = teamWithChannel();
     $newcomer = User::factory()->create(['email' => 'newcomer@example.com']);
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
     $announcements = Channel::factory()->for($team)->create(['name' => 'Announcements', 'slug' => 'announcements', 'is_default' => true]);
     $watercooler = Channel::factory()->for($team)->create(['name' => 'Watercooler', 'slug' => 'watercooler', 'is_default' => false]);
@@ -31,10 +29,8 @@ test('accepting an invitation joins the newcomer to every default channel', func
 });
 
 test('a joining member always lands in #general even with no default marked', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
     $newcomer = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->sole();
 
     $team->memberships()->create(['user_id' => $newcomer->id, 'role' => TeamRole::Member]);
 
@@ -42,8 +38,7 @@ test('a joining member always lands in #general even with no default marked', fu
 });
 
 test('a directory-provisioned user joins the default channels too', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
     config(['sso.default_team_id' => $team->id]);
 
     $announcements = Channel::factory()->for($team)->create(['slug' => 'announcements', 'is_default' => true]);
@@ -51,13 +46,12 @@ test('a directory-provisioned user joins the default channels too', function ():
     $user = app(ProvisionSsoUser::class)->handle('oidc', 'sub-123', 'jordan@example.com', 'Jordan Rivers');
 
     expect($announcements->members()->whereKey($user->id)->exists())->toBeTrue()
-        ->and($team->channels()->where('slug', Channel::GENERAL_SLUG)->sole()->members()->whereKey($user->id)->exists())->toBeTrue();
+        ->and($general->members()->whereKey($user->id)->exists())->toBeTrue();
 });
 
 test('marking a channel default does not sweep the existing members in', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team] = teamWithChannel();
     $existing = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $team->memberships()->create(['user_id' => $existing->id, 'role' => TeamRole::Member]);
 
     $announcements = Channel::factory()->for($team)->create(['slug' => 'announcements', 'is_default' => false]);
@@ -73,9 +67,8 @@ test('marking a channel default does not sweep the existing members in', functio
 });
 
 test('a private or archived channel is never joined as a default', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team] = teamWithChannel();
     $newcomer = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
     $private = Channel::factory()->for($team)->private()->create(['slug' => 'secret', 'is_default' => true]);
     $archived = Channel::factory()->for($team)->create(['slug' => 'retired', 'is_default' => true, 'archived_at' => now()]);
@@ -87,9 +80,8 @@ test('a private or archived channel is never joined as a default', function (): 
 });
 
 test('joining a default channel posts no notice into it', function (): void {
-    $owner = User::factory()->create();
+    ['team' => $team] = teamWithChannel();
     $newcomer = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $announcements = Channel::factory()->for($team)->create(['slug' => 'announcements', 'is_default' => true]);
 
     $team->memberships()->create(['user_id' => $newcomer->id, 'role' => TeamRole::Member]);
@@ -98,10 +90,8 @@ test('joining a default channel posts no notice into it', function (): void {
 });
 
 test('a team admin marks a public channel as a default and takes it back', function (): void {
-    $owner = User::factory()->create();
-    $admin = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
 
     // An Admin, not the Owner, and not a member of the channel: deciding where
     // newcomers land is workspace administration, not channel membership.
@@ -125,13 +115,11 @@ test('a team admin marks a public channel as a default and takes it back', funct
 });
 
 test('a plain member cannot mark a channel as a default', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create(['slug' => 'announcements']);
-    $channel->channelMembers()->create(['user_id' => $member->id]);
+    channelMembership($channel, $member);
 
     $this->actingAs($member)
         ->patch(route('channels.update', ['team' => $team->slug, 'channel' => $channel->slug]), [
@@ -143,13 +131,11 @@ test('a plain member cannot mark a channel as a default', function (): void {
 });
 
 test('a member may still edit the topic of a channel they cannot default', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create(['slug' => 'announcements']);
-    $channel->channelMembers()->create(['user_id' => $member->id]);
+    channelMembership($channel, $member);
 
     $this->actingAs($member)
         ->patch(route('channels.update', ['team' => $team->slug, 'channel' => $channel->slug]), [
@@ -161,10 +147,9 @@ test('a member may still edit the topic of a channel they cannot default', funct
 });
 
 test('a private channel cannot be made a default', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
-    $channel->channelMembers()->create(['user_id' => $owner->id]);
+    channelMembership($channel, $owner);
 
     $this->actingAs($owner)
         ->patch(route('channels.update', ['team' => $team->slug, 'channel' => $channel->slug]), [
@@ -176,10 +161,8 @@ test('a private channel cannot be made a default', function (): void {
 });
 
 test('the always-default #general has no flag to toggle', function (): void {
-    $owner = User::factory()->create();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $newcomer = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->sole();
 
     $this->actingAs($owner)
         ->patch(route('channels.update', ['team' => $team->slug, 'channel' => $general->slug]), [
@@ -197,13 +180,11 @@ test('the always-default #general has no flag to toggle', function (): void {
 });
 
 test('re-submitting the standing default flag is not treated as a change', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $channel = Channel::factory()->for($team)->create(['slug' => 'announcements', 'is_default' => true]);
-    $channel->channelMembers()->create(['user_id' => $member->id]);
+    channelMembership($channel, $member);
 
     // The details form posts every field it renders, so a member editing the
     // topic re-sends the flag unchanged; that must not read as an admin action.
@@ -218,8 +199,7 @@ test('re-submitting the standing default flag is not treated as a change', funct
 });
 
 test('the workspace admin page lists the public channels an admin may default', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     Channel::factory()->for($team)->create(['name' => 'Announcements', 'slug' => 'announcements', 'is_default' => true]);
     Channel::factory()->for($team)->create(['name' => 'Watercooler', 'slug' => 'watercooler']);
@@ -241,10 +221,8 @@ test('the workspace admin page lists the public channels an admin may default', 
 });
 
 test('a plain member is sent no list of default channels to manage', function (): void {
-    $owner = User::factory()->create();
-    $member = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     $this->actingAs($member)
         ->get(route('teams.edit', ['team' => $team->slug]))
@@ -254,8 +232,7 @@ test('a plain member is sent no list of default channels to manage', function ()
 });
 
 test('an archived channel cannot be made a default', function (): void {
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
     $channel = Channel::factory()->for($team)->create(['slug' => 'retired', 'archived_at' => now()]);
 
     $this->actingAs($owner)
@@ -268,10 +245,8 @@ test('an archived channel cannot be made a default', function (): void {
 });
 
 test('flipping the default flag alongside a detail edit still needs channel membership', function (): void {
-    $owner = User::factory()->create();
-    $admin = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
 
     $channel = Channel::factory()->for($team)->create(['slug' => 'announcements']);
 

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -3,11 +3,13 @@
 declare(strict_types=1);
 
 use App\Actions\Teams\CreateTeam;
+use App\Data\ChannelData;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\SidebarChannels;
 use Database\Factories\ChannelMemberFactory;
 
 /*
@@ -93,6 +95,27 @@ function joinTeamAndChannel(
     channelMembership($channel, $user, $state);
 
     return $user;
+}
+
+/**
+ * The row the sidebar lists for the channel, as the given viewer sees it.
+ *
+ * Taken off {@see SidebarChannels}, which is what builds the `channels` prop, so
+ * a test that wants one row's state no longer renders `channels/Show` and plucks
+ * it out of the 44 props `share()` ships (#1117). What the list *holds* — which
+ * channels, in what order, carrying what state — is stated in
+ * `tests/Integration/Support/SidebarChannelsTest.php`; this is for the tests
+ * whose subject is an endpoint that writes one of those columns.
+ */
+function sidebarRow(User $viewer, Team $team, Channel $channel): ChannelData
+{
+    $row = collect(new SidebarChannels($viewer, $team)->forSidebar())
+        ->firstWhere('slug', $channel->slug);
+
+    expect($row)->toBeInstanceOf(ChannelData::class);
+
+    /** @var ChannelData $row */
+    return $row;
 }
 
 /**

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -68,8 +68,26 @@ function teamMemberInChannel(
     TeamRole $role = TeamRole::Member,
     ?Closure $state = null,
 ): User {
-    $user = User::factory()->create($attributes);
+    return joinTeamAndChannel($channel, User::factory()->create($attributes), $role, $state);
+}
 
+/**
+ * The same arrange for a user who already exists.
+ *
+ * {@see teamMemberInChannel()} covers the common case, where the test cares
+ * about the membership and not about who is holding it. This one is for when
+ * the user has to be built first — because a *factory state* shapes them
+ * (`withoutReadReceipts()`) or because they are already someone in the story,
+ * joining a second team.
+ *
+ * @param  (Closure(ChannelMemberFactory): ChannelMemberFactory)|null  $state  the membership state, see {@see channelMembership()}
+ */
+function joinTeamAndChannel(
+    Channel $channel,
+    User $user,
+    TeamRole $role = TeamRole::Member,
+    ?Closure $state = null,
+): User {
     $channel->team->memberships()->create(['user_id' => $user->id, 'role' => $role]);
 
     channelMembership($channel, $user, $state);

--- a/tests/Integration/Support/SidebarChannelsTest.php
+++ b/tests/Integration/Support/SidebarChannelsTest.php
@@ -7,6 +7,7 @@ use App\Actions\Teams\CreateTeam;
 use App\Data\ChannelData;
 use App\Enums\ChannelVisibility;
 use App\Models\Channel;
+use App\Models\ChannelSection;
 use App\Models\Message;
 use App\Support\ChannelMembership;
 use App\Support\SidebarChannels;
@@ -62,6 +63,23 @@ test('the list holds the viewer\'s channels in the team, ordered by position the
 
     expect(sidebarSlugs(new SidebarChannels($user, $team)->forSidebar()))
         ->toBe([$zulu->slug, $alpha->slug, $general->slug]);
+});
+
+test('a channel filed under a custom section carries that section and its manual position', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $filed = Channel::factory()->for($team)->create(['name' => 'Roadmap', 'slug' => 'roadmap']);
+    channelMembership($filed, $owner);
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+
+    $owner->channels()->updateExistingPivot($filed->id, ['section_id' => $section->id, 'position' => -1]);
+
+    $rows = collect(new SidebarChannels($owner, $team)->forSidebar())->keyBy('slug');
+
+    expect($rows[$filed->slug]->sectionId)->toBe($section->id)
+        ->and($rows[$filed->slug]->position)->toBe(-1)
+        // A channel the viewer never filed sits in the default group.
+        ->and($rows[$general->slug]->sectionId)->toBeNull()
+        ->and($rows[$general->slug]->position)->toBe(0);
 });
 
 test('the list is scoped to the team and excludes archived channels and non-memberships', function (): void {

--- a/tests/Integration/Support/WorkspaceShellTest.php
+++ b/tests/Integration/Support/WorkspaceShellTest.php
@@ -5,7 +5,9 @@ use App\Enums\ChannelVisibility;
 use App\Enums\MessageReminderStatus;
 use App\Enums\NavDestination;
 use App\Enums\SearchScope;
+use App\Enums\TeamRole;
 use App\Enums\ThreadInboxFilter;
+use App\Models\ChannelSection;
 use App\Models\User;
 use App\Support\WorkspaceShell;
 use Illuminate\Http\Request;
@@ -24,7 +26,8 @@ use Illuminate\Routing\Route;
 | `teamMembers()` is stated here in full (who is listed, in what order, and
 | who is withheld). `tests/Feature/Channels/TeamMembersPropTest.php` keeps the
 | HTTP half: that a workspace render ships the prop, and that a page outside
-| the workspace ships none.
+| the workspace ships none. `channelSections()` is split the same way against
+| `tests/Feature/Sidebar/ChannelSectionTest.php`, which keeps the endpoints.
 |
 */
 
@@ -112,6 +115,27 @@ test('the team roster withholds a bot and another workspace entirely', function 
     teamWithChannel('Other');
 
     expect(array_column(new WorkspaceShell($viewer, $team)->teamMembers(), 'id'))->toBe([$viewer->id]);
+});
+
+test('the sidebar sections are the viewer own, in their manual order, scoped to the team', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    // Created out of order, so the manual position is what the order can come
+    // from and not the insertion order.
+    ChannelSection::factory()->for($viewer)->for($team)->position(1)->create(['name' => 'Second']);
+    ChannelSection::factory()->for($viewer)->for($team)->position(0)->collapsed()->create(['name' => 'First']);
+
+    // Another member's section in this team, and one of the viewer's own in a
+    // workspace they are not looking at: neither belongs in this sidebar.
+    ChannelSection::factory()->for(teamMemberInChannel($general))->for($team)->create(['name' => 'Theirs']);
+    ['team' => $elsewhere] = teamWithChannel('Other');
+    $elsewhere->memberships()->create(['user_id' => $viewer->id, 'role' => TeamRole::Member]);
+    ChannelSection::factory()->for($viewer)->for($elsewhere)->create(['name' => 'Elsewhere']);
+
+    $sections = new WorkspaceShell($viewer, $team)->channelSections();
+
+    expect(array_column($sections, 'name'))->toBe(['First', 'Second'])
+        ->and(array_column($sections, 'collapsed'))->toBe([true, false]);
 });
 
 test('a panel contributes its props only while its destination is the pinned one', function (): void {


### PR DESCRIPTION
Closes #1117.

The rest of the child in one PR, as asked: **batch 3 of slice 7**, **slice 6**, and the
**page-plucking helpers** the third done-condition names — which the sizing comment had
not enumerated, and which are what actually close the issue.

Test-only. 22 files, **-240 lines**, no application code touched.

## Metrics

| metric | at filing | before | now |
| --- | --- | --- | --- |
| `grep -rn "TeamWithGeneral" tests/Feature` | 274 | 46 | **0** |
| files declaring a local `*TeamWithGeneral()` | 37 | 4 | **0** |
| helpers that render a page purely to pluck one prop | 10 | 10 | **0** |
| renders of `channels/Show` behind those helpers | — | 60 | **6** |
| `assertInertia` in `tests/Feature` | 258 | 243 | 246 |

`assertInertia` goes **up** by three, and that is not a regression: the ten helpers read
their prop through `viewData('page')`, which that grep never counted, and three of the
retained HTTP tests are new `assertInertia` calls standing in for them. The honest number
is the row above it — 60 page renders down to 6.

## 1. Batch 3 — the last four arrange clones

`ReadReceiptsTest`, `CrossDeviceReadSyncTest`, `MentionTest`, `CrossTeamSearchTest`, held
back from #1181 because each needed something `teamMemberInChannel()` could not say. The
shared arrange grows one helper rather than four exceptions:

```php
joinTeamAndChannel(Channel $channel, User $user, TeamRole $role, ?Closure $state): User
```

The same join for a user who **already exists** — because a factory *state* shapes them
(`withoutReadReceipts()`, which an attributes array cannot carry without naming
`share_read_receipts` in the test) or because they are already someone in the story,
joining a second team (`CrossTeamSearchTest`'s `addToTeam()`). `teamMemberInChannel()` is
now one line on top of it.

`MentionTest`'s `teamMember()` joined the **team only**, and folds without weakening
anything for the reason #1181's mutation table recorded: on #general the membership
observer auto-joins, so the explicit channel join is a no-op.

## 2. Slice 6 — the inline-repeater cluster

All five files, ~83 re-pasted arranges: `ChannelPolicyTest` (25), `ChannelTest` (18),
`DefaultChannelsTest` (16), `CreateChannelTest` (13), `BrowseAndJoinChannelTest` (11).

Two arranges are **deliberately left inline**, and this is the part worth reviewing:

- `ChannelTest`'s *'creating a team auto-creates a #general channel'* and *'the team owner
  is auto-joined to #general on team creation'*. `teamWithChannel()` is built on
  `CreateTeam` and `firstOrFail()`s #general, so building the arrange through it would beg
  the question these two tests exist to ask.
- Every `memberships()->create(...)` in `DefaultChannelsTest` whose **subject** is the
  observer placing a newcomer into the default channels. Those stay explicit; only the
  ones that are plain setup (an admin, a plain member, a channel-side join) fold.

## 3. The page-plucking helpers

`SidebarChannels`, `WorkspaceShell`, `User::toUserTeams()` and `ChannelTimelineWindow` are
all constructible; ten helpers were still rendering `channels/Show` and plucking one prop
out of the 44 `share()` ships.

**Five of them were the same helper, copied five times.** They now take their row from a
shared `sidebarRow()` off `SidebarChannels`, keeping their exact name, signature and
return shape — so **not one call site changes**, and every assertion is provably the one it
was:

```php
function sidebarChannel(User $user, Team $team, Channel $channel): array
{
    $row = sidebarRow($user, $team, $channel);

    return ['unreadCount' => $row->unreadCount, 'mentionCount' => $row->mentionCount];
}
```

The other five, and what moved:

| helper | now reads | claims moved | HTTP test kept |
| --- | --- | --- | --- |
| `workspaceBadge` | `User::toUserTeams()` | — | new: a render ships `teams` with the counts the read-model was asserted on |
| `rootPayload` | `ChannelTimelineWindow` | — | the file's existing `assertInertia` |
| `sidebarCollapsedProp` | *(deleted)* | — | rewritten: `share()` ships the prop, and turns the column's null into `[]` |
| `sidebarSectionsProp` | *(deleted)* | whose sections, in what order, collapsed or not → `WorkspaceShell::channelSections()` | the create test keeps one render |
| `placementSidebar` | *(deleted)* | `sectionId` + manual `position` on the row → `SidebarChannels` | — (slice 1 retained the `channels` HTTP tests) |

Two claims came out **stronger**. `channelSections()` had nothing asserting its manual
order, its per-team scoping, or `collapsed`; it does now. `sectionId` was asserted in
exactly one place in the whole suite — that one plucked line — and is now stated on the
read-model beside the default-group case, which was asserted nowhere.

## Mutation check

Nothing moved onto a module in parts 1 and 2, so what needs proving there is that the
shared arrange is not *weaker* than the clones it replaced; part 3 needs the read-model
half to bite.

| mutation | files red |
| --- | --- |
| `joinTeamAndChannel` does not join the member to the team | ReadReceipts (2), CrossDeviceReadSync (3), Mention (7), CrossWorkspaceUnread (14) |
| `teamMemberInChannel` ignores the attributes it is handed | Mention (3), ReadReceipts (1), WorkspaceShell (1) |
| `teamWithChannel` leaves the owner out of the channel it returns | BrowseAndJoin (2), Channel (4), ChannelPlacement (8), ChannelSection (1) |
| `ChannelData` reports no unread traffic | ChannelPreference (1), Thread (3), UnreadBadge (8), **SidebarChannels (4)** |
| `ChannelData` forgets which section a channel is filed under | **SidebarChannels (1)** only |
| `WorkspaceShell::channelSections()` ignores the manual order | **WorkspaceShell (1)** only |

The last two are the split working as intended: the section claims now live on the
read-models alone, and the retained HTTP tests — one section, one render — cannot see
them, which is exactly why they are no longer stated there.

Two mutations I tried first killed **nothing**, and both were no-ops rather than gaps:
`teamWithChannel` returning a non-#general channel, and `sidebarRow` returning `first()`
instead of matching the slug. `CreateTeam` makes only #general, so at the moment either
runs there is one channel to pick. Re-aimed above.

## Gates

- `./vendor/bin/sail composer test` — Pint, PHPStan, Rector, 3370 tests green.
- `php artisan test --parallel --coverage --min=100` — `Total: 100.0 %`.
- `lint:check`, `format:check`, `types:check`, `test:js` (2641), `build` — all green.
- `coderabbit review --agent --base develop` — **0 findings** across all 22 files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788358435&installation_model_id=428379&pr_number=1182&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1182&signature=b60303494fa596aa723f1fa58f37a17c1e95d4cf19637b02daaf1df40d1f39cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->