### PR TITLE
fix: record a security event when an SSO identity is linked to an existing account

### DIFF
--- a/app/Actions/Sso/ProvisionSsoUser.php
+++ b/app/Actions/Sso/ProvisionSsoUser.php
@@ -32,6 +32,12 @@ class ProvisionSsoUser
      * accounts have no local password, are treated as email-verified (the IdP
      * verified them), and land in the default team as a Member.
      *
+     * Both of the paths that attach a subject leave a security event behind:
+     * SsoIdentityLinked for (2) and AccountProvisioned for (3). Path (2) is the
+     * one that matters for review — it widens how an account somebody already
+     * owned can be signed into — and until it was recorded the only trace was an
+     * ordinary sign-in (#1175).
+     *
      * When $syncName is set, the mapped display name is refreshed from the
      * directory on every login for an already-existing account (a blank name is
      * ignored rather than wiping the current one). Directories that push
@@ -71,8 +77,9 @@ class ProvisionSsoUser
             throw_unless($emailVerified, UnverifiedSsoEmailException::class, 'The directory did not assert the email address as verified.');
 
             $user = User::query()->whereRaw('lower(email) = ?', [$email])->first();
+            $linksExistingAccount = $user instanceof User;
 
-            if ($user) {
+            if ($user instanceof User) {
                 $this->syncName($user, $name, $syncName);
             } else {
                 $user = $this->provisionUser($email, $name);
@@ -82,6 +89,14 @@ class ProvisionSsoUser
                 'provider' => $provider,
                 'provider_id' => $providerId,
             ]);
+
+            // Only the email-match path is recorded here: it changes how an
+            // account the user already had can be authenticated, and nothing
+            // else would leave a trace of it. A JIT-provisioned account already
+            // emitted AccountProvisioned, which covers the same fact.
+            if ($linksExistingAccount) {
+                event(new SecurityEventOccurred($user, SecurityEventType::SsoIdentityLinked));
+            }
 
             return $user;
         });

--- a/app/Enums/SecurityEventType.php
+++ b/app/Enums/SecurityEventType.php
@@ -19,6 +19,7 @@ enum SecurityEventType: string
     case DataExportRequested = 'data_export_requested';
     case DataExportDownloaded = 'data_export_downloaded';
     case AccountProvisioned = 'account_provisioned';
+    case SsoIdentityLinked = 'sso_identity_linked';
     case AccountDeactivated = 'account_deactivated';
     case AccountReactivated = 'account_reactivated';
     case TeamDeleted = 'team_deleted';
@@ -44,6 +45,7 @@ enum SecurityEventType: string
             self::DataExportRequested => __('Data export requested'),
             self::DataExportDownloaded => __('Data export downloaded'),
             self::AccountProvisioned => __('Account provisioned via SSO'),
+            self::SsoIdentityLinked => __('SSO identity linked'),
             self::AccountDeactivated => __('Account deactivated'),
             self::AccountReactivated => __('Account reactivated'),
             self::TeamDeleted => __('Workspace deleted'),

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -711,6 +711,7 @@
   "Something went wrong.": "Une erreur s’est produite.",
   "Speed up navigation without reaching for the mouse.": "Accélérez la navigation sans avoir à toucher la souris.",
   "Square PNG or GIF, up to 128×128. The name must be unique in this workspace.": "PNG ou GIF carré, jusqu’à 128×128. Le nom doit être unique dans cet espace de travail.",
+  "SSO identity linked": "Identité SSO liée",
   "Star :channel": "Ajouter :channel aux favoris",
   "Star channel": "Ajouter le canal aux favoris",
   "Starred": "Favoris",

--- a/tests/Feature/Auth/Sso/ProvisionSsoUserTest.php
+++ b/tests/Feature/Auth/Sso/ProvisionSsoUserTest.php
@@ -71,6 +71,44 @@ test('an existing user with a matching email is linked, not duplicated', functio
     expect(SecurityEvent::query()->where('type', SecurityEventType::AccountProvisioned)->count())->toBe(0);
 });
 
