### PR TITLE
fix: bind incoming webhook signatures to a timestamp so they cannot replay

### DIFF
--- a/app/Http/Controllers/Webhooks/IncomingWebhookController.php
+++ b/app/Http/Controllers/Webhooks/IncomingWebhookController.php
@@ -8,6 +8,7 @@ use App\Models\IncomingWebhook;
 use App\Support\Integrations\IncomingWebhookPayload;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
@@ -34,6 +35,21 @@ class IncomingWebhookController extends Controller
      * raw request body, tolerating a `sha256=` prefix (GitHub/Slack style).
      */
     private const string SIGNATURE_HEADER = 'X-Signature-256';
+
+    /**
+     * The request header carrying the Unix timestamp the signature was computed
+     * at. Its presence selects the timestamped scheme: the signed message becomes
+     * `"{timestamp}.{raw body}"`, the same one outgoing deliveries use.
+     */
+    private const string TIMESTAMP_HEADER = 'X-Timestamp';
+
+    /**
+     * How far a signature's timestamp may sit from the server's own clock, in
+     * either direction, before the request is refused. It absorbs ordinary clock
+     * skew and delivery latency while bounding how long a captured request stays
+     * usable.
+     */
+    private const int TIMESTAMP_TOLERANCE = 300;
 
     public function __invoke(Request $request, string $token, PostMessage $postMessage): JsonResponse
     {
@@ -113,6 +129,13 @@ class IncomingWebhookController extends Controller
      * Enforce the HMAC signature when the webhook is configured with a signing
      * secret. An unsigned webhook skips this entirely (drop-in curl support); a
      * signed one rejects a missing or mismatched signature with 401.
+     *
+     * Two schemes are verified here. The one to send signs `"{timestamp}.{body}"`
+     * and states that timestamp, which bounds how long a captured request stays
+     * usable and lets a replay inside that window be refused outright. The other
+     * signs the body alone and replays forever; it is accepted only by webhooks
+     * created before the timestamped scheme existed, whose senders predate it,
+     * and those webhooks accept either so a sender can move over on its own.
      */
     private function verifySignature(Request $request, IncomingWebhook $webhook): void
     {
@@ -122,10 +145,63 @@ class IncomingWebhookController extends Controller
 
         $header = $request->header(self::SIGNATURE_HEADER);
         $signature = is_string($header) ? Str::after($header, 'sha256=') : '';
+        $timestamp = $this->signedTimestamp($request);
 
+        // A webhook minted under the timestamped scheme never falls back to the
+        // replayable one, so an absent or malformed timestamp is refused here
+        // rather than quietly verifying the body on its own.
+        abort_if($timestamp === null && $webhook->requires_signed_timestamp, 401);
+
+        // `claimSignature` is last on purpose: it has a side effect, and the
+        // short-circuit keeps it from burning a signature that failed anything
+        // before it.
         abort_unless(
-            $signature !== '' && $webhook->signatureMatches($signature, $request->getContent()),
+            $signature !== ''
+                && $this->timestampIsFresh($timestamp)
+                && $webhook->signatureMatches($signature, $request->getContent(), $timestamp)
+                && $this->claimSignature($webhook, $signature, $timestamp),
             401,
         );
+    }
+
+    /**
+     * Record a timestamped signature as spent, and report whether it was still
+     * unspent — a replay inside the freshness window loses the race and is
+     * refused. The marker outlives the window it was accepted in: a timestamp up
+     * to the tolerance in the future stays fresh for twice the tolerance, so a
+     * shorter marker would expire while the signature is still verifiable.
+     *
+     * A request under the legacy scheme carries no timestamp to bound the marker,
+     * so there is nothing here to expire against and it is not claimed.
+     */
+    private function claimSignature(IncomingWebhook $webhook, string $signature, ?int $timestamp): bool
+    {
+        if ($timestamp === null) {
+            return true;
+        }
+
+        return Cache::add("incoming-webhook:{$webhook->id}:{$signature}", true, self::TIMESTAMP_TOLERANCE * 2);
+    }
+
+    /**
+     * Whether a claimed signing time is close enough to now to be acted on. A
+     * request carrying no timestamp is not held to the window — it is verified
+     * under the legacy scheme instead.
+     */
+    private function timestampIsFresh(?int $timestamp): bool
+    {
+        return $timestamp === null || abs(now()->getTimestamp() - $timestamp) <= self::TIMESTAMP_TOLERANCE;
+    }
+
+    /**
+     * The Unix timestamp the request claims to have been signed at, or null when
+     * the header is absent or not an integer — either way the request is held to
+     * the legacy body-only scheme, which only a legacy webhook still accepts.
+     */
+    private function signedTimestamp(Request $request): ?int
+    {
+        $header = $request->header(self::TIMESTAMP_HEADER);
+
+        return is_string($header) && ctype_digit($header) ? (int) $header : null;
     }
 }

