### PR TITLE
fix: block reserved IPv6 ranges and zone-index hosts in the outbound URL guard

### DIFF
--- a/app/Support/Http/OutboundUrlGuard.php
+++ b/app/Support/Http/OutboundUrlGuard.php
@@ -70,7 +70,11 @@ class OutboundUrlGuard
             return false;
         }
 
-        $host = trim($parts['host'], '[]');
+        $host = self::normalizeHost($parts['host']);
+
+        if ($host === null) {
+            return false;
+        }
 
         if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
             return self::isPublicIp($host);
@@ -94,9 +98,9 @@ class OutboundUrlGuard
             return null;
         }
 
-        $host = trim((string) (parse_url($url, PHP_URL_HOST) ?? ''), '[]');
+        $host = self::normalizeHost((string) (parse_url($url, PHP_URL_HOST) ?? ''));
 
-        if ($host === '') {
+        if ($host === null) {
             return false;
         }
 
@@ -151,10 +155,54 @@ class OutboundUrlGuard
     /**
      * Whether an IP address sits in a publicly-routable range (rejecting private,
      * loopback, link-local, and other reserved blocks in both IPv4 and IPv6).
+     *
+     * The filter flags carry IPv4 on their own, but for IPv6 they only reject
+     * `fc00::/7` (`NO_PRIV_RANGE`) plus `::/128`, `::1/128`, `::ffff:0:0/96` and
+     * `fe80::/10` (`NO_RES_RANGE`) — an undocumented table that has never
+     * covered `fec0::/10` or `ff00::/8`. So the v6 ranges are checked here, on
+     * the packed address, rather than resting on PHP's internals.
      */
     private static function isPublicIp(string $ip): bool
     {
-        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            return false;
+        }
+
+        $packed = inet_pton($ip);
+
+        if ($packed === false || strlen($packed) !== 16) {
+            return true;
+        }
+
+        $first = ord($packed[0]);
+        $second = ord($packed[1]);
+
+        return match (true) {
+            $first === 0xFE && ($second & 0xC0) === 0x80 => false, // fe80::/10 link-local.
+            $first === 0xFE && ($second & 0xC0) === 0xC0 => false, // fec0::/10 site-local (deprecated).
+            $first === 0xFF => false, // ff00::/8 multicast.
+            default => true,
+        };
+    }
+
+    /**
+     * The URL's host in the form the checks below expect — IPv6 brackets
+     * stripped — or `null` when there is nothing usable to check.
+     *
+     * A zone index (`fe80::1%eth0`, or `%25eth0` once encoded into the URL) is
+     * rejected outright: it is never part of a public destination, and left in
+     * place it fails {@see FILTER_VALIDATE_IP}, so the address would fall
+     * through to the hostname branch and skip the IP ranges entirely.
+     */
+    private static function normalizeHost(string $host): ?string
+    {
+        $host = trim($host, '[]');
+
+        if ($host === '' || str_contains($host, '%')) {
+            return null;
+        }
+
+        return $host;
     }
 
     /**

--- a/tests/Feature/Support/OutboundUrlGuardTest.php
+++ b/tests/Feature/Support/OutboundUrlGuardTest.php
@@ -61,15 +61,16 @@ it('rejects every reserved IPv6 literal, at both ends of each range', function (
     'loopback' => '::1',
     'ipv4-mapped-loopback' => '::ffff:127.0.0.1',
     'ipv4-mapped-metadata' => '::ffff:169.254.169.254',
-    'unique-local-bottom' => 'fc00::1',
-    'unique-local-top' => 'fdff:ffff::1',
-    'link-local-bottom' => 'fe80::1',
-    'link-local-top' => 'febf:ffff::1',
-    'site-local-bottom' => 'fec0::1',
-    'site-local-top' => 'feff:ffff::1',
+    'unique-local-bottom' => 'fc00::',
+    'unique-local-top' => 'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+    'link-local-bottom' => 'fe80::',
+    'link-local' => 'fe80::1',
+    'link-local-top' => 'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+    'site-local-bottom' => 'fec0::',
+    'site-local-top' => 'feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
     'multicast-bottom' => 'ff00::',
     'multicast-all-nodes' => 'ff02::1',
-    'multicast-top' => 'ffff:ffff::1',
+    'multicast-top' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
 ]);
 
 it('accepts a literal public IP', function (): void {

--- a/tests/Feature/Support/OutboundUrlGuardTest.php
+++ b/tests/Feature/Support/OutboundUrlGuardTest.php
@@ -54,8 +54,39 @@ it('rejects literal private, loopback, link-local, and metadata IPs', function (
     'ipv6-loopback' => 'http://[::1]/x',
 ]);
 
+it('rejects every reserved IPv6 literal, at both ends of each range', function (string $ip): void {
+    expect(OutboundUrlGuard::isPublic('http://['.$ip.']/x'))->toBeFalse();
+})->with([
+    'unspecified' => '::',
+    'loopback' => '::1',
+    'ipv4-mapped-loopback' => '::ffff:127.0.0.1',
+    'ipv4-mapped-metadata' => '::ffff:169.254.169.254',
+    'unique-local-bottom' => 'fc00::1',
+    'unique-local-top' => 'fdff:ffff::1',
+    'link-local-bottom' => 'fe80::1',
+    'link-local-top' => 'febf:ffff::1',
+    'site-local-bottom' => 'fec0::1',
+    'site-local-top' => 'feff:ffff::1',
+    'multicast-bottom' => 'ff00::',
+    'multicast-all-nodes' => 'ff02::1',
+    'multicast-top' => 'ffff:ffff::1',
+]);
+
 it('accepts a literal public IP', function (): void {
     expect(OutboundUrlGuard::isPublic('https://8.8.8.8/x'))->toBeTrue();
+    expect(OutboundUrlGuard::isPublic('https://[2606:4700:4700::1111]/x'))->toBeTrue();
+});
+
+it('rejects a zone-index host, which would otherwise pass as a hostname', function (string $url): void {
+    expect(OutboundUrlGuard::isPublic($url))->toBeFalse();
+})->with([
+    'encoded' => 'http://[fe80::1%25eth0]/x',
+    'raw' => 'http://[fe80::1%eth0]/x',
+    'unbracketed' => 'http://fe80::1%25eth0/x',
+]);
+
+it('blocks delivery to a zone-index host', function (): void {
+    expect(guardResolving(['93.184.216.34'])->resolveDeliveryIp('http://[fe80::1%25eth0]/hook'))->toBeFalse();
 });
 
 it('rejects local hostnames without a DNS lookup', function (string $url): void {
@@ -87,7 +118,16 @@ it('blocks delivery when any resolved address is non-public', function (string $
     'loopback' => '127.0.0.1',
     'metadata' => '169.254.169.254',
     'ipv6-loopback' => '::1',
+    'ipv6-unique-local' => 'fc00::1',
+    'ipv6-link-local' => 'fe80::1',
+    'ipv6-site-local' => 'fec0::1',
+    'ipv6-multicast' => 'ff02::1',
 ]);
+
+it('resolves a hostname to a vetted public IPv6 address for delivery pinning', function (): void {
+    expect(guardResolving(['2606:4700:4700::1111'])->resolveDeliveryIp('https://example.test/hook'))
+        ->toBe('2606:4700:4700::1111');
+});
 
 it('blocks delivery when the hostname does not resolve', function (): void {
     expect(guardResolving([])->resolveDeliveryIp('https://example.test/hook'))->toBeFalse();
@@ -115,6 +155,18 @@ it('drives the PublicWebhookUrl validation rule', function (): void {
     expect($fails->fails())->toBeTrue()
         ->and($fails->errors()->first('url'))->toBe('The webhook URL must be a public HTTP or HTTPS address.');
 });
+
+it('rejects a reserved IPv6 endpoint through the validation rule', function (string $url): void {
+    $validator = Validator::make(['url' => $url], ['url' => new PublicWebhookUrl]);
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('url'))->toBe('The webhook URL must be a public HTTP or HTTPS address.');
+})->with([
+    'link-local' => 'http://[fe80::1]/webhook',
+    'site-local' => 'http://[fec0::1]/webhook',
+    'multicast' => 'http://[ff02::1]/webhook',
+    'zone-index' => 'http://[fe80::1%25eth0]/webhook',
+]);
 
 it('lets a surface name the destination in its own words', function (): void {
     $fails = Validator::make(


### PR DESCRIPTION
Closes #1177.

## What

`OutboundUrlGuard` now owns its IPv6 reserved-range table instead of delegating the whole decision to `filter_var`, and rejects a host carrying a zone index.

- `isPublicIp()` keeps the filter flags as a first pass, then checks the packed address for `fe80::/10` (link-local), `fec0::/10` (site-local, deprecated) and `ff00::/8` (multicast).
- A new `normalizeHost()` strips IPv6 brackets and returns `null` for an empty host or one containing `%`, so both `isPublic()` and `resolveDeliveryIp()` reject a zone index.
- The `isPublicIp()` docblock now describes what the code actually does, including which ranges PHP's flags do and don't cover.

## Why

One correction to the issue's premise, verified against PHP 8.5.8 in the container: `fe80::/10` is **already** rejected today, by `FILTER_FLAG_NO_RES_RANGE` (not `NO_PRIV_RANGE`). The genuinely open ranges were `fec0::/10` and `ff00::/8`, and the zone-index path was a real bypass — `http://[fe80::1%25eth0]/` fails `FILTER_VALIDATE_IP`, so it fell through to the *hostname* branch and skipped the IP table entirely. `isPublic()` returned `true`, and `resolveDeliveryIp()` resolved it as a hostname and pinned the connection.

Either way, the guard's link-local guarantee rested on an undocumented `filter_var` table that has never covered `fec0::/10` or `ff00::/8`. Doing the range check here makes the promise in the docblock the guard's own.

This closes the guard-side half of link-preview SSRF; #1172 (the missing IP pin in `FetchLinkPreview`) is still needed for the other half.

## How tested

`tests/Feature/Support/OutboundUrlGuardTest.php`, 53 tests:

- The full reserved-IPv6 table through `isPublic()`, at the exact inclusive endpoints of each range (`fc00::` … `fdff:ffff:…:ffff`, `fe80::` … `febf:…`, `fec0::` … `feff:…`, `ff00::` … `ffff:…`), plus the unspecified, loopback and IPv4-mapped forms.
- Public IPv6 (`2606:4700:4700::1111`) still passes, both as a literal and as a delivery-pinned resolution.
- Zone-index hosts rejected by `isPublic()` (encoded and raw) and blocked by `resolveDeliveryIp()`.
- Delivery-time resolution blocked for each reserved v6 range.
- `PublicWebhookUrl` rejects link-local, site-local, multicast and zone-index endpoints with the existing message.

Backend gate green, `Total: 100.0 %` (`OutboundUrlGuard` at 100%). No i18n or docs changes: the failure message already exists and has its French translation, and no `.env`/config surface changed.

## Noted, out of scope

`2002:0a00:0001::1` (6to4 encapsulating `10.0.0.1`) still passes the guard. 6to4 is deprecated by RFC 7526 and rarely enabled, and it isn't in this issue's range table, so I left it alone rather than widen the scope. Happy to file a follow-up if it's worth closing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788369112&installation_model_id=428379&pr_number=1190&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1190&signature=e69a48584b41bdbb63db53d08bcb52c8685e49369d7ab99a281a4adfe2b32feb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->