+test('linking a directory identity to an existing account records a security event', function (): void {
+    $existing = User::factory()->create(['email' => 'jordan@example.com']);
+
+    app(ProvisionSsoUser::class)->handle('oidc', 'sub-123', 'jordan@example.com', 'Jordan Rivers');
+
+    expect(SecurityEvent::query()
+        ->where('user_id', $existing->id)
+        ->where('type', SecurityEventType::SsoIdentityLinked)
+        ->count())->toBe(1);
+});
+
+test('a just-in-time provisioned account records no identity linked event', function (): void {
+    Team::factory()->create();
+
+    $user = app(ProvisionSsoUser::class)->handle('oidc', 'sub-123', 'jordan@example.com', 'Jordan Rivers');
+
+    expect(SecurityEvent::query()->where('user_id', $user->id)->where('type', SecurityEventType::SsoIdentityLinked)->count())->toBe(0)
+        ->and(SecurityEvent::query()->where('user_id', $user->id)->where('type', SecurityEventType::AccountProvisioned)->count())->toBe(1);
+});
+
+test('a returning directory user records no identity linked event', function (): void {
+    $existing = User::factory()->create();
+    SsoIdentity::factory()->provider('oidc')->for($existing)->create(['provider_id' => 'sub-xyz']);
+
+    app(ProvisionSsoUser::class)->handle('oidc', 'sub-xyz', 'jordan@example.com', 'Jordan Rivers');
+
+    expect(SecurityEvent::query()->where('type', SecurityEventType::SsoIdentityLinked)->count())->toBe(0);
+});
+
+test('a rejected unverified email records no identity linked event', function (): void {
+    User::factory()->create(['email' => 'jordan@example.com']);
+
+    expect(fn (): User => app(ProvisionSsoUser::class)->handle('oidc', 'sub-123', 'jordan@example.com', 'Jordan Rivers', emailVerified: false))
+        ->toThrow(UnverifiedSsoEmailException::class);
+
+    expect(SecurityEvent::query()->where('type', SecurityEventType::SsoIdentityLinked)->count())->toBe(0);
+});
+
 test('an already-linked identity resolves straight to its user, even against a different email', function (): void {
     $existing = User::factory()->create();
     SsoIdentity::factory()->provider('oidc')->for($existing)->create(['provider_id' => 'sub-xyz']);


### PR DESCRIPTION
Closes #1175.

## What

`ProvisionSsoUser::handle()` has three identity-resolution paths, and the one that attaches a directory subject to an **existing local account** (the email-match path) left no trace: the `SsoIdentity` row was created, the user was signed in, and the only entry in the security log was an ordinary `Signed in`.

This adds `SecurityEventType::SsoIdentityLinked` and fires `SecurityEventOccurred` on that path only, after the identity row is written.

## Why

Attaching an external directory identity to an account widens how that account can be authenticated. That is a privileged change, and neither the account owner reviewing their security activity nor an operator reviewing the workspace security log could tell it had happened.

#553 hardened this path with the `email_verified` check — that reduces how often a bad link happens. This is the detection half: it makes any link visible after the fact, which is what the SOC 2 / ISO 27001 audit-trail work in #417 needs.

## How

- `SsoIdentityLinked = 'sso_identity_linked'` added to `App\Enums\SecurityEventType`, with the label `SSO identity linked`.
- The event fires only when an existing user was matched by email. A JIT-provisioned account already emits `AccountProvisioned`, so it stays a single event with no duplicate; a returning subject (matching step 1) short-circuits before this code and records nothing.

The admin log's filter dropdown and the Security settings page are both driven off `SecurityEventType::cases()` / `label()`, so the new type renders in both with no frontend change.

## Testing

Four feature tests in `tests/Feature/Auth/Sso/ProvisionSsoUserTest.php` covering every path:

- email-match link records exactly one `SsoIdentityLinked`
- JIT provisioning records `AccountProvisioned` only, no link event
- a returning subject records no link event
- a rejected unverified email records no link event

`tests/Unit/SecurityEventTypeTest.php` already runs its label assertion over `SecurityEventType::cases()`, so the new case is covered there automatically.

Backend gate green at `Total: 100.0 %`; frontend `lint:check` / `format:check` / `types:check` / `test:js` / `build` all pass. Local CodeRabbit pass against `develop` returned 0 findings.

## i18n

`SSO identity linked` → `Identité SSO liée` added to `lang/fr.json`.

## Deliberately left out

Two items from the issue, both flagged rather than folded in:

1. **Provider name on the event** was conditional on the log format supporting metadata. It doesn't — `security_events` carries only `user_id`, `type`, `ip_address`, `user_agent`, `is_new_device`. Adding a metadata column would reach into the admin log, its filter, and the #421 export pipeline, so it belongs in its own change.
2. **Emailing the account owner on a first link** — the issue itself says to split this if contentious. It is a product decision (new mailable plus French copy, and it would fire on every SCIM/LDAP link too), so it is not in this PR.

No docs change: nothing here is operator-facing (no new `.env` key, config setting, or install/upgrade step).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788363226&installation_model_id=428379&pr_number=1186&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1186&signature=08979f417c5caf0f13b98f59b96b88ee16d6e92aaf654aa4258c54e792a7c0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->