### PR TITLE
fix!: require a timestamped signature from every signed incoming webhook

### DIFF
--- a/app/Http/Controllers/Webhooks/IncomingWebhookController.php
+++ b/app/Http/Controllers/Webhooks/IncomingWebhookController.php
@@ -38,7 +38,7 @@ class IncomingWebhookController extends Controller
 
     /**
      * The request header carrying the Unix timestamp the signature was computed
-     * at. Its presence selects the timestamped scheme: the signed message becomes
+     * at. Every signed request states one: the signed message is
      * `"{timestamp}.{raw body}"`, the same one outgoing deliveries use.
      */
     private const string TIMESTAMP_HEADER = 'X-Timestamp';
@@ -130,12 +130,12 @@ class IncomingWebhookController extends Controller
      * secret. An unsigned webhook skips this entirely (drop-in curl support); a
      * signed one rejects a missing or mismatched signature with 401.
      *
-     * Two schemes are verified here. The one to send signs `"{timestamp}.{body}"`
-     * and states that timestamp, which bounds how long a captured request stays
-     * usable and lets a replay inside that window be refused outright. The other
-     * signs the body alone and replays forever; it is accepted only by webhooks
-     * created before the timestamped scheme existed, whose senders predate it,
-     * and those webhooks accept either so a sender can move over on its own.
+     * One scheme is verified here: the sender signs `"{timestamp}.{body}"` and
+     * states that timestamp, which bounds how long a captured request stays
+     * usable and lets a replay inside that window be refused outright. A digest
+     * over the body alone replays forever and is no longer accepted from any
+     * webhook, so an absent or malformed timestamp is refused rather than
+     * quietly falling back to verifying the body on its own.
      */
     private function verifySignature(Request $request, IncomingWebhook $webhook): void
     {
@@ -147,56 +147,43 @@ class IncomingWebhookController extends Controller
         $signature = is_string($header) ? Str::after($header, 'sha256=') : '';
         $timestamp = $this->signedTimestamp($request);
 
-        // A webhook minted under the timestamped scheme never falls back to the
-        // replayable one, so an absent or malformed timestamp is refused here
-        // rather than quietly verifying the body on its own.
-        abort_if($timestamp === null && $webhook->requires_signed_timestamp, 401);
-
         // `claimSignature` is last on purpose: it has a side effect, and the
         // short-circuit keeps it from burning a signature that failed anything
         // before it.
         abort_unless(
-            $signature !== ''
+            $timestamp !== null
+                && $signature !== ''
                 && $this->timestampIsFresh($timestamp)
                 && $webhook->signatureMatches($signature, $request->getContent(), $timestamp)
-                && $this->claimSignature($webhook, $signature, $timestamp),
+                && $this->claimSignature($webhook, $signature),
             401,
         );
     }
 
     /**
-     * Record a timestamped signature as spent, and report whether it was still
-     * unspent — a replay inside the freshness window loses the race and is
-     * refused. The marker outlives the window it was accepted in: a timestamp up
-     * to the tolerance in the future stays fresh for twice the tolerance, so a
-     * shorter marker would expire while the signature is still verifiable.
-     *
-     * A request under the legacy scheme carries no timestamp to bound the marker,
-     * so there is nothing here to expire against and it is not claimed.
+     * Record a signature as spent, and report whether it was still unspent — a
+     * replay inside the freshness window loses the race and is refused. The
+     * marker outlives the window it was accepted in: a timestamp up to the
+     * tolerance in the future stays fresh for twice the tolerance, so a shorter
+     * marker would expire while the signature is still verifiable.
      */
-    private function claimSignature(IncomingWebhook $webhook, string $signature, ?int $timestamp): bool
+    private function claimSignature(IncomingWebhook $webhook, string $signature): bool
     {
-        if ($timestamp === null) {
-            return true;
-        }
-
         return Cache::add("incoming-webhook:{$webhook->id}:{$signature}", true, self::TIMESTAMP_TOLERANCE * 2);
     }
 
     /**
-     * Whether a claimed signing time is close enough to now to be acted on. A
-     * request carrying no timestamp is not held to the window — it is verified
-     * under the legacy scheme instead.
+     * Whether a claimed signing time is close enough to now to be acted on.
      */
