### PR TITLE
fix: reject a scheduled reply that quotes a system notice

### DIFF
--- a/app/Http/Requests/Channels/ScheduleMessageRequest.php
+++ b/app/Http/Requests/Channels/ScheduleMessageRequest.php
@@ -3,9 +3,9 @@
 namespace App\Http\Requests\Channels;
 
 use App\Http\Requests\RouteBoundRequest;
+use App\Rules\MessageTarget;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Validation\Rule;
 
 class ScheduleMessageRequest extends RouteBoundRequest
 {
@@ -46,15 +46,7 @@ class ScheduleMessageRequest extends RouteBoundRequest
             // insists the moment is still in the future, so a stale request that
             // has slipped into the past is rejected rather than firing instantly.
             'send_at' => ['required', 'date', 'after:now'],
-            // An inline reply must quote a live (non-deleted) message in this same
-            // channel, exactly like an immediate reply.
-            'reply_to_id' => [
-                'nullable',
-                'uuid',
-                Rule::exists('messages', 'id')
-                    ->where('channel_id', $this->channel()->id)
-                    ->whereNull('deleted_at'),
-            ],
+            'reply_to_id' => ['nullable', 'uuid', MessageTarget::replyTo($this->channel())],
         ];
     }
 }

--- a/tests/Feature/Channels/SystemMessageTest.php
+++ b/tests/Feature/Channels/SystemMessageTest.php
@@ -115,6 +115,22 @@ test('a system notice cannot be the root of a thread reply', function (): void {
         ->assertSessionHasErrors('thread_root_id');
 });
 
+test('a scheduled message cannot inline-reply to a system notice', function (): void {
+    [$owner, $team, $general, $notice] = systemNoticeFixture();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+        ]), [
+            'body' => 'scheduling a reply to a notice',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+            'reply_to_id' => $notice->id,
+        ])
+        ->assertSessionHasErrors('reply_to_id');
+});
+
 test('MessageData exposes the message type', function (): void {
     [, , , $notice] = systemNoticeFixture();
     $notice->loadMessageDataRelations();


### PR DESCRIPTION
Closes #1165.

## What

`ScheduleMessageRequest` validated `reply_to_id` with its own `Rule::exists` chain that
checked the channel and `deleted_at` but not the message type, under a comment claiming it
behaved *"exactly like an immediate reply"*. It did not: every other path accepting a
`reply_to_id` or `thread_root_id` also excludes system notices. So a user who could not
reply to *":name joined the channel"* could schedule that same reply and have it post,
quoting an inert, bodyless row.

The chain is replaced by the shared rule added in #1150:

```php
'reply_to_id' => ['nullable', 'uuid', MessageTarget::replyTo($this->channel())],
```

`MessageTarget` already excludes `MessageType::systemValues()` and, being an Eloquent query
on a `SoftDeletes` model, still scopes to the channel and still excludes deleted targets —
so the three behaviours the old chain carried are preserved and the missing fourth is added.
The now-inaccurate comment went with it, matching `PostMessageRequest`, where the rule class
documents itself.

## Why this shape

The issue asks for the rule to be reached through `MessageTarget::replyTo()` rather than a
seventh `Rule::exists` chain, which is what makes the divergence impossible to reintroduce:
scheduling now shares the one definition of *"a message an inline reply may quote"* with
the immediate path.

## Testing

New `a scheduled message cannot inline-reply to a system notice` in
`tests/Feature/Channels/SystemMessageTest.php`, alongside the existing immediate-reply and
thread-root assertions and reusing `systemNoticeFixture()`. It fails before the change
(`Session is missing expected key [errors]`) and passes after.

Backend gate green; a raw `artisan test --parallel --coverage --min=100` run reports
`Total: 100.0 %`. Frontend `lint:check` / `format:check` / `types:check` pass. `build` and
`test:js` were not run — the diff is PHP-only.

## i18n / docs

None. No user-facing copy is added (the refusal keeps Laravel's own `validation.exists`
message, unchanged), and nothing here is operator-facing.

## Out of scope

`UpdateScheduledMessageRequest` does not accept `reply_to_id` at all, and
`SetMessageReminderRequest` is excluded by the issue deliberately — reminding yourself
about a system notice is a different question.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788372012&installation_model_id=428379&pr_number=1192&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1192&signature=18f330ca7699396b907508739fc6c8a6635815b39ce5f9aff7b0008db1f85a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->