### PR TITLE
test: cover the security log in the cross-team export download guard

### DIFF
--- a/tests/Feature/Teams/AuditExportTest.php
+++ b/tests/Feature/Teams/AuditExportTest.php
@@ -585,18 +585,24 @@ test('an expired export cannot be downloaded', function (): void {
         ->assertNotFound();
 });
 
-test('an export from another team cannot be downloaded', function (): void {
+// The URL names the caller's own workspace, so both download policies pass; only
+// the route's scoped binding (ADR-0014) keeps the other workspace's archive out
+// of reach, for either log.
+test('an export from another team cannot be downloaded', function (AuditExportLogType $logType): void {
     Storage::fake('local');
 
     [$owner, $team] = exportTeam();
     [, $otherTeam] = exportTeam();
-    $export = AuditExport::factory()->for($otherTeam)->ready()->create();
+    $export = AuditExport::factory()->for($otherTeam)->ready()->create(['log_type' => $logType]);
     Storage::disk('local')->put($export->path, 'csv-bytes');
 
     $this->actingAs($owner)
         ->get(route('teams.audit-exports.download', [$team, $export]))
         ->assertNotFound();
-});
+})->with([
+    'audit log' => AuditExportLogType::Audit,
+    'security log' => AuditExportLogType::Security,
+]);
 
 // ── DTO + model + mail ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Refs #1173.

## Why

#1173 reported that `AuditExportController::download` never checks the export belongs to the team in the URL, allowing an admin of workspace A to download workspace B's audit archive. **That vulnerability does not exist.** The issue's central claim, that "the route at `routes/settings.php:158` is not scoped", is wrong: the route sits inside a group that scopes every nested binding.

```php
// routes/settings.php:144
Route::middleware(EnsureTeamMembership::class)->scopeBindings()->group(function (): void {
```

`{auditExport}` therefore resolves through `Team::auditExports()`, so a foreign export 404s before `download()` runs. That group landed in #1160 (ADR-0014), whose own comment explains why controllers in it "never re-ask whether the row belongs to the workspace in the URL". The scan read the controller in isolation and missed the route group.

Adding the `abort_unless($auditExport->team_id === $team->id, 404)` the issue prescribes would be unreachable code (the binding 404s first), so it would fail the 100% coverage gate, and it would re-introduce exactly the per-call-site duplication #1160 removed.

## What

The invariant was already locked for the audit log by `an export from another team cannot be downloaded`. This turns that test into a dataset so the **security** log is covered too, which is the one half of #1173's acceptance criteria that was genuinely missing, and adds a comment recording that the route binding, not a controller guard, is what does the work.

## How tested

- Both dataset cases green.
- Mutation check: dropping `->scopeBindings()` from the group turns both cases into `200` instead of `404`, confirming the test guards something real rather than passing incidentally.
- `sail composer test` green: Pint, PHPStan, Rector, 3371 tests, `Total: 100.0 %`.

No i18n or docs changes: test-only, no user-facing copy and nothing operator-facing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788360875&installation_model_id=428379&pr_number=1184&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1184&signature=b27f81a3806b9ad87ff6d167477106ccb64950caf6ebb60a5bfcef01e7b8e6e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->