### PR TITLE
test: run the RouteBoundRequest dataset without booting a model

### DIFF
--- a/tests/Integration/Http/RouteBoundRequestTest.php
+++ b/tests/Integration/Http/RouteBoundRequestTest.php
@@ -47,15 +47,29 @@ function routeBoundRequest(array $parameters): RouteBoundRequest
  * reads. `channel` and `message` are the two `Api/V1\ApiRequest` already had;
  * `team` is the one the web subtree copied fifteen times.
  *
- * @return array<string, array{string, string, Model}>
+ * The model is named rather than instantiated here because a dataset is resolved
+ * while the suite is being *built* — before any application boots. `Message` is
+ * `Searchable`, and Scout's `bootSearchable()` reaches for a facade that has no
+ * root yet, so constructing one in this array threw. `Model::bootIfNotBooted()`
+ * marks a class booted before it boots it, so the throw landed exactly once:
+ * the first test to pull the dataset lost all three of its cases to a single
+ * provider error, and the two after it re-resolved the same dataset against an
+ * already-booted `Message` and ran normally. That is why the file exited 2
+ * while reporting nothing but passes, and why the full suite — where something
+ * boots `Message` long before this file is built — never showed it (#1167).
+ *
+ * @return array<string, array{string, string, class-string<Model>}>
  */
 dataset('recurring route models', fn (): array => [
-    'channel' => ['channel', 'channel', new Channel],
-    'team' => ['team', 'team', new Team],
-    'message' => ['message', 'message', new Message],
+    'channel' => ['channel', 'channel', Channel::class],
+    'team' => ['team', 'team', Team::class],
+    'message' => ['message', 'message', Message::class],
 ]);
 
-test('each accessor returns the model the route bound', function (string $accessor, string $key, Model $model): void {
+test('each accessor returns the model the route bound', function (string $accessor, string $key, string $class): void {
+    /** @var Model $model */
+    $model = new $class;
+
     expect(routeBoundRequest([$key => $model])->{$accessor}())->toBe($model);
 })->with('recurring route models');
 


### PR DESCRIPTION
Closes #1167.

## What

`tests/Integration/Http/RouteBoundRequestTest.php` now names its models
(`Channel::class`) instead of holding instances, and the test constructs one at
run time. The file reports 10 tests where it previously reported 7, and exits 0.

## Why

The dataset built `new Channel` / `new Team` / `new Message` inline. Pest
resolves a dataset while the suite is being *built*, before any application
boots. `Message` is `Searchable`, and Scout's `bootSearchable()` reaches for a
facade that has no root yet, so it threw `A facade root has not been set.`

Only one of the three dataset tests lost its cases because
`Model::bootIfNotBooted()` marks a class booted *before* it boots it. The throw
landed exactly once, on the first test to pull the dataset, which PHPUnit
collapsed into a single `with data set #0` provider error. The two tests after
it re-resolved the same dataset against an already-booted `Message` and ran
normally. In the full suite something boots `Message` long before this file is
built, which is why CI was always green.

That missing case was the positive half of #1151's specification: the one
asserting `channel()`, `team()` and `message()` return the model the route
bound. Only the two negative cases were running.

## Why a class-string and not a closure

The repo's other three datasets defer construction behind a closure, which was
the first thing tried here. Pest errors with `Undefined array key 2` when a
`Closure` value sits at an index the receiving test has no parameter for, and
two of these three tests take fewer parameters than the dataset supplies. A
class-string defers construction just as well without that constraint.

## Is it general? (third acceptance criterion)

The repo has exactly four `dataset()` definitions. The other three already
defer construction behind closures. Each was run standalone and exits 0 with
its full case count:

| File | Tests | Exit |
| --- | --- | --- |
| `tests/Feature/Http/Responses/AuthResponsesTest.php` | 10 | 0 |
| `tests/Feature/Teams/NestedResourceTenancyTest.php` | 28 | 0 |
| `tests/Feature/Teams/Integrations/IntegrationsAuthorizationTest.php` | 16 | 0 |

A sweep for file-scope model construction anywhere under `tests/` came back
empty, so this was the only instance.

## Testing

- `pest tests/Integration/Http/RouteBoundRequestTest.php`: 10 passed, exit 0.
- `composer test`: Pint, PHPStan and Rector clean, 3427/3427 passing.
- Coverage verified with a raw `artisan test --parallel --coverage --min=100`
  run: `Total: 100.0 %`, exit 0.
- Local CodeRabbit against `develop`: 0 findings.

No frontend gate: the diff is a single PHP test file with no frontend surface.
No i18n or docs changes: nothing user-facing or operator-facing ships here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788373246&installation_model_id=428379&pr_number=1194&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1194&signature=35f8b295782c646974919788e2b9db55e479852c83b2af5d90bf6457c41edb82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->