--- a/app/Models/IncomingWebhook.php
+++ b/app/Models/IncomingWebhook.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\Webhooks\WebhookSignature;
 use Database\Factories\IncomingWebhookFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -25,6 +26,7 @@ use Illuminate\Support\Carbon;
  * @property string $name
  * @property string $token_hash
  * @property string|null $signing_secret
+ * @property bool $requires_signed_timestamp
  * @property Carbon|null $revoked_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -32,7 +34,7 @@ use Illuminate\Support\Carbon;
  * @property-read Channel|null $channel
  * @property-read User $bot
  */
-#[Fillable(['team_id', 'channel_id', 'bot_id', 'created_by', 'name', 'token_hash', 'signing_secret'])]
+#[Fillable(['team_id', 'channel_id', 'bot_id', 'created_by', 'name', 'token_hash', 'signing_secret', 'requires_signed_timestamp'])]
 class IncomingWebhook extends Model
 {
     /** @use HasFactory<IncomingWebhookFactory> */
@@ -46,6 +48,7 @@ class IncomingWebhook extends Model
     {
         return [
             'signing_secret' => 'encrypted',
+            'requires_signed_timestamp' => 'boolean',
             'revoked_at' => 'datetime',
         ];
     }
@@ -73,14 +76,22 @@ class IncomingWebhook extends Model
      * Whether the request's HMAC signature matches this webhook's signing secret.
      * A webhook without a signing secret is unsigned and never matches here — the
      * caller decides whether an unsigned request is acceptable.
+     *
+     * Passing a timestamp signs `"{timestamp}.{body}"` through the same
+     * {@see WebhookSignature} both directions share, so a captured request stops
+     * verifying once its timestamp falls outside the caller's freshness window.
+     * Omitting it is the original body-only scheme, which replays forever and
+     * survives only for webhooks minted before the timestamped one.
      */
-    public function signatureMatches(string $signature, string $rawBody): bool
+    public function signatureMatches(string $signature, string $rawBody, ?int $timestamp = null): bool
     {
         if ($this->signing_secret === null) {
             return false;
         }
 
-        $expected = hash_hmac('sha256', $rawBody, $this->signing_secret);
+        $expected = $timestamp === null
+            ? hash_hmac('sha256', $rawBody, $this->signing_secret)
+            : WebhookSignature::digest($this->signing_secret, $rawBody, $timestamp);
 
         return hash_equals($expected, $signature);
     }

--- a/database/factories/IncomingWebhookFactory.php
+++ b/database/factories/IncomingWebhookFactory.php
@@ -38,6 +38,17 @@ class IncomingWebhookFactory extends Factory
     }
 
     /**
+     * Indicate that the webhook predates the timestamped signing scheme, so its
+     * senders still sign the raw body on its own.
+     */
+    public function legacySignatures(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'requires_signed_timestamp' => false,
+        ]);
+    }
+
+    /**
      * Indicate that the webhook has been revoked and no longer resolves.
      */
     public function revoked(): static

--- a/database/migrations/2026_08_03_154337_add_requires_signed_timestamp_to_incoming_webhooks_table.php
+++ b/database/migrations/2026_08_03_154337_add_requires_signed_timestamp_to_incoming_webhooks_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('incoming_webhooks', function (Blueprint $table): void {
+            // Whether this webhook's senders must sign `"{timestamp}.{body}"` and
+            // send that timestamp alongside the digest. Newly created webhooks do;
+            // the rows below were minted against the body-only scheme, and their
+            // senders cannot be updated by a migration.
+            $table->boolean('requires_signed_timestamp')->default(true);
+        });
+
+        // Adding the column stamped every existing row with the new default, so
+        // walk them back: a webhook that predates the scheme keeps working under
+        // the old one until its operator revokes it and creates a replacement.
+        DB::table('incoming_webhooks')->update(['requires_signed_timestamp' => false]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('incoming_webhooks', function (Blueprint $table): void {
+            $table->dropColumn('requires_signed_timestamp');
+        });
+    }
+};