-    private function timestampIsFresh(?int $timestamp): bool
+    private function timestampIsFresh(int $timestamp): bool
     {
-        return $timestamp === null || abs(now()->getTimestamp() - $timestamp) <= self::TIMESTAMP_TOLERANCE;
+        return abs(now()->getTimestamp() - $timestamp) <= self::TIMESTAMP_TOLERANCE;
     }
 
     /**
      * The Unix timestamp the request claims to have been signed at, or null when
-     * the header is absent or not an integer — either way the request is held to
-     * the legacy body-only scheme, which only a legacy webhook still accepts.
+     * the header is absent or not an integer — a signed request that states no
+     * usable timestamp cannot be verified at all and is refused.
      */
     private function signedTimestamp(Request $request): ?int
     {

--- a/app/Models/IncomingWebhook.php
+++ b/app/Models/IncomingWebhook.php
@@ -26,7 +26,6 @@ use Illuminate\Support\Carbon;
  * @property string $name
  * @property string $token_hash
  * @property string|null $signing_secret
- * @property bool $requires_signed_timestamp
  * @property Carbon|null $revoked_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -34,7 +33,7 @@ use Illuminate\Support\Carbon;
  * @property-read Channel|null $channel
  * @property-read User $bot
  */
-#[Fillable(['team_id', 'channel_id', 'bot_id', 'created_by', 'name', 'token_hash', 'signing_secret', 'requires_signed_timestamp'])]
+#[Fillable(['team_id', 'channel_id', 'bot_id', 'created_by', 'name', 'token_hash', 'signing_secret'])]
 class IncomingWebhook extends Model
 {
     /** @use HasFactory<IncomingWebhookFactory> */
@@ -48,7 +47,6 @@ class IncomingWebhook extends Model
     {
         return [
             'signing_secret' => 'encrypted',
-            'requires_signed_timestamp' => 'boolean',
             'revoked_at' => 'datetime',
         ];
     }
@@ -77,23 +75,19 @@ class IncomingWebhook extends Model
      * A webhook without a signing secret is unsigned and never matches here — the
      * caller decides whether an unsigned request is acceptable.
      *
-     * Passing a timestamp signs `"{timestamp}.{body}"` through the same
+     * The signed message is `"{timestamp}.{body}"`, computed through the same
      * {@see WebhookSignature} both directions share, so a captured request stops
      * verifying once its timestamp falls outside the caller's freshness window.
-     * Omitting it is the original body-only scheme, which replays forever and
-     * survives only for webhooks minted before the timestamped one.
+     * The timestamp is not optional: a digest over the body alone replays
+     * forever, and signing one is no longer a way to authenticate here.
      */
-    public function signatureMatches(string $signature, string $rawBody, ?int $timestamp = null): bool
+    public function signatureMatches(string $signature, string $rawBody, int $timestamp): bool
     {
         if ($this->signing_secret === null) {
             return false;
         }
 
-        $expected = $timestamp === null
-            ? hash_hmac('sha256', $rawBody, $this->signing_secret)
-            : WebhookSignature::digest($this->signing_secret, $rawBody, $timestamp);
-
-        return hash_equals($expected, $signature);
+        return hash_equals(WebhookSignature::digest($this->signing_secret, $rawBody, $timestamp), $signature);
     }
 
     /**

--- a/database/factories/IncomingWebhookFactory.php
+++ b/database/factories/IncomingWebhookFactory.php
@@ -38,17 +38,6 @@ class IncomingWebhookFactory extends Factory
     }
 
     /**
-     * Indicate that the webhook predates the timestamped signing scheme, so its
-     * senders still sign the raw body on its own.
-     */
-    public function legacySignatures(): static
-    {
-        return $this->state(fn (array $attributes): array => [
-            'requires_signed_timestamp' => false,
-        ]);
-    }
-
-    /**
      * Indicate that the webhook has been revoked and no longer resolves.
      */
     public function revoked(): static

--- a/database/migrations/2026_08_03_171735_drop_requires_signed_timestamp_from_incoming_webhooks_table.php
+++ b/database/migrations/2026_08_03_171735_drop_requires_signed_timestamp_from_incoming_webhooks_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('incoming_webhooks', function (Blueprint $table): void {
+            // The flag exempted webhooks that predated the timestamped signing
+            // scheme from it, for one release, so their senders could be moved
+            // over. Every signed webhook is held to that scheme now, so the
+            // exemption has nothing left to express — and a column that outlives
+            // the branch reading it is an exemption waiting to be honoured again.
+            $table->dropColumn('requires_signed_timestamp');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('incoming_webhooks', function (Blueprint $table): void {
+            // Rolling back restores the column, not the exemption: the code that
+            // read it is gone, so every row lands on the scheme they all now use
+            // rather than being swept back into a window that has closed.
+            $table->boolean('requires_signed_timestamp')->default(true);
+        });
+    }
+};

--- a/docs/src/content/docs/reference/incoming-webhooks.md
+++ b/docs/src/content/docs/reference/incoming-webhooks.md
@@ -158,19 +158,19 @@ Two rules follow from it, and a sender has to satisfy both:
   message: if the first attempt did reach The Desk, that 401 is the duplicate
   being refused rather than an authentication problem.
 
-### Migrating an existing webhook
+### The body-only scheme has been removed
 
-Webhooks created **before** you upgraded to this version still accept the old
-scheme, where the digest covers the body alone and no `X-Timestamp` is sent:
-upgrading The Desk cannot rewrite the systems that post to them. Those webhooks
-accept **either** scheme, so you can switch a sender over on its own schedule and
-verify it before anything changes on this end.
+An older scheme signed the body alone and sent no `X-Timestamp`. A signature like
+that never expires, so a captured request replays forever — the whole reason the
+timestamp exists. Webhooks that predated the timestamped scheme were allowed to
+keep using it for one release, so their senders could be moved over without a
+coordinated flip at both ends.
 
-They keep accepting the old scheme, and stay replayable, until you retire them:
-**revoke the webhook and create a new one**, then move the sender to the new URL.
-Every webhook created from now on requires the timestamp and cannot fall back.
-Treat the old scheme as deprecated and plan the swap: a future release will drop
-it, and any sender still on it will start getting **401**.
+That window has closed. **Every signed webhook now requires `X-Timestamp`**, and
+a sender still signing the body alone gets **401**, whenever the webhook was
+created. There is nothing to re-mint: the URL and the signing secret are
+unchanged, and the fix is entirely on the sending side — sign
+`"{timestamp}.{body}"` and send that timestamp, as above.
 
 :::caution[Not the header outgoing deliveries use]
 Deliveries _from_ The Desk are signed with `X-Desk-Signature`, which packs both

--- a/docs/src/content/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/self-hosting/upgrading.md
@@ -237,6 +237,30 @@ queue, so real-time updates still arrive — they simply wait behind whatever el
 that worker is busy with, which is how the stack behaved before the service
 existed. Adding it is what makes them immediate.
 
+### Behaviour retired in a release
+
+A release can also **remove** something a previous one deprecated. Nothing in
+your `.env` or your compose file changes, so there is no report to read — the
+break shows up in whatever was still relying on it.
+
+:::danger[Incoming webhooks: the body-only signature is gone]
+Incoming webhooks created before the timestamped signing scheme existed were
+allowed to keep signing the request body on its own, with no `X-Timestamp`
+header, for one release. That exemption has been removed: **every** signed
+incoming webhook now requires the timestamp, and a sender still signing the body
+alone gets **401** from the upgrade onwards.
+
+Only webhooks that were minted with a signing secret *and* whose sender was never
+moved over are affected. Unsigned webhooks are untouched, and so is any sender
+already sending `X-Timestamp`. If you are not sure, the sender's own logs are the
+place to look: a `401` where a `202` used to be is this.
+
+Fix it by signing `"{timestamp}.{body}"` and sending the timestamp you signed at,
+exactly as the current scheme has always documented — see
+[Signing](/reference/incoming-webhooks/#signing-optional). The webhook URL and
+its signing secret do not change, so no re-minting is needed.
+:::
+
 ### If it fails, it stops and hands you the backup
 
 The script **never rolls back on its own**, and that is deliberate.

--- a/tests/Feature/Integrations/IncomingWebhookIngestTest.php
+++ b/tests/Feature/Integrations/IncomingWebhookIngestTest.php
@@ -10,6 +10,7 @@ use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 /**
@@ -218,37 +219,30 @@ it('accepts a signature sitting exactly on the edge of the freshness window', fu
     'a clock five minutes ahead' => [300],
 ]);
 
-it('still accepts a body-only signature from a webhook that predates the timestamp', function (): void {
+it('401s a body-only signature however long the webhook has existed', function (): void {
     $secret = Str::random(48);
-    [$webhook, $token] = makeWebhook(['signing_secret' => $secret, 'requires_signed_timestamp' => false]);
+    [$webhook, $token] = makeWebhook(['signing_secret' => $secret]);
 
-    $payload = ['body' => 'signed and sealed'];
+    // Webhooks minted before the timestamped scheme were exempted from it for
+    // one release so their senders could be moved over. That exemption is gone:
+    // a webhook's age no longer buys it the replayable scheme, and the 401 is
+    // how a sender still on the old one finds out.
+    $webhook->forceFill(['created_at' => now()->subYear()])->save();
+
+    $payload = ['body' => 'signed the old way'];
     $signature = hash_hmac('sha256', json_encode($payload), $secret);
 
-    // The migration window: this sender was written against the old scheme and
-    // cannot be updated by upgrading The Desk.
     $this->postJson("/webhooks/incoming/{$token}", $payload, ['X-Signature-256' => 'sha256='.$signature])
-        ->assertStatus(202);
+        ->assertStatus(401);
 
-    $this->assertDatabaseHas('messages', ['channel_id' => $webhook->channel_id, 'body' => 'signed and sealed']);
+    $this->assertDatabaseCount('messages', 0);
 });
 
-it('lets a legacy webhook move to the timestamped scheme before it is required', function (): void {
-    $secret = Str::random(48);
-    [$webhook, $token] = makeWebhook(['signing_secret' => $secret, 'requires_signed_timestamp' => false]);
-
-    $payload = ['body' => 'migrated early'];
-    $timestamp = now()->getTimestamp();
-    $signature = hash_hmac('sha256', $timestamp.'.'.json_encode($payload), $secret);
-
-    // Accepting both is what makes the window usable: a sender switches over on
-    // its own schedule, with no coordinated flip at the other end.
-    $this->postJson("/webhooks/incoming/{$token}", $payload, [
-        'X-Signature-256' => 'sha256='.$signature,
-        'X-Timestamp' => (string) $timestamp,
-    ])->assertStatus(202);
-
-    $this->assertDatabaseHas('messages', ['channel_id' => $webhook->channel_id, 'body' => 'migrated early']);
+it('no longer carries a column that could exempt a webhook from the timestamp', function (): void {
+    // The exemption was a schema flag, so retiring the branch that read it is
+    // only half the job — a surviving column is an exemption waiting to be
+    // honoured again by the next person who finds it.
+    expect(Schema::hasColumn('incoming_webhooks', 'requires_signed_timestamp'))->toBeFalse();
 });
 
 it('accepts a bare hex signature without the sha256= prefix', function (): void {

--- a/tests/Feature/Integrations/IncomingWebhookTest.php
+++ b/tests/Feature/Integrations/IncomingWebhookTest.php
@@ -61,14 +61,6 @@ it('optionally mints an encrypted HMAC signing secret', function (): void {
     expect($raw)->not->toBe($result->signingSecret);
 });
 
-it('mints a webhook on the timestamped signing scheme', function (): void {
-    $result = app(CreateIncomingWebhook::class)->handle($this->bot, $this->channel, $this->owner, 'Signed', withSigningSecret: true);
-
-    // Only webhooks that predate the scheme are exempt, and they are exempted by
-    // the migration that introduced it — nothing minted from here on is.
-    expect($result->webhook->fresh()?->requires_signed_timestamp)->toBeTrue();
-});
-
 it('refuses to bind a webhook to a channel the bot is not a member of', function (): void {
     $other = Channel::factory()->for($this->team)->create();
 

--- a/tests/Unit/IncomingWebhookSignatureTest.php
+++ b/tests/Unit/IncomingWebhookSignatureTest.php
@@ -12,28 +12,20 @@ uses(TestCase::class);
 it('never matches a signature when the webhook has no signing secret', function (): void {
     $webhook = new IncomingWebhook(['signing_secret' => null]);
 
-    expect($webhook->signatureMatches('anything', '{"body":"hi"}'))->toBeFalse();
+    expect($webhook->signatureMatches('anything', '{"body":"hi"}', 1764547200))->toBeFalse();
 });
 
-it('matches only the correct HMAC-SHA256 signature of the raw body', function (): void {
-    $secret = 'shhh';
-    $body = '{"body":"hi"}';
-    $webhook = new IncomingWebhook(['signing_secret' => $secret]);
-
-    expect($webhook->signatureMatches(hash_hmac('sha256', $body, $secret), $body))->toBeTrue()
-        ->and($webhook->signatureMatches('wrong', $body))->toBeFalse();
-});
-
-it('signs the timestamp together with the body when one is given', function (): void {
+it('signs the timestamp together with the body', function (): void {
     $secret = 'shhh';
     $body = '{"body":"hi"}';
     $timestamp = 1764547200;
     $webhook = new IncomingWebhook(['signing_secret' => $secret]);
 
     expect($webhook->signatureMatches(hash_hmac('sha256', $timestamp.'.'.$body, $secret), $body, $timestamp))->toBeTrue()
+        ->and($webhook->signatureMatches('wrong', $body, $timestamp))->toBeFalse()
         // The body-only digest signs a different message and cannot stand in for
-        // it, which is what stops a captured legacy request from being replayed
-        // as a timestamped one.
+        // it, which is what stops a captured request signed the old way from
+        // being replayed as a timestamped one.
         ->and($webhook->signatureMatches(hash_hmac('sha256', $body, $secret), $body, $timestamp))->toBeFalse()
         // And the timestamp is bound to the digest: restating it does not help.
         ->and($webhook->signatureMatches(hash_hmac('sha256', $timestamp.'.'.$body, $secret), $body, $timestamp + 1))->toBeFalse();


### PR DESCRIPTION
Closes #1188.

## Why this is a draft

**Do not merge until the release carrying #1187 has actually shipped.**

#1187 added the timestamped signing scheme and exempted pre-existing webhooks
via `incoming_webhooks.requires_signed_timestamp`. That PR is on `develop` and in
no tag — `v1.19.0` predates it — so its migration has never run on any install.

If this lands in the same release as #1187, an operator upgrading from v1.19.0
runs both migrations back to back: the exemption is written and dropped in one
upgrade, and every signed incoming webhook they already have breaks at that
moment. The migration window would exist only inside `develop` and never in
anything installable, which defeats the point of #1187 having built one.

Shipping #1187 first, then this in the following release, gives senders one
release in which the old scheme still works while they are moved over — which is
what `docs/` currently promises them.

## What changed

- The body-only verification path is gone. `verifySignature()` refuses a signed
  request that states no usable `X-Timestamp`, for every webhook, rather than
  falling back to verifying the body on its own.
- `IncomingWebhook::signatureMatches()` takes a required `int $timestamp` — a
  body-only digest is no longer something the model can produce or accept.
- `requires_signed_timestamp` is dropped: the column, the cast, the fillable
  entry, the model property, and the unused `legacySignatures()` factory state. A
  column that outlives the branch reading it is an exemption waiting to be
  honoured again.
- `claimSignature()` and `timestampIsFresh()` lose their null branches.

## Breaking change

Incoming webhooks signing the request body alone, with no `X-Timestamp` header,
now get **401**. Senders must sign `"{timestamp}.{body}"` and send that
timestamp. The webhook URL and its signing secret are unchanged, so nothing needs
re-minting — the fix is entirely on the sending side.

Unsigned webhooks are unaffected, as is any sender already sending
`X-Timestamp`.

## Docs

- `reference/incoming-webhooks.md` — the "Migrating an existing webhook" section
  becomes "The body-only scheme has been removed", stating the break rather than
  deprecating it.
- `self-hosting/upgrading.md` — a new "Behaviour retired in a release" section
  with a `danger` callout naming who is affected, how it surfaces (a 401 where a
  202 used to be, visible in the sender's own logs), and the fix.

No user-facing copy changed in the app, so no `lang/fr.json` keys were added.

## Testing

- `401s a body-only signature however long the webhook has existed` replaces the
  two tests that encoded the legacy allowance.
- `no longer carries a column that could exempt a webhook from the timestamp`
  guards the schema, so the exemption cannot be quietly reinstated.
- `mints a webhook on the timestamped signing scheme` was removed — it asserted
  the retired column.
- Backend gate green, `Total: 100.0 %` on a raw `--coverage --min=100` run.
  Frontend gate (lint/format/types/test:js/build) and the docs build green.

CodeRabbit raised one minor finding — a test for the migration's `up()`/`down()`.
Skipped: `up()` is already exercised (every run migrates fresh, and the schema
test asserts the column is gone), and no migration in this repo has a rollback
test, so adding one would invent a convention rather than follow one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788370458&installation_model_id=428379&pr_number=1191&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1191&signature=f4b8e581ac4db38b2d474cf65ff6e1a87d4647a27636da717e3f9581c99ca8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->