--- a/database/migrations/2026_08_03_154337_add_requires_signed_timestamp_to_incoming_webhooks_table.php
+++ b/database/migrations/2026_08_03_154337_add_requires_signed_timestamp_to_incoming_webhooks_table.php
@@ -23,6 +23,12 @@ return new class extends Migration
         // Adding the column stamped every existing row with the new default, so
         // walk them back: a webhook that predates the scheme keeps working under
         // the old one until its operator revokes it and creates a replacement.
+        //
+        // Only rows that predate the column may be walked back, and on Postgres
+        // that is what happens: the migration runs inside a transaction, so the
+        // ALTER above holds its exclusive lock until this UPDATE commits, and a
+        // webhook created in the meantime blocks and lands with the new default
+        // rather than being swept into the exemption.
         DB::table('incoming_webhooks')->update(['requires_signed_timestamp' => false]);
     }
 

--- a/docs/src/content/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/reference/feature-toggles.md
@@ -206,7 +206,8 @@ opaque token in the URL **is** the credential (Slack-style). Each webhook is bou
 to a single bot and channel, its token is stored only as a hash, and it is
 individually revocable. The JSON body accepts either a native `{"body": "..."}` or
 a Slack-compatible `{"text": "..."}` field (Block Kit is ignored); an optional
-HMAC `X-Signature-256` header is honoured when a signing secret is configured.
+HMAC `X-Signature-256` header, paired with the `X-Timestamp` it was signed at, is
+honoured when a signing secret is configured.
 Incoming webhooks are governed by the same `INTEGRATIONS_ENABLED` toggle — the
 endpoint 404s when the platform is off.
 

--- a/docs/src/content/docs/reference/incoming-webhooks.md
+++ b/docs/src/content/docs/reference/incoming-webhooks.md
@@ -151,9 +151,12 @@ Two rules follow from it, and a sender has to satisfy both:
   and keep the sending host's clock in step (NTP is enough). Outside the window
   the request is **401**.
 - **Each signature is accepted once.** Retrying a failed delivery means signing
-  it again with a fresh timestamp; re-sending the identical bytes is a replay and
-  is refused. A retry that reuses the signature gets **401**, never a duplicate
-  message.
+  it again; re-sending the identical bytes is a replay and is refused. Since the
+  timestamp is in whole seconds, an identical body re-signed within the same
+  second produces the same signature, so wait for the next second before
+  retrying. A retry that reuses the signature gets **401**, never a duplicate
+  message: if the first attempt did reach The Desk, that 401 is the duplicate
+  being refused rather than an authentication problem.
 
 ### Migrating an existing webhook
 

--- a/docs/src/content/docs/reference/incoming-webhooks.md
+++ b/docs/src/content/docs/reference/incoming-webhooks.md
@@ -108,16 +108,24 @@ survives the revocation.
 
 When you create the webhook you can also mint an **HMAC signing secret**, shown
 once alongside the URL. If you do, sign each request so The Desk can reject
-forgeries: compute `HMAC-SHA256` over the exact raw request body and send the hex
-digest in the **`X-Signature-256`** header. A bare digest and a `sha256=`-prefixed
-one (GitHub/Slack style) are both accepted.
+forgeries and replays. Two headers make up a signed request:
+
+| Header | Value |
+| --- | --- |
+| `X-Timestamp` | The Unix time, in whole seconds, that you signed at. |
+| `X-Signature-256` | `HMAC-SHA256` of `"{timestamp}.{raw body}"`, hex-encoded. A bare digest and a `sha256=`-prefixed one (GitHub/Slack style) are both accepted. |
+
+Note what is signed: the timestamp, a literal `.`, then the exact request body.
+That is the same construction The Desk signs its own outgoing deliveries with.
 
 ```bash
 BODY='{"text": "Build passed ✅"}'
-SIGNATURE=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SIGNING_SECRET" | awk '{print $2}')
+TIMESTAMP=$(date +%s)
+SIGNATURE=$(printf '%s.%s' "$TIMESTAMP" "$BODY" | openssl dgst -sha256 -hmac "$SIGNING_SECRET" | awk '{print $2}')
 
 curl -X POST $WEBHOOK_URL \
   -H 'Content-Type: application/json' \
+  -H "X-Timestamp: $TIMESTAMP" \
   -H "X-Signature-256: sha256=$SIGNATURE" \
   -d "$BODY"
 ```
@@ -129,11 +137,43 @@ A webhook created without a secret accepts unsigned requests. One created with a
 secret rejects a missing, malformed, or mismatched signature with **401** — so a
 signature sent under any other header name fails as if it were absent.
 
+### Why the timestamp
+
+A signature over the body alone never expires. Anyone who captures one signed
+request, from a plaintext internal hop, a CI log that echoes the request, or a
+compromised proxy, can POST it back forever, and each replay posts the message
+again. Signing the time you sent at closes that.
+
+Two rules follow from it, and a sender has to satisfy both:
+
+- **The timestamp must be within 5 minutes of The Desk's clock**, in either
+  direction. Sign at send time rather than reusing a signature computed earlier,
+  and keep the sending host's clock in step (NTP is enough). Outside the window
+  the request is **401**.
+- **Each signature is accepted once.** Retrying a failed delivery means signing
+  it again with a fresh timestamp; re-sending the identical bytes is a replay and
+  is refused. A retry that reuses the signature gets **401**, never a duplicate
+  message.
+
+### Migrating an existing webhook
+
+Webhooks created **before** you upgraded to this version still accept the old
+scheme, where the digest covers the body alone and no `X-Timestamp` is sent:
+upgrading The Desk cannot rewrite the systems that post to them. Those webhooks
+accept **either** scheme, so you can switch a sender over on its own schedule and
+verify it before anything changes on this end.
+
+They keep accepting the old scheme, and stay replayable, until you retire them:
+**revoke the webhook and create a new one**, then move the sender to the new URL.
+Every webhook created from now on requires the timestamp and cannot fall back.
+Treat the old scheme as deprecated and plan the swap: a future release will drop
+it, and any sender still on it will start getting **401**.
+
 :::caution[Not the header outgoing deliveries use]
-Deliveries _from_ The Desk are signed with `X-Desk-Signature`, which carries
-`t=<unix ts>,v1=<hex>` computed over `"{timestamp}.{body}"` — see
+Deliveries _from_ The Desk are signed with `X-Desk-Signature`, which packs both
+values into one header as `t=<unix ts>,v1=<hex>`. See
 [verifying an outgoing signature](/reference/webhooks/#verifying-the-signature).
-That is a different header with a different value format. Incoming ingest reads
-only `X-Signature-256`, and the digest there is over the body alone — bare or
-`sha256=`-prefixed, never timestamped.
+The signed message is the same `"{timestamp}.{body}"`, but the header names and
+the value format are not: incoming ingest reads the timestamp and the digest as
+two separate headers and never parses a `t=…,v1=…` value.
 :::

--- a/tests/Feature/Integrations/IncomingWebhookIngestTest.php
+++ b/tests/Feature/Integrations/IncomingWebhookIngestTest.php
@@ -113,17 +113,142 @@ it('422s a body that exceeds the maximum length', function (): void {
     $this->assertDatabaseCount('messages', 0);
 });
 
-it('accepts a correctly HMAC-signed request when the webhook requires signing', function (): void {
+it('accepts a request signed over the timestamp and the body', function (): void {
     $secret = Str::random(48);
     [$webhook, $token] = makeWebhook(['signing_secret' => $secret]);
+
+    $payload = ['body' => 'timestamped and sealed'];
+    $timestamp = now()->getTimestamp();
+    $signature = hash_hmac('sha256', $timestamp.'.'.json_encode($payload), $secret);
+
+    $this->postJson("/webhooks/incoming/{$token}", $payload, [
+        'X-Signature-256' => 'sha256='.$signature,
+        'X-Timestamp' => (string) $timestamp,
+    ])->assertStatus(202);
+
+    $this->assertDatabaseHas('messages', ['channel_id' => $webhook->channel_id, 'body' => 'timestamped and sealed']);
+});
+
+it('401s a webhook on the timestamped scheme when no usable timestamp is sent', function (?string $timestamp): void {
+    $secret = Str::random(48);
+    [, $token] = makeWebhook(['signing_secret' => $secret]);
+
+    $payload = ['body' => 'signed the old way'];
+    $headers = ['X-Signature-256' => hash_hmac('sha256', json_encode($payload), $secret)];
+
+    if ($timestamp !== null) {
+        $headers['X-Timestamp'] = $timestamp;
+    }
+
+    $this->postJson("/webhooks/incoming/{$token}", $payload, $headers)->assertStatus(401);
+
+    $this->assertDatabaseCount('messages', 0);
+})->with([
+    'no timestamp header at all' => [null],
+    'a non-numeric timestamp' => ['yesterday'],
+    'an empty timestamp' => [''],
+    'a fractional timestamp' => ['1764547200.5'],
+]);
+
+it('401s a byte-for-byte replay of a request it has already accepted', function (): void {
+    $secret = Str::random(48);
+    [$webhook, $token] = makeWebhook(['signing_secret' => $secret]);
+
+    $payload = ['body' => 'deploy finished'];
+    $timestamp = now()->getTimestamp();
+    $headers = [
+        'X-Signature-256' => 'sha256='.hash_hmac('sha256', $timestamp.'.'.json_encode($payload), $secret),
+        'X-Timestamp' => (string) $timestamp,
+    ];
+
+    $this->postJson("/webhooks/incoming/{$token}", $payload, $headers)->assertStatus(202);
+
+    // Still inside the freshness window, so the window alone would let this one
+    // through and post the message a second time.
+    $this->postJson("/webhooks/incoming/{$token}", $payload, $headers)->assertStatus(401);
+
+    expect(Message::query()->where('channel_id', $webhook->channel_id)->count())->toBe(1);
+});
+
+it('401s a signature whose timestamp falls outside the freshness window', function (int $offset): void {
+    // The window is asserted at its exact edge, so the second the request spends
+    // in flight would otherwise decide the outcome.
+    $this->freezeTime();
+
+    $secret = Str::random(48);
+    [, $token] = makeWebhook(['signing_secret' => $secret]);
+
+    $payload = ['body' => 'stale'];
+    $timestamp = now()->getTimestamp() + $offset;
+    $signature = hash_hmac('sha256', $timestamp.'.'.json_encode($payload), $secret);
+
+    $this->postJson("/webhooks/incoming/{$token}", $payload, [
+        'X-Signature-256' => 'sha256='.$signature,
+        'X-Timestamp' => (string) $timestamp,
+    ])->assertStatus(401);
+
+    $this->assertDatabaseCount('messages', 0);
+})->with([
+    // Both directions: a captured request replayed later, and a sender whose
+    // clock runs far enough ahead that its signature would outlive the window.
+    'signed more than five minutes ago' => [-301],
+    'signed more than five minutes from now' => [301],
+]);
+
+it('accepts a signature sitting exactly on the edge of the freshness window', function (int $offset): void {
+    $this->freezeTime();
+
+    $secret = Str::random(48);
+    [$webhook, $token] = makeWebhook(['signing_secret' => $secret]);
+
+    $payload = ['body' => 'skewed but honest'];
+    $timestamp = now()->getTimestamp() + $offset;
+    $signature = hash_hmac('sha256', $timestamp.'.'.json_encode($payload), $secret);
+
+    // The tolerance exists to absorb clock skew, so the edge itself belongs to
+    // the senders it is there for.
+    $this->postJson("/webhooks/incoming/{$token}", $payload, [
+        'X-Signature-256' => 'sha256='.$signature,
+        'X-Timestamp' => (string) $timestamp,
+    ])->assertStatus(202);
+
+    $this->assertDatabaseHas('messages', ['channel_id' => $webhook->channel_id, 'body' => 'skewed but honest']);
+})->with([
+    'a clock five minutes behind' => [-300],
+    'a clock five minutes ahead' => [300],
+]);
+
+it('still accepts a body-only signature from a webhook that predates the timestamp', function (): void {
+    $secret = Str::random(48);
+    [$webhook, $token] = makeWebhook(['signing_secret' => $secret, 'requires_signed_timestamp' => false]);
 
     $payload = ['body' => 'signed and sealed'];
     $signature = hash_hmac('sha256', json_encode($payload), $secret);
 
+    // The migration window: this sender was written against the old scheme and
+    // cannot be updated by upgrading The Desk.
     $this->postJson("/webhooks/incoming/{$token}", $payload, ['X-Signature-256' => 'sha256='.$signature])
         ->assertStatus(202);
 
     $this->assertDatabaseHas('messages', ['channel_id' => $webhook->channel_id, 'body' => 'signed and sealed']);
+});
+
+it('lets a legacy webhook move to the timestamped scheme before it is required', function (): void {
+    $secret = Str::random(48);
+    [$webhook, $token] = makeWebhook(['signing_secret' => $secret, 'requires_signed_timestamp' => false]);
+
+    $payload = ['body' => 'migrated early'];
+    $timestamp = now()->getTimestamp();
+    $signature = hash_hmac('sha256', $timestamp.'.'.json_encode($payload), $secret);
+
+    // Accepting both is what makes the window usable: a sender switches over on
+    // its own schedule, with no coordinated flip at the other end.
+    $this->postJson("/webhooks/incoming/{$token}", $payload, [
+        'X-Signature-256' => 'sha256='.$signature,
+        'X-Timestamp' => (string) $timestamp,
+    ])->assertStatus(202);
+
+    $this->assertDatabaseHas('messages', ['channel_id' => $webhook->channel_id, 'body' => 'migrated early']);
 });
 
 it('accepts a bare hex signature without the sha256= prefix', function (): void {
@@ -131,10 +256,13 @@ it('accepts a bare hex signature without the sha256= prefix', function (): void 
     [$webhook, $token] = makeWebhook(['signing_secret' => $secret]);
 
     $payload = ['body' => 'bare hex'];
-    $signature = hash_hmac('sha256', json_encode($payload), $secret);
+    $timestamp = now()->getTimestamp();
+    $signature = hash_hmac('sha256', $timestamp.'.'.json_encode($payload), $secret);
 
-    $this->postJson("/webhooks/incoming/{$token}", $payload, ['X-Signature-256' => $signature])
-        ->assertStatus(202);
+    $this->postJson("/webhooks/incoming/{$token}", $payload, [
+        'X-Signature-256' => $signature,
+        'X-Timestamp' => (string) $timestamp,
+    ])->assertStatus(202);
 
     $this->assertDatabaseHas('messages', ['channel_id' => $webhook->channel_id, 'body' => 'bare hex']);
 });

--- a/tests/Feature/Integrations/IncomingWebhookTest.php
+++ b/tests/Feature/Integrations/IncomingWebhookTest.php
@@ -61,6 +61,14 @@ it('optionally mints an encrypted HMAC signing secret', function (): void {
     expect($raw)->not->toBe($result->signingSecret);
 });
 
+it('mints a webhook on the timestamped signing scheme', function (): void {
+    $result = app(CreateIncomingWebhook::class)->handle($this->bot, $this->channel, $this->owner, 'Signed', withSigningSecret: true);
+
+    // Only webhooks that predate the scheme are exempt, and they are exempted by
+    // the migration that introduced it — nothing minted from here on is.
+    expect($result->webhook->fresh()?->requires_signed_timestamp)->toBeTrue();
+});
+
 it('refuses to bind a webhook to a channel the bot is not a member of', function (): void {
     $other = Channel::factory()->for($this->team)->create();
 

--- a/tests/Unit/IncomingWebhookSignatureDocsTest.php
+++ b/tests/Unit/IncomingWebhookSignatureDocsTest.php
@@ -92,6 +92,39 @@ test('the incoming-webhook page names the outgoing header only to tell them apar
         ->and(array_values($ambiguous))->toBe([]);
 });
 
+/**
+ * The timestamp half of the scheme is what makes a captured request expire, and
+ * a sender only sends it because the page says to. Both the prose and the
+ * copy-paste sample are held to the controller's own constants so a rename or a
+ * retuned window cannot leave integrators signing the replayable way. See #1176.
+ */
+$constant = function (string $name): string {
+    $value = (new ReflectionClass(IncomingWebhookController::class))->getConstant($name);
+
+    throw_if($value === false, RuntimeException::class, "IncomingWebhookController::{$name} no longer exists.");
+
+    return (string) $value;
+};
+
+test('the signing section documents the timestamp header and its tolerance window', function () use ($incomingPage, $signingSection, $constant): void {
+    $section = $signingSection($incomingPage);
+
+    expect($section)->toContain($constant('TIMESTAMP_HEADER'))
+        // Stated in minutes, because it is what an integrator sizes a retry and
+        // a clock-skew budget against.
+        ->and($section)->toContain(intdiv((int) $constant('TIMESTAMP_TOLERANCE'), 60).' minutes');
+});
+
+test('the copy-paste signing sample sends the timestamp it signs', function () use ($incomingPage, $signingSection, $constant): void {
+    preg_match_all('/^```.*?\n(?<body>.*?)^```/ms', $signingSection($incomingPage), $matches);
+
+    $samples = implode("\n", $matches['body']);
+
+    // A sample that signs `"{timestamp}.{body}"` but forgets to send the header
+    // produces a 401 nobody can diagnose from the page.
+    expect($samples)->toContain($constant('TIMESTAMP_HEADER'));
+});
+
 test('the feature-toggles page names the same incoming signature header', function () use ($togglesPage, $incomingHeader): void {
     expect((string) file_get_contents($togglesPage))->toContain($incomingHeader());
 });

--- a/tests/Unit/IncomingWebhookSignatureTest.php
+++ b/tests/Unit/IncomingWebhookSignatureTest.php
@@ -23,3 +23,18 @@ it('matches only the correct HMAC-SHA256 signature of the raw body', function ()
     expect($webhook->signatureMatches(hash_hmac('sha256', $body, $secret), $body))->toBeTrue()
         ->and($webhook->signatureMatches('wrong', $body))->toBeFalse();
 });
+
+it('signs the timestamp together with the body when one is given', function (): void {
+    $secret = 'shhh';
+    $body = '{"body":"hi"}';
+    $timestamp = 1764547200;
+    $webhook = new IncomingWebhook(['signing_secret' => $secret]);
+
+    expect($webhook->signatureMatches(hash_hmac('sha256', $timestamp.'.'.$body, $secret), $body, $timestamp))->toBeTrue()
+        // The body-only digest signs a different message and cannot stand in for
+        // it, which is what stops a captured legacy request from being replayed
+        // as a timestamped one.
+        ->and($webhook->signatureMatches(hash_hmac('sha256', $body, $secret), $body, $timestamp))->toBeFalse()
+        // And the timestamp is bound to the digest: restating it does not help.
+        ->and($webhook->signatureMatches(hash_hmac('sha256', $timestamp.'.'.$body, $secret), $body, $timestamp + 1))->toBeFalse();
+});


### PR DESCRIPTION
Closes #1176.

## What

Incoming-webhook ingest signed the raw request body and nothing else, so a captured `X-Signature-256` plus body stayed valid forever: anyone who obtained one signed request could POST it back indefinitely, each replay posting another message into the bound channel. The outgoing path already signed `"{timestamp}.{payload}"`; the two directions now agree.

- Signatures cover `"{timestamp}.{raw body}"` through the same `WebhookSignature::digest` outgoing deliveries use, with the time sent in a new `X-Timestamp` header.
- A timestamp more than 300s from the server's clock, in either direction, is refused with 401, as is a missing or non-numeric one on a webhook that requires the scheme.
- Each accepted signature is claimed in the cache for twice the tolerance, so a replay inside the freshness window is refused too. The window alone would still admit one.

## Migration window

`incoming_webhooks.requires_signed_timestamp` defaults to true, and the migration walks existing rows back to false: their senders were written against the body-only scheme and upgrading The Desk cannot rewrite them. A legacy webhook accepts **either** scheme, so a sender moves over on its own schedule; every webhook created from here on requires the timestamp and cannot fall back. Retiring a legacy webhook means revoking it and creating a replacement, which the docs say plainly. A follow-up will make the scheme mandatory.

No UI change: the flag is not operator-flippable, by design, since recreating a webhook is already how credentials rotate here.

## Testing

Feature tests at the ingest endpoint cover accept, both edges of the freshness window (accepted at ±300s, refused at ±301s, with time frozen so the boundary is exact), a missing / non-numeric / empty / fractional timestamp, a byte-for-byte replay, a legacy webhook still accepting the body-only scheme, and a legacy webhook accepting the timestamped one early. Unit tests cover the digest boundary; a creation test pins new webhooks to the strict scheme. Backend gate green at `Total: 100.0 %`, frontend gate green, docs site builds.

## Docs

`reference/incoming-webhooks.md` documents both headers, what is signed, the 5-minute window, the accepted-once rule (including the same-second retry caveat), and the migration path; `reference/feature-toggles.md` names the paired header. Drift guards in `IncomingWebhookSignatureDocsTest` hold the page to the controller's own header and tolerance constants.

No user-facing copy was added, so no new translation keys.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788365928&installation_model_id=428379&pr_number=1187&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1187&signature=b5867a9de817bd11d4967fba3dc8907b964937a4b678032539bae4c6a0ad06e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->