### PR TITLE
fix: route every member-controlled fetch through one guarded egress module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,6 +118,23 @@ built; build them once, then reuse.
   lapsed profile instant (compare-and-swap, then broadcast). Sweepers stay one
   Action per concern, each with its own name, description and
   `withoutOverlapping()` in `routes/console.php`; only the walk is shared.
+- **`GuardedEgress`** _(ADR-0015)_ — the one place the application opens a
+  connection to a **member-controlled** URL, in two named readings.
+  `fetch($url, FetchPolicy)` is *give me the bytes*: it owns the hop bound,
+  re-guards and re-pins every hop, disables curl-level redirects, enforces the
+  size cap and returns one null for every way a fetch can fail, a dead host
+  included. `send($url, PendingRequest)` is *send what I composed*: the guard
+  triple and the no-redirects rule and nothing else, for `DeliverWebhook`, which
+  keeps its own retry and failure log. Callers supply only what differs — the
+  content-type predicate, the byte cap, and which reading of the cap they want
+  (`FetchPolicy::truncatingAt()` for an unfurl, `refusingOver()` for an image).
+  **Never call `OutboundUrlGuard::resolveDeliveryIp()` or `transportOptions()`
+  from anywhere else**; `tests/Unit/GuardedEgressHomeTest.php` fails if you do.
+  `isPublic()` is the exception and stays public and static — it is a pre-flight
+  question asked before any request exists (`PublicWebhookUrl`,
+  `User::routeNotificationForWebPush`). Giphy, `UpdateChecker` and the OIDC
+  discovery calls are deliberately outside: they talk to operator-configured
+  hosts, and the ADR records why folding them in would be a mistake.
 - **Channel membership** — `ChannelMembership` is the one module that reads and
   writes the channel-member pivot: star, mute, notification level, draft, close
   (hide) and sidebar placement are its columns, not five unrelated settings. It is

--- a/app/Jobs/DeliverWebhook.php
+++ b/app/Jobs/DeliverWebhook.php
@@ -8,7 +8,7 @@ use App\Enums\AuditAction;
 use App\Enums\WebhookSubscriptionStatus;
 use App\Events\AuditableActionOccurred;
 use App\Models\WebhookSubscription;
-use App\Support\Http\OutboundUrlGuard;
+use App\Support\Http\GuardedEgress;
 use App\Support\Webhooks\WebhookSignature;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -82,8 +82,14 @@ class DeliverWebhook implements ShouldQueue
 
     /**
      * Attempt one delivery.
+     *
+     * The endpoint is member-controlled, so the request goes out through
+     * {@see GuardedEgress::send()} rather than the HTTP client directly. A
+     * destination the guard refuses arrives here the same way a dead one does —
+     * as a throw — so both are one failed attempt with no status code, logged
+     * with the reason and counted towards the auto-disable threshold.
      */
-    public function handle(OutboundUrlGuard $guard): void
+    public function handle(GuardedEgress $egress): void
     {
         if (! config('integrations.enabled')) {
             return;
@@ -99,35 +105,23 @@ class DeliverWebhook implements ShouldQueue
             return;
         }
 
-        if (! OutboundUrlGuard::isPublic($subscription->url)) {
-            $this->recordFailure($subscription, null, 'Blocked non-public webhook URL', 0);
-
-            return;
-        }
-
-        $pinnedIp = $guard->resolveDeliveryIp($subscription->url);
-
-        if ($pinnedIp === false) {
-            $this->recordFailure($subscription, null, 'Blocked webhook URL resolving to a non-public address', 0);
-
-            return;
-        }
-
         $body = (string) json_encode($this->envelope);
         $timestamp = now()->getTimestamp();
         $startedAt = microtime(true);
 
         try {
-            $response = Http::withHeaders([
-                'Content-Type' => 'application/json',
-                'X-Desk-Event' => (string) $this->envelope['type'],
-                'X-Desk-Delivery' => (string) $this->envelope['id'],
-                'X-Desk-Signature' => WebhookSignature::header($subscription->secret, $body, $timestamp),
-            ])
-                ->timeout((int) config('integrations.webhooks.timeout'))
-                ->withOptions($guard->transportOptions($subscription->url, $pinnedIp))
-                ->withBody($body, 'application/json')
-                ->post($subscription->url);
+            $response = $egress->send(
+                $subscription->url,
+                Http::withHeaders([
+                    'Content-Type' => 'application/json',
+                    'X-Desk-Event' => (string) $this->envelope['type'],
+                    'X-Desk-Delivery' => (string) $this->envelope['id'],
+                    'X-Desk-Signature' => WebhookSignature::header($subscription->secret, $body, $timestamp),
+                ])
+                    ->timeout((int) config('integrations.webhooks.timeout'))
+                    ->withBody($body, 'application/json'),
+                'POST',
+            );
         } catch (Throwable $exception) {
             $this->recordFailure($subscription, null, $this->summarize($exception->getMessage()), $this->elapsedMs($startedAt));
 

--- a/app/Support/FetchLinkPreview.php
+++ b/app/Support/FetchLinkPreview.php
@@ -3,34 +3,26 @@
 namespace App\Support;
 
 use App\Support\Http\AbsoluteUrl;
-use App\Support\Http\OutboundUrlGuard;
+use App\Support\Http\FetchedBody;
+use App\Support\Http\FetchPolicy;
+use App\Support\Http\GuardedEgress;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * Unfurls a member-posted URL into its Open Graph preview.
  *
- * The URL comes from whatever a member typed into a message, so every hop goes
- * through {@see OutboundUrlGuard}: public http(s) hosts only, the connection
- * pinned to the address the guard vetted, redirects followed manually so each
- * new target is re-checked rather than handed to curl.
+ * The URL comes from whatever a member typed into a message, so the fetch goes
+ * through {@see GuardedEgress}, which owns the SSRF guarding, the pinning and
+ * the redirect walk. This class supplies only what is its own: HTML, two
+ * megabytes of it, and what to make of what comes back.
  */
 class FetchLinkPreview
 {
     /**
-     * Total time budget for a single request, in seconds.
-     */
-    private const int TIMEOUT_SECONDS = 5;
-
-    /**
-     * How many redirect hops to follow before giving up. Each hop is re-validated
-     * against the SSRF guard so a public URL can't bounce us onto an internal one.
-     */
-    private const int MAX_REDIRECTS = 3;
-
-    /**
      * Hard cap on the HTML we read and parse, guarding against huge responses.
+     * A truncated document is fine here — everything an unfurl reads is in
+     * `<head>`.
      */
     private const int MAX_BYTES = 2097152; // 2 MB
 
@@ -45,7 +37,7 @@ class FetchLinkPreview
      */
     private const string FAILED = '__failed__';
 
-    public function __construct(private readonly OutboundUrlGuard $guard) {}
+    public function __construct(private readonly GuardedEgress $egress) {}
 
     /**
      * Unfurl a URL into its Open Graph preview, or null when it can't be fetched.
@@ -73,67 +65,16 @@ class FetchLinkPreview
      */
     private function unfurl(string $url): ?array
     {
-        $fetched = $this->fetch($url);
+        $fetched = $this->egress->fetch($url, FetchPolicy::truncatingAt(
+            self::MAX_BYTES,
+            static fn (string $contentType): bool => $contentType === 'text/html',
+        ));
 
-        if ($fetched === null) {
+        if (! $fetched instanceof FetchedBody) {
             return null;
         }
 
-        [$finalUrl, $html] = $fetched;
-
-        return $this->parse($html, $finalUrl);
-    }
-
-    /**
-     * Request the URL, manually following redirects and re-validating each hop.
-     *
-     * @return array{0: string, 1: string}|null The final URL and its HTML body.
-     */
-    private function fetch(string $url): ?array
-    {
-        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
-            if (! OutboundUrlGuard::isPublic($url)) {
-                return null;
-            }
-
-            $pinnedIp = $this->guard->resolveDeliveryIp($url);
-
-            if ($pinnedIp === false) {
-                return null;
-            }
-
-            $response = Http::timeout(self::TIMEOUT_SECONDS)
-                ->withOptions($this->guard->transportOptions($url, $pinnedIp))
-                ->get($url);
-
-            if ($response->redirect()) {
-                $location = (string) $response->header('Location');
-
-                if ($location === '') {
-                    return null;
-                }
-
-                $url = AbsoluteUrl::from($url, $location);
-
-                continue;
-            }
-
-            if (! $response->successful()) {
-                return null;
-            }
-
-            if (! str_contains((string) $response->header('Content-Type'), 'text/html')) {
-                return null;
-            }
-
-            if ((int) $response->header('Content-Length') > self::MAX_BYTES) {
-                return null;
-            }
-
-            return [$url, substr($response->body(), 0, self::MAX_BYTES)];
-        }
-
-        return null;
+        return $this->parse($fetched->body, $fetched->url);
     }
 
     /**

--- a/app/Support/Http/BlockedEgress.php
+++ b/app/Support/Http/BlockedEgress.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Http;
+
+use RuntimeException;
+
+/**
+ * Raised by {@see GuardedEgress} when the SSRF guard refuses a destination, so a
+ * blocked URL arrives at the caller the same way an unreachable one does — as a
+ * throw out of the send — rather than as a second return shape every caller
+ * would have to remember to check.
+ *
+ * The messages are what a caller logs (a webhook delivery records one verbatim),
+ * so they name the reason and never the URL: the row already knows its own
+ * destination, and the error column is trimmed to 255 characters.
+ */
+class BlockedEgress extends RuntimeException
+{
+    /**
+     * The URL failed the pre-flight check: a non-http(s) scheme, a literal
+     * private address, or a hostname reserved for local use.
+     */
+    public static function notPublic(): self
+    {
+        return new self('Blocked non-public URL');
+    }
+
+    /**
+     * The URL looked public but its hostname resolved to a private, reserved or
+     * unroutable address — or did not resolve at all.
+     */
+    public static function resolvesToPrivateAddress(): self
+    {
+        return new self('Blocked URL resolving to a non-public address');
+    }
+}

--- a/app/Support/Http/FetchPolicy.php
+++ b/app/Support/Http/FetchPolicy.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Http;
+
+use Closure;
+
+/**
+ * Everything a {@see GuardedEgress::fetch()} caller has that the next one does
+ * not: which content types it will read, how many bytes it will take, and what
+ * an over-cap body means to it.
+ *
+ * The hop bound, the timeout, the re-guarding and the pinning are the module's,
+ * not the caller's — a policy that could turn any of those off would be a way of
+ * asking for unguarded egress, which is the thing this module exists to end.
+ *
+ * The two named constructors are the two readings of the cap:
+ * {@see self::truncatingAt()} for a caller that only reads a prefix (an unfurl
+ * parses `<head>`), {@see self::refusingOver()} for one that needs the bytes
+ * whole (half an image is a corrupt image, not a small one).
+ */
+final readonly class FetchPolicy
+{
+    /**
+     * @param  Closure(string): bool  $accepts  Given the response's content type — lower-cased, parameters stripped — whether to read the body at all.
+     */
+    private function __construct(
+        public Closure $accepts,
+        public int $maxBytes,
+        public bool $truncatesOversizeBody,
+    ) {}
+
+    /**
+     * A body over the cap is cut down to it.
+     *
+     * @param  Closure(string): bool  $accepts
+     */
+    public static function truncatingAt(int $maxBytes, Closure $accepts): self
+    {
+        return new self($accepts, $maxBytes, truncatesOversizeBody: true);
+    }
+
+    /**
+     * A body over the cap is refused outright.
+     *
+     * @param  Closure(string): bool  $accepts
+     */
+    public static function refusingOver(int $maxBytes, Closure $accepts): self
+    {
+        return new self($accepts, $maxBytes, truncatesOversizeBody: false);
+    }
+}

--- a/app/Support/Http/FetchedBody.php
+++ b/app/Support/Http/FetchedBody.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Http;
+
+/**
+ * What {@see GuardedEgress::fetch()} hands back once a destination has survived
+ * every hop: the URL the bytes actually came from, the content type the policy
+ * accepted, and the body itself, already within the policy's cap.
+ */
+final readonly class FetchedBody
+{
+    /**
+     * @param  string  $url  The final URL, after any redirects the guard cleared — what a relative link in the body resolves against.
+     * @param  string  $contentType  Lower-cased, parameters stripped (`text/html`, never `text/html; charset=utf-8`).
+     */
+    public function __construct(
+        public string $url,
+        public string $contentType,
+        public string $body,
+    ) {}
+}

--- a/app/Support/Http/GuardedEgress.php
+++ b/app/Support/Http/GuardedEgress.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Http;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * The one way this application opens a connection to a member-controlled URL.
+ *
+ * {@see OutboundUrlGuard} answers three separate questions — is this URL public,
+ * what address does it resolve to, how must the connection be pinned — and they
+ * only mean anything asked together, in that order, on every hop. Asking them at
+ * a call site is how the sequence drifts: two of the three sites here once
+ * spelled the same forty-five line hop-and-pin walk, and only one of them caught
+ * a transport failure, so an unreachable host degraded to an empty result on the
+ * image path and requeued the job on the unfurl path.
+ *
+ * Two named readings, because two different callers need two different things
+ * from the same guarantee:
+ *
+ *  - {@see self::fetch()} — *give me the bytes at this URL*. Owns the hop bound,
+ *    re-guards and re-pins every hop, enforces the size cap, applies the policy's
+ *    content-type predicate, and returns null for anything that fails, including
+ *    a host that never answers.
+ *  - {@see self::send()} — *send this request I have already composed*. Owns the
+ *    guard triple and nothing else, for a caller (webhook delivery) that has its
+ *    own retry, its own failure log and its own idea of what a bad response
+ *    means.
+ *
+ * Deliberately not routed through here: the Giphy client, the update checker and
+ * the OIDC discovery calls. They talk to operator-configured hosts rather than
+ * member-controlled ones, and routing them through a guard they would each need
+ * to switch off is how a security module stops being one. ADR-0015 records that.
+ */
+class GuardedEgress
+{
+    /**
+     * How many redirect hops {@see self::fetch()} follows before giving up. Each
+     * hop is re-guarded and re-pinned, so a public URL cannot bounce us onto an
+     * internal one.
+     */
+    private const int MAX_REDIRECTS = 3;
+
+    /**
+     * Total time budget for a single hop, in seconds.
+     */
+    private const int TIMEOUT_SECONDS = 5;
+
+    public function __construct(private readonly OutboundUrlGuard $guard) {}
+
+    /**
+     * Read the bytes at a URL, following redirects the guard clears, or null when
+     * there is nothing safe and usable to read.
+     *
+     * Every way this can fail — blocked destination, dead host, error status,
+     * unwanted content type, oversize body, redirect loop — is one null, because
+     * a caller unfurling a link a member typed has the same answer for all of
+     * them: no preview.
+     */
+    public function fetch(string $url, FetchPolicy $policy): ?FetchedBody
+    {
+        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
+            try {
+                $response = $this->send($url, Http::timeout(self::TIMEOUT_SECONDS));
+            } catch (Throwable) {
+                // Blocked by the guard, or a DNS/connect/timeout failure. Either
+                // way there are no bytes, and an instance with no egress at all
+                // degrades rather than failing the request that asked.
+                return null;
+            }
+
+            if (! $response->redirect()) {
+                return $this->read($response, $url, $policy);
+            }
+
+            $location = (string) $response->header('Location');
+
+            if ($location === '') {
+                return null;
+            }
+
+            $url = AbsoluteUrl::from($url, $location);
+        }
+
+        return null;
+    }
+
+    /**
+     * Send an already-composed request to a vetted URL.
+     *
+     * The request arrives carrying whatever the caller owns — headers, body,
+     * timeout, retry — and leaves with the two things it does not: redirects
+     * disabled, and the connection pinned to the address the guard resolved.
+     *
+     * @throws BlockedEgress when the guard refuses the destination
+     * @throws ConnectionException when the host does not answer
+     */
+    public function send(string $url, PendingRequest $request, string $method = 'GET'): Response
+    {
+        if (! OutboundUrlGuard::isPublic($url)) {
+            throw BlockedEgress::notPublic();
+        }
+
+        $pinnedIp = $this->guard->resolveDeliveryIp($url);
+
+        if ($pinnedIp === false) {
+            throw BlockedEgress::resolvesToPrivateAddress();
+        }
+
+        return $request->withOptions($this->guard->transportOptions($url, $pinnedIp))->send($method, $url);
+    }
+
+    /**
+     * Turn a non-redirect response into the body the policy will accept, or null.
+     *
+     * `Content-Length` is checked before the body is touched so an oversize
+     * response that declares itself is refused without being read at all; the
+     * measured length is checked after, because a chunked response declares
+     * nothing.
+     */
+    private function read(Response $response, string $url, FetchPolicy $policy): ?FetchedBody
+    {
+        if (! $response->successful()) {
+            return null;
+        }
+
+        $contentType = strtolower(trim(explode(';', (string) $response->header('Content-Type'))[0]));
+
+        if (! ($policy->accepts)($contentType)) {
+            return null;
+        }
+
+        if ((int) $response->header('Content-Length') > $policy->maxBytes) {
+            return null;
+        }
+
+        $body = $response->body();
+
+        if ($body === '') {
+            return null;
+        }
+
+        if (strlen($body) > $policy->maxBytes && ! $policy->truncatesOversizeBody) {
+            return null;
+        }
+
+        return new FetchedBody($url, $contentType, substr($body, 0, $policy->maxBytes));
+    }
+}

--- a/app/Support/Images/FetchRemoteImage.php
+++ b/app/Support/Images/FetchRemoteImage.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 namespace App\Support\Images;
 
 use App\Actions\Images\PurgeCachedProxyImages;
-use App\Support\Http\AbsoluteUrl;
-use App\Support\Http\OutboundUrlGuard;
+use App\Support\Http\FetchedBody;
+use App\Support\Http\FetchPolicy;
+use App\Support\Http\GuardedEgress;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Throwable;
 
 /**
  * Fetches a remote image once and keeps the bytes on a local disk, so the app
  * can serve every image from its own origin (see {@see ImageProxy}).
  *
  * The URL comes from a member — a scraped `og:image`, a Giphy rendition, the
- * operator's Gravatar base — so every hop goes through {@see OutboundUrlGuard}:
- * public http(s) hosts only, connection pinned to the vetted IP, redirects
- * followed manually so each new target is re-checked rather than handed to curl.
+ * operator's Gravatar base — so the fetch goes through {@see GuardedEgress},
+ * which owns the SSRF guarding, the pinning and the redirect walk. This class
+ * supplies only what is its own: which image types are worth proxying, five
+ * megabytes, and where the bytes land.
  *
  * Every failure path returns null rather than throwing. An instance with no
  * egress therefore degrades to a 404 per image (initials avatar, no link
@@ -53,18 +53,9 @@ class FetchRemoteImage
     private const int FAILURE_TTL_SECONDS = 600; // 10 minutes
 
     /**
-     * Total time budget for a single hop, in seconds.
-     */
-    private const int TIMEOUT_SECONDS = 5;
-
-    /**
-     * How many redirect hops to follow before giving up. Each hop is re-validated
-     * against the SSRF guard so a public URL can't bounce us onto an internal one.
-     */
-    private const int MAX_REDIRECTS = 3;
-
-    /**
-     * Hard cap on the bytes read from a remote image.
+     * Hard cap on the bytes read from a remote image. Unlike an unfurl, this one
+     * refuses an oversize body rather than trimming it: half an image is a
+     * corrupt image, not a small one.
      */
     private const int MAX_BYTES = 5242880; // 5 MB
 
@@ -82,7 +73,7 @@ class FetchRemoteImage
      */
     private const string FAILED = '__failed__';
 
-    public function __construct(private readonly OutboundUrlGuard $guard) {}
+    public function __construct(private readonly GuardedEgress $egress) {}
 
     /**
      * Resolve a remote image URL to its cached bytes, fetching it on first use.
@@ -119,74 +110,29 @@ class FetchRemoteImage
     }
 
     /**
-     * Request the URL, manually following redirects, and store the bytes.
+     * Fetch the URL through the guarded module and store what comes back.
+     *
+     * The cache key and the file name are both hashes of the URL the caller
+     * asked for, not of whichever URL the redirect walk ended on, so the same
+     * request resolves to the same bytes however the remote host moves them.
      *
      * @return array{path: string, mime: string}|null
      */
     private function fetch(string $url): ?array
     {
-        $target = $url;
+        $fetched = $this->egress->fetch($url, FetchPolicy::refusingOver(
+            self::MAX_BYTES,
+            static fn (string $contentType): bool => in_array($contentType, self::ALLOWED_MIMES, true),
+        ));
 
-        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
-            if (! OutboundUrlGuard::isPublic($target)) {
-                return null;
-            }
-
-            $pinnedIp = $this->guard->resolveDeliveryIp($target);
-
-            if ($pinnedIp === false) {
-                return null;
-            }
-
-            try {
-                $response = Http::timeout(self::TIMEOUT_SECONDS)
-                    ->withOptions($this->guard->transportOptions($target, $pinnedIp))
-                    ->get($target);
-            } catch (Throwable) {
-                // DNS/connect/timeout failure — degrade to no image rather than
-                // surfacing a 500 on an air-gapped instance.
-                return null;
-            }
-
-            if ($response->redirect()) {
-                $location = (string) $response->header('Location');
-
-                if ($location === '') {
-                    return null;
-                }
-
-                $target = AbsoluteUrl::from($target, $location);
-
-                continue;
-            }
-
-            if (! $response->successful()) {
-                return null;
-            }
-
-            $mime = strtolower(trim(explode(';', (string) $response->header('Content-Type'))[0]));
-
-            if (! in_array($mime, self::ALLOWED_MIMES, true)) {
-                return null;
-            }
-
-            if ((int) $response->header('Content-Length') > self::MAX_BYTES) {
-                return null;
-            }
-
-            $body = $response->body();
-
-            if ($body === '' || strlen($body) > self::MAX_BYTES) {
-                return null;
-            }
-
-            $path = self::DIRECTORY.'/'.hash('sha256', $url);
-
-            Storage::disk(self::DISK)->put($path, $body);
-
-            return ['path' => $path, 'mime' => $mime];
+        if (! $fetched instanceof FetchedBody) {
+            return null;
         }
 
-        return null;
+        $path = self::DIRECTORY.'/'.hash('sha256', $url);
+
+        Storage::disk(self::DISK)->put($path, $fetched->body);
+
+        return ['path' => $path, 'mime' => $fetched->contentType];
     }
 }

--- a/dev-docs/adr/0015-one-guarded-egress-module.md
+++ b/dev-docs/adr/0015-one-guarded-egress-module.md
@@ -128,6 +128,11 @@ the fixture named.
   taken verbatim from the fetched discovery document with no scheme or issuer-host
   check. Real, and worth their own issue; fixed with Guzzle client config and a
   check, not with this module.
+- **Bounding the response in memory (#1202).** The byte cap is enforced after the
+  body is buffered, so it bounds what the module *keeps* rather than what it reads —
+  a chunked response declares no `Content-Length` to pre-check against. That is
+  pre-existing, identical in both of the copies collapsed here, and fixing it means
+  streaming the body rather than moving it.
 - **A user-agent, a connect timeout, or egress logging.** `GuardedEgress` is the
   first place any of those could live. Deciding whether they should is a separate
   question, and adding them here by reflex would be the same mistake as folding

--- a/dev-docs/adr/0015-one-guarded-egress-module.md
+++ b/dev-docs/adr/0015-one-guarded-egress-module.md
@@ -1,0 +1,134 @@
+# ADR-0015: One guarded-egress module owns every connection to a member-controlled URL
+
+- Status: Accepted
+- Date: 2026-08-03
+- Relates to: epic architecture-hardening V (#1195), child #1196
+
+## Context
+
+`OutboundUrlGuard` answers three separate questions — *is this URL public*
+(`isPublic()`, static), *what address does it resolve to* (`resolveDeliveryIp()`),
+and *how must the connection be pinned* (`transportOptions()`). None of them means
+anything on its own: a URL vetted and then resolved by curl is a DNS rebind waiting
+to happen, and a pinned connection that curl is free to redirect off is not pinned at
+all. They are one sequence, asked in one order, on **every** hop.
+
+Three call sites asked that sequence by hand — `FetchLinkPreview`,
+`FetchRemoteImage` and `DeliverWebhook` — and the two `fetch` ones then spelled the
+same ~45-line hop-and-pin walk twice: the same `for ($hop = 0; $hop <= MAX_REDIRECTS; $hop++)`,
+the same three guard calls, the same `redirect()` → `Location` → `AbsoluteUrl::from()`
+→ `continue` block, the same `Content-Length` pre-check. Even the class docblocks
+were near-copies, both ending *"redirects followed manually so each new target is
+re-checked rather than handed to curl"*.
+
+**One copy had a `try/catch` and the other did not.** `FetchRemoteImage` caught
+`Throwable` and returned null. `FetchLinkPreview` was unprotected, so an unreachable
+host raised `ConnectionException` out of `Cache::remember` and out of
+`UnfurlMessageLinks::handle`, failing and requeuing the job — while every sibling
+egress site in the codebase degraded to an empty result instead. The 100% coverage
+gate could not see it: an uncaught path leaves no line uncovered. There was no test
+to write against it either, which is why `ImageProxyTest`, `WebhookDeliveryTest` and
+`UpdateCheckTest` each had a `ConnectionException` case and `LinkPreviewFetchTest`
+had none. The missing `catch` and the missing test were the same hole.
+
+The duplication had a second cost, in the suite. The `HostResolver` stub was
+re-declared **six times** under six names, two of them byte-for-byte identical. And
+the pin was asserted at **one of three** call sites: `CURLOPT_RESOLVE` appeared in
+tests only in `LinkPreviewFetchTest`, through a capture helper local to that file.
+`allow_redirects => false` was asserted nowhere at all, and `transportOptions()` had
+no direct test.
+
+## Decision
+
+**`App\Support\Http\GuardedEgress` is the only place this application opens a
+connection to a member-controlled URL.** Two named readings, because two callers
+need two different things from the same guarantee:
+
+- **`fetch(string $url, FetchPolicy $policy): ?FetchedBody`** — *give me the bytes
+  at this URL*. Owns the hop bound, re-guards and re-pins every hop, disables
+  curl-level redirects, enforces the size cap, applies the policy's content-type
+  predicate, and maps every failure — blocked destination, dead host, error status,
+  wrong type, oversize body, redirect loop — to one null. Callers supply only what
+  differs, through `FetchPolicy`: the content-type predicate, the byte cap, and
+  which of the two readings of the cap they want (`truncatingAt()` for an unfurl
+  that only parses `<head>`, `refusingOver()` for an image, where half the bytes is
+  a corrupt file rather than a small one).
+- **`send(string $url, PendingRequest $request, string $method): Response`** — *send
+  this request I have already composed*. Owns the guard triple and the no-redirects
+  rule and nothing else. `DeliverWebhook` adapts in and keeps its own retry, its own
+  `recordFailure`, its own 255-character message trim.
+
+Judged alone, `send()` is shallow. It earns its place as the second reading of a
+module whose first reading is deep: leaving `DeliverWebhook` outside would keep the
+three-call ritual public at one site, which is the thing the module exists to end.
+It is also what `fetch()` is built on, so there is one vetting path, not two.
+
+**A refused destination leaves through the same door as an unreachable one.**
+`send()` throws `BlockedEgress` rather than returning a second shape every caller
+would have to remember to check. `fetch()` catches it alongside the transport
+failure — which *is* the behaviour fix — and `DeliverWebhook`'s existing
+`catch (Throwable)` now covers all three of its old branches, logging the reason and
+counting the attempt towards the auto-disable threshold exactly as before.
+
+**`OutboundUrlGuard` splits by audience.**
+
+- **`isPublic()` stays public and static.** `PublicWebhookUrl` asks it at validation
+  time, before any request exists, and `User::routeNotificationForWebPush` asks it
+  where the web-push package owns the connection. It is a *pre-flight* question, not
+  an egress one.
+- **`resolveDeliveryIp()` and `transportOptions()` keep their home on the guard but
+  gain a single caller.** They are two thirds of a sequence with no meaning apart,
+  and `GuardedEgress` is the only thing that asks them.
+  `tests/Unit/GuardedEgressHomeTest.php` fails if a second caller appears.
+- **The `HostResolver` container binding stays the seam.** It already works, and it
+  is what proves the DNS-rebind defence. The win is that six anonymous stubs
+  collapse to one shared `Tests\Support\StubHostResolver` with two named
+  constructors: `returning()` for a fixed answer, `rebinding()` for a nameserver
+  that answers differently on successive lookups.
+
+**`Http::preventStrayRequests()` runs suite-wide**, from `Tests\TestCase::setUp()`.
+With one module owning egress, a tenth site added later either goes through it or
+turns the suite red; before this, an unfaked request quietly dialled whatever host
+the fixture named.
+
+## Consequences
+
+- **The behaviour fix ships with a test.** An unreachable host on the link-preview
+  path degrades to a null preview instead of raising, `UnfurlMessageLinks` no longer
+  requeues, and the failure is cached like any other so a dead host is not re-dialled
+  on the next message. `LinkPreviewFetchTest` now mirrors `ImageProxyTest`'s
+  `ConnectionException` case.
+- **The pin is asserted at all three call sites**, through one shared
+  `captureTransportOptions()` helper in `tests/Helpers.php` rather than a copy per
+  file, and `allow_redirects => false` is asserted alongside it.
+  `transportOptions()` also gains direct cases in `OutboundUrlGuardTest` — default
+  ports per scheme, an explicit port, and the brackets an IPv6 literal needs before
+  curl will read the colons as an address rather than a port.
+- **Every hop is re-guarded and re-pinned, and both `fetch()` callers now prove it.**
+  A redirect chain whose second hop resolves private is refused on the image path as
+  well as the unfurl path.
+- **A blocked webhook delivery now records a measured duration rather than a literal
+  zero**, since it takes the same `catch` as a transport error. The value is
+  sub-millisecond — nothing was dialled — and no caller reads it as a sentinel.
+- **The two size-cap readings are now stated rather than implied.** They genuinely
+  differ and always did; before, that difference lived in two files that otherwise
+  claimed to be the same algorithm.
+
+## Explicitly out of scope
+
+- **Giphy (`GiphyClient`), `UpdateChecker`, and the three OIDC discovery calls in
+  `GenericOidcProvider`.** They talk to **operator-configured** hosts rather than
+  member-controlled ones, and want JSON semantics plus degrade-to-empty. Routing
+  them through a guarded module would need a `guard: off` flag per caller — which is
+  how a security module stops being one. This is recorded here so the next review
+  does not re-suggest it; `GuardedEgressHomeTest` lists them by name for the same
+  reason.
+- **The OIDC defects themselves** — no timeout on any of the three calls, and
+  `authorization_endpoint` / `token_endpoint` / `userinfo_endpoint` / `jwks_uri`
+  taken verbatim from the fetched discovery document with no scheme or issuer-host
+  check. Real, and worth their own issue; fixed with Guzzle client config and a
+  check, not with this module.
+- **A user-agent, a connect timeout, or egress logging.** `GuardedEgress` is the
+  first place any of those could live. Deciding whether they should is a separate
+  question, and adding them here by reflex would be the same mistake as folding
+  Giphy in.

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -20,3 +20,4 @@ seams live in [`CONTEXT.md`](../../CONTEXT.md).
 | [0012](0012-three-test-suites.md) | Three test suites: pure, database, HTTP contract |
 | [0013](0013-generated-types-are-the-wire-contract.md) | The generated `App.Data.*` types are the wire contract |
 | [0014](0014-nested-resource-tenancy-on-the-route.md) | Nested-resource tenancy is enforced by the route |
+| [0015](0015-one-guarded-egress-module.md) | One guarded-egress module owns every member-controlled URL |

--- a/tests/Feature/Channels/LinkPreviewFetchTest.php
+++ b/tests/Feature/Channels/LinkPreviewFetchTest.php
@@ -2,85 +2,15 @@
 
 use App\Support\FetchLinkPreview;
 use App\Support\HostResolver;
+use App\Support\Http\GuardedEgress;
 use App\Support\Http\OutboundUrlGuard;
-use GuzzleHttp\Promise\PromiseInterface;
-use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
-
-/**
- * A HostResolver stub that returns fixed IPs per host, so the SSRF guard can be
- * exercised without touching real DNS.
- *
- * @param  array<string, array<int, string>>  $map
- * @param  array<int, string>  $default
- */
-function resolverReturning(array $map = [], array $default = ['93.184.216.34']): HostResolver
-{
-    return new class($map, $default) extends HostResolver
-    {
-        /**
-         * @param  array<string, array<int, string>>  $map
-         * @param  array<int, string>  $default
-         */
-        public function __construct(private array $map, private readonly array $default) {}
-
-        public function resolve(string $host): array
-        {
-            return $this->map[$host] ?? $this->default;
-        }
-    };
-}
-
-/**
- * A HostResolver stub answering successive lookups differently, standing in for
- * an authoritative nameserver that rebinds a host between the guard's check and
- * the connection. The final answer repeats once the script runs out, and every
- * lookup is counted so a test can prove only one was made.
- *
- * @param  array<int, array<int, string>>  $answers
- */
-function rebindingResolver(array $answers): HostResolver
-{
-    return new class($answers) extends HostResolver
-    {
-        public int $calls = 0;
-
-        /**
-         * @param  array<int, array<int, string>>  $answers
-         */
-        public function __construct(private readonly array $answers) {}
-
-        public function resolve(string $host): array
-        {
-            $answer = $this->answers[$this->calls] ?? $this->answers[array_key_last($this->answers)];
-            $this->calls++;
-
-            return $answer;
-        }
-    };
-}
-
-/**
- * Fake every outbound request, recording the transport options it went out
- * with so a test can read back the address curl was pinned to.
- *
- * @param  array<string, PromiseInterface>  $responses  keyed by requested URL
- * @param  array<int, array<string, mixed>>  $captured
- */
-function captureTransportOptions(array $responses, ?array &$captured): void
-{
-    $captured = [];
-
-    Http::fake(function (Request $request, array $options) use ($responses, &$captured): PromiseInterface {
-        $captured[] = $options;
-
-        return $responses[$request->url()];
-    });
-}
+use Tests\Support\StubHostResolver;
 
 function fetcherWith(HostResolver $resolver): FetchLinkPreview
 {
-    return new FetchLinkPreview(new OutboundUrlGuard($resolver));
+    return new FetchLinkPreview(new GuardedEgress(new OutboundUrlGuard($resolver)));
 }
 
 test('unfurls Open Graph metadata from a public URL', function (): void {
@@ -95,7 +25,7 @@ test('unfurls Open Graph metadata from a public URL', function (): void {
         ['Content-Type' => 'text/html'],
     )]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBe([
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com'))->toBe([
         'title' => 'Hello',
         'description' => 'A page',
         'image' => 'https://example.com/img.png',
@@ -110,7 +40,7 @@ test('falls back to the title tag and host when og tags are absent', function ()
         ['Content-Type' => 'text/html'],
     )]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBe([
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com'))->toBe([
         'title' => 'Just a title',
         'description' => null,
         'image' => null,
@@ -125,7 +55,7 @@ test('ignores whitespace-only meta content', function (): void {
         ['Content-Type' => 'text/html'],
     )]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com')['description'])->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com')['description'])->toBeNull();
 });
 
 test('returns null when the page has no title at all', function (): void {
@@ -135,13 +65,13 @@ test('returns null when the page has no title at all', function (): void {
         ['Content-Type' => 'text/html'],
     )]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com'))->toBeNull();
 });
 
 test('returns null for an empty body', function (): void {
     Http::fake(['https://example.com' => Http::response('   ', 200, ['Content-Type' => 'text/html'])]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com'))->toBeNull();
 });
 
 test('resolves a protocol-relative og:image against the base scheme', function (): void {
@@ -151,7 +81,7 @@ test('resolves a protocol-relative og:image against the base scheme', function (
         ['Content-Type' => 'text/html'],
     )]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com')['image'])
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com')['image'])
         ->toBe('https://cdn.example.com/i.png');
 });
 
@@ -162,14 +92,14 @@ test('resolves a root-relative og:image against the base origin', function (): v
         ['Content-Type' => 'text/html'],
     )]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com')['image'])
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com')['image'])
         ->toBe('https://example.com/img/a.png');
 });
 
 test('blocks a private, loopback, link-local or reserved host', function (string $ip): void {
     Http::fake();
 
-    expect(fetcherWith(resolverReturning(default: [$ip]))->handle('https://internal.test'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning(default: [$ip]))->handle('https://internal.test'))->toBeNull();
 
     Http::assertNothingSent();
 })->with(['10.0.0.5', '127.0.0.1', '169.254.169.254', '192.168.1.1', '172.16.0.1']);
@@ -177,7 +107,7 @@ test('blocks a private, loopback, link-local or reserved host', function (string
 test('rejects a non-http(s) scheme', function (): void {
     Http::fake();
 
-    expect(fetcherWith(resolverReturning())->handle('ftp://example.com'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('ftp://example.com'))->toBeNull();
 
     Http::assertNothingSent();
 });
@@ -185,7 +115,7 @@ test('rejects a non-http(s) scheme', function (): void {
 test('rejects a malformed URL', function (): void {
     Http::fake();
 
-    expect(fetcherWith(resolverReturning())->handle('http://foo:bar'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('http://foo:bar'))->toBeNull();
 
     Http::assertNothingSent();
 });
@@ -193,7 +123,7 @@ test('rejects a malformed URL', function (): void {
 test('rejects a URL with no host', function (): void {
     Http::fake();
 
-    expect(fetcherWith(resolverReturning())->handle('http:///just/a/path'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('http:///just/a/path'))->toBeNull();
 
     Http::assertNothingSent();
 });
@@ -201,7 +131,7 @@ test('rejects a URL with no host', function (): void {
 test('rejects a host that does not resolve', function (): void {
     Http::fake();
 
-    expect(fetcherWith(resolverReturning(default: []))->handle('https://ghost.example'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning(default: []))->handle('https://ghost.example'))->toBeNull();
 
     Http::assertNothingSent();
 });
@@ -216,19 +146,19 @@ test('follows a safe redirect to the final page', function (): void {
         ),
     ]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com/start')['title'])->toBe('Final');
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com/start')['title'])->toBe('Final');
 });
 
 test('rejects a redirect with no Location', function (): void {
     Http::fake(['https://example.com/go' => Http::response('', 302, [])]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com/go'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com/go'))->toBeNull();
 });
 
 test('re-validates the host on each redirect hop', function (): void {
     Http::fake(['https://safe.test/go' => Http::response('', 302, ['Location' => 'https://internal.test/secret'])]);
 
-    $resolver = resolverReturning([
+    $resolver = StubHostResolver::returning([
         'safe.test' => ['93.184.216.34'],
         'internal.test' => ['10.0.0.5'],
     ]);
@@ -239,19 +169,19 @@ test('re-validates the host on each redirect hop', function (): void {
 test('gives up after too many redirects', function (): void {
     Http::fake(['https://example.com/loop' => Http::response('', 302, ['Location' => 'https://example.com/loop'])]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com/loop'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com/loop'))->toBeNull();
 });
 
 test('rejects an unsuccessful response', function (): void {
     Http::fake(['https://example.com' => Http::response('nope', 404)]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com'))->toBeNull();
 });
 
 test('rejects a non-html response', function (): void {
     Http::fake(['https://example.com' => Http::response('{"a":1}', 200, ['Content-Type' => 'application/json'])]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com'))->toBeNull();
 });
 
 test('rejects an oversized response', function (): void {
@@ -261,11 +191,11 @@ test('rejects an oversized response', function (): void {
         ['Content-Type' => 'text/html', 'Content-Length' => (string) (3 * 1024 * 1024)],
     )]);
 
-    expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com'))->toBeNull();
 });
 
 test('resolves once and pins the connection, so a rebinding second answer is never dialled', function (): void {
-    $resolver = rebindingResolver([['93.184.216.34'], ['169.254.169.254']]);
+    $resolver = StubHostResolver::rebinding([['93.184.216.34'], ['169.254.169.254']]);
 
     captureTransportOptions(
         ['https://example.com/page' => Http::response(
@@ -277,12 +207,25 @@ test('resolves once and pins the connection, so a rebinding second answer is nev
     );
 
     expect(fetcherWith($resolver)->handle('https://example.com/page')['title'])->toBe('Pinned')
-        ->and($resolver->calls)->toBe(1)
-        ->and($captured[0]['curl'][CURLOPT_RESOLVE])->toBe(['example.com:443:93.184.216.34']);
+        ->and($resolver->lookups)->toBe(['example.com'])
+        ->and($captured[0]['curl'][CURLOPT_RESOLVE])->toBe(['example.com:443:93.184.216.34'])
+        // curl is never allowed to follow a redirect itself: a hop it took is a
+        // hop the guard never saw.
+        ->and($captured[0]['allow_redirects'])->toBeFalse();
+});
+
+test('truncates an oversized body rather than refusing it, since only the head is parsed', function (): void {
+    Http::fake(['https://example.com' => Http::response(
+        '<html><head><title>Long</title></head><body>'.str_repeat('x', 3 * 1024 * 1024).'</body></html>',
+        200,
+        ['Content-Type' => 'text/html'],
+    )]);
+
+    expect(fetcherWith(StubHostResolver::returning())->handle('https://example.com')['title'])->toBe('Long');
 });
 
 test('pins every redirect hop to its own vetted address', function (): void {
-    $resolver = resolverReturning([
+    $resolver = StubHostResolver::returning([
         'start.test' => ['93.184.216.34'],
         'final.test' => ['93.184.216.35'],
     ]);
@@ -313,9 +256,25 @@ test('unfurls an internal URL when the operator has turned the guard off', funct
         $captured,
     );
 
-    expect(fetcherWith(resolverReturning(default: ['10.0.0.5']))->handle('http://wiki.internal/page')['title'])
+    expect(fetcherWith(StubHostResolver::returning(default: ['10.0.0.5']))->handle('http://wiki.internal/page')['title'])
         ->toBe('Runbook')
         ->and($captured[0])->not->toHaveKey('curl');
+});
+
+test('degrades to no preview when the remote host is unreachable, and does not retry it immediately', function (): void {
+    $attempts = 0;
+
+    Http::fake(function () use (&$attempts): never {
+        $attempts++;
+
+        throw new ConnectionException('no route to host');
+    });
+
+    $fetcher = fetcherWith(StubHostResolver::returning());
+
+    expect($fetcher->handle('https://example.com'))->toBeNull()
+        ->and($fetcher->handle('https://example.com'))->toBeNull()
+        ->and($attempts)->toBe(1);
 });
 
 test('caches the result so the same URL is only fetched once', function (): void {
@@ -325,7 +284,7 @@ test('caches the result so the same URL is only fetched once', function (): void
         ['Content-Type' => 'text/html'],
     )]);
 
-    $fetcher = fetcherWith(resolverReturning());
+    $fetcher = fetcherWith(StubHostResolver::returning());
     $first = $fetcher->handle('https://example.com');
 
     expect($fetcher->handle('https://example.com'))->toBe($first);

--- a/tests/Feature/Images/ImageProxyTest.php
+++ b/tests/Feature/Images/ImageProxyTest.php
@@ -15,27 +15,18 @@ use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Tests\Support\StubHostResolver;
 
 /**
  * Point every hostname at a public IP so the SSRF guard's delivery-time
  * resolution can run without touching real DNS.
  *
- * @param  array<int, string>  $ips
+ * @param  array<string, array<int, string>>  $map
+ * @param  array<int, string>  $default
  */
-function resolveHostsTo(array $ips = ['93.184.216.34']): void
+function resolveHostsTo(array $map = [], array $default = ['93.184.216.34']): void
 {
-    app()->bind(HostResolver::class, fn (): HostResolver => new class($ips) extends HostResolver
-    {
-        /**
-         * @param  array<int, string>  $ips
-         */
-        public function __construct(private readonly array $ips) {}
-
-        public function resolve(string $host): array
-        {
-            return $this->ips;
-        }
-    });
+    app()->instance(HostResolver::class, StubHostResolver::returning($map, $default));
 }
 
 /**
@@ -124,6 +115,45 @@ it('follows a redirect, re-checking each hop against the guard', function (): vo
     $response->assertOk()->assertHeader('Content-Type', 'image/gif');
 });
 
+it('refuses a redirect whose next hop resolves to a private address', function (): void {
+    resolveHostsTo([
+        'cdn.example.test' => ['93.184.216.34'],
+        'internal.example.test' => ['10.0.0.5'],
+    ]);
+
+    Http::fake([
+        'cdn.example.test/cat.png' => Http::response('', 302, ['Location' => 'https://internal.example.test/cat.png']),
+        'internal.example.test/*' => imageResponse(),
+    ]);
+
+    $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url('https://cdn.example.test/cat.png'))
+        ->assertNotFound();
+
+    Http::assertNotSent(fn ($request): bool => str_contains((string) $request->url(), 'internal.example.test'));
+});
+
+it('pins each hop to the address the guard vetted, and never lets curl follow one', function (): void {
+    resolveHostsTo([
+        'cdn.example.test' => ['93.184.216.34'],
+        'images.example.test' => ['93.184.216.35'],
+    ]);
+
+    captureTransportOptions([
+        'https://cdn.example.test/cat.png' => Http::response('', 302, ['Location' => 'https://images.example.test/cat.png']),
+        'https://images.example.test/cat.png' => imageResponse(),
+    ], $captured);
+
+    $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url('https://cdn.example.test/cat.png'))
+        ->assertOk();
+
+    expect($captured[0]['curl'][CURLOPT_RESOLVE])->toBe(['cdn.example.test:443:93.184.216.34'])
+        ->and($captured[0]['allow_redirects'])->toBeFalse()
+        ->and($captured[1]['curl'][CURLOPT_RESOLVE])->toBe(['images.example.test:443:93.184.216.35'])
+        ->and($captured[1]['allow_redirects'])->toBeFalse();
+});
+
 it('rejects an unsigned or tampered url', function (): void {
     $signed = (string) ImageProxy::url('https://cdn.example.test/cat.png');
     $user = User::factory()->create();
@@ -142,7 +172,7 @@ it('requires an authenticated session', function (): void {
 
 it('404s rather than fetching a target the SSRF guard blocks', function (string $url, array $resolvesTo): void {
     Http::fake();
-    resolveHostsTo($resolvesTo);
+    resolveHostsTo(default: $resolvesTo);
 
     $this->actingAs(User::factory()->create())
         ->get((string) ImageProxy::url($url))

--- a/tests/Feature/Support/OutboundUrlGuardTest.php
+++ b/tests/Feature/Support/OutboundUrlGuardTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use App\Rules\PublicWebhookUrl;
-use App\Support\HostResolver;
 use App\Support\Http\OutboundUrlGuard;
 use Illuminate\Support\Facades\Validator;
+use Tests\Support\StubHostResolver;
 
 /**
  * Build a guard whose resolver returns the given IPs for every hostname, so
@@ -15,18 +15,7 @@ use Illuminate\Support\Facades\Validator;
  */
 function guardResolving(array $ips): OutboundUrlGuard
 {
-    return new OutboundUrlGuard(new class($ips) extends HostResolver
-    {
-        /**
-         * @param  array<int, string>  $ips
-         */
-        public function __construct(private readonly array $ips) {}
-
-        public function resolve(string $host): array
-        {
-            return $this->ips;
-        }
-    });
+    return new OutboundUrlGuard(StubHostResolver::returning(default: $ips));
 }
 
 it('accepts a public https URL', function (): void {
@@ -147,6 +136,23 @@ it('skips delivery-time resolution when the guard is disabled', function (): voi
 
     expect(guardResolving(['10.0.0.5'])->resolveDeliveryIp('https://example.test/hook'))->toBeNull();
 });
+
+it('never lets the transport follow a redirect itself', function (): void {
+    expect(guardResolving(['93.184.216.34'])->transportOptions('https://example.test/hook', null))
+        ->toBe(['allow_redirects' => false]);
+});
+
+it('pins the connection to the vetted address, on the URL\'s own port', function (string $url, string $pinnedIp, string $expected): void {
+    expect(guardResolving(['93.184.216.34'])->transportOptions($url, $pinnedIp))
+        ->toBe(['allow_redirects' => false, 'curl' => [CURLOPT_RESOLVE => [$expected]]]);
+})->with([
+    'https defaults to 443' => ['https://example.test/hook', '93.184.216.34', 'example.test:443:93.184.216.34'],
+    'http defaults to 80' => ['http://example.test/hook', '93.184.216.34', 'example.test:80:93.184.216.34'],
+    'an explicit port wins' => ['https://example.test:8443/hook', '93.184.216.34', 'example.test:8443:93.184.216.34'],
+    // curl's resolve entries take the address in brackets, or the colons in an
+    // IPv6 literal would read as the port separator.
+    'an IPv6 address is bracketed' => ['https://example.test/hook', '2606:4700::6810:84e5', 'example.test:443:[2606:4700::6810:84e5]'],
+]);
 
 it('drives the PublicWebhookUrl validation rule', function (): void {
     $passes = Validator::make(['url' => 'https://example.test/x'], ['url' => new PublicWebhookUrl]);

--- a/tests/Feature/Webhooks/WebhookDeliveryTest.php
+++ b/tests/Feature/Webhooks/WebhookDeliveryTest.php
@@ -12,38 +12,15 @@ use App\Models\Channel;
 use App\Models\Team;
 use App\Models\WebhookSubscription;
 use App\Support\HostResolver;
-use App\Support\Http\OutboundUrlGuard;
+use App\Support\Http\GuardedEgress;
 use App\Support\Webhooks\WebhookSignature;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
-
-/**
- * A HostResolver stub returning fixed IPs per host, so delivery-time DNS
- * validation can be exercised without touching real DNS.
- *
- * @param  array<string, array<int, string>>  $map
- * @param  array<int, string>  $default
- */
-function webhookResolver(array $map = [], array $default = ['93.184.216.34']): HostResolver
-{
-    return new class($map, $default) extends HostResolver
-    {
-        /**
-         * @param  array<string, array<int, string>>  $map
-         * @param  array<int, string>  $default
-         */
-        public function __construct(private readonly array $map, private readonly array $default) {}
-
-        public function resolve(string $host): array
-        {
-            return $this->map[$host] ?? $this->default;
-        }
-    };
-}
+use Tests\Support\StubHostResolver;
 
 beforeEach(function (): void {
-    $this->app->instance(HostResolver::class, webhookResolver());
+    $this->app->instance(HostResolver::class, StubHostResolver::returning());
     $this->team = Team::factory()->create();
     $this->channel = Channel::factory()->for($this->team)->create();
     $this->subscription = WebhookSubscription::factory()->for($this->team)->create([
@@ -145,7 +122,7 @@ it('skips an already-queued job once the platform is disabled', function (): voi
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     Http::assertNothingSent();
     expect($this->subscription->deliveries()->count())->toBe(0);
@@ -161,7 +138,7 @@ it('refuses to deliver to a non-public URL and logs the blocked attempt', functi
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(OutboundUrlGuard::class));
+        ]))->handle(app(GuardedEgress::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -174,7 +151,7 @@ it('refuses to deliver to a non-public URL and logs the blocked attempt', functi
 });
 
 it('blocks delivery when the hostname resolves to a private address', function (): void {
-    $this->app->instance(HostResolver::class, webhookResolver(['example.test' => ['10.0.0.5']]));
+    $this->app->instance(HostResolver::class, StubHostResolver::returning(['example.test' => ['10.0.0.5']]));
     Http::fake();
 
     try {
@@ -183,7 +160,7 @@ it('blocks delivery when the hostname resolves to a private address', function (
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(OutboundUrlGuard::class));
+        ]))->handle(app(GuardedEgress::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -198,7 +175,7 @@ it('blocks delivery when the hostname resolves to a private address', function (
 
 it('auto-disables a subscription whose hostname resolves private once it hits the threshold', function (): void {
     $threshold = (int) config('integrations.webhooks.disable_after');
-    $this->app->instance(HostResolver::class, webhookResolver(['example.test' => ['169.254.169.254']]));
+    $this->app->instance(HostResolver::class, StubHostResolver::returning(['example.test' => ['169.254.169.254']]));
     $this->subscription->update(['consecutive_failures' => $threshold - 1]);
     Http::fake();
 
@@ -209,14 +186,14 @@ it('auto-disables a subscription whose hostname resolves private once it hits th
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     Http::assertNothingSent();
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
 });
 
 it('delivers to a hostname resolving to a public IPv6 address', function (): void {
-    $this->app->instance(HostResolver::class, webhookResolver(['example.test' => ['2606:4700::6810:84e5']]));
+    $this->app->instance(HostResolver::class, StubHostResolver::returning(['example.test' => ['2606:4700::6810:84e5']]));
     Http::fake(['example.test/*' => Http::response('', 200)]);
 
     (new DeliverWebhook($this->subscription->id, [
@@ -224,10 +201,24 @@ it('delivers to a hostname resolving to a public IPv6 address', function (): voi
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     Http::assertSentCount(1);
     expect($this->subscription->deliveries()->sole()->succeeded)->toBeTrue();
+});
+
+it('pins the delivery to the vetted address, and never lets curl follow a redirect', function (): void {
+    captureTransportOptions(['https://example.test/hooks' => Http::response('', 200)], $captured);
+
+    (new DeliverWebhook($this->subscription->id, [
+        'id' => (string) Str::uuid(),
+        'type' => WebhookEvent::MessageCreated->value,
+        'created_at' => now()->toIso8601String(),
+        'data' => [],
+    ]))->handle(app(GuardedEgress::class));
+
+    expect($captured[0]['curl'][CURLOPT_RESOLVE])->toBe(['example.test:443:93.184.216.34'])
+        ->and($captured[0]['allow_redirects'])->toBeFalse();
 });
 
 it('delivers to a literal public IP without pinning', function (): void {
@@ -239,7 +230,7 @@ it('delivers to a literal public IP without pinning', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     Http::assertSentCount(1);
     expect($this->subscription->deliveries()->sole()->succeeded)->toBeTrue();
@@ -257,7 +248,7 @@ it('does not follow a redirect to an internal address and records the attempt as
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(OutboundUrlGuard::class));
+        ]))->handle(app(GuardedEgress::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -285,7 +276,7 @@ it('auto-disables a subscription whose URL is blocked once it hits the threshold
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     Http::assertNothingSent();
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
@@ -306,7 +297,7 @@ it('retries a failing endpoint, then auto-disables after the threshold and logs 
     // final attempt reaches the threshold and disables without throwing.
     for ($attempt = 1; $attempt < $threshold; $attempt++) {
         try {
-            (new DeliverWebhook($this->subscription->id, $envelope))->handle(app(OutboundUrlGuard::class));
+            (new DeliverWebhook($this->subscription->id, $envelope))->handle(app(GuardedEgress::class));
         } catch (RuntimeException) {
             // expected retry signal
         }
@@ -316,7 +307,7 @@ it('retries a failing endpoint, then auto-disables after the threshold and logs 
             ->and($this->subscription->status)->toBe(WebhookSubscriptionStatus::Active);
     }
 
-    (new DeliverWebhook($this->subscription->id, $envelope))->handle(app(OutboundUrlGuard::class));
+    (new DeliverWebhook($this->subscription->id, $envelope))->handle(app(GuardedEgress::class));
 
     $this->subscription->refresh();
     expect($this->subscription->status)->toBe(WebhookSubscriptionStatus::Disabled)
@@ -335,7 +326,7 @@ it('resets the failure streak after a success', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     expect($this->subscription->refresh()->consecutive_failures)->toBe(0);
 });
@@ -349,7 +340,7 @@ it('records a transport error as a failed attempt with no status code', function
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(OutboundUrlGuard::class));
+        ]))->handle(app(GuardedEgress::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -372,7 +363,7 @@ it('auto-disables on a transport error that reaches the threshold', function ():
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
 });
@@ -386,7 +377,7 @@ it('is a no-op when the subscription has since been disabled', function (): void
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     Http::assertNothingSent();
     expect($this->subscription->deliveries()->count())->toBe(0);
@@ -400,7 +391,7 @@ it('is a no-op when the subscription no longer exists', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(OutboundUrlGuard::class));
+    ]))->handle(app(GuardedEgress::class));
 
     Http::assertNothingSent();
 });

--- a/tests/Feature/Webhooks/WebhookReplayTest.php
+++ b/tests/Feature/Webhooks/WebhookReplayTest.php
@@ -17,24 +17,10 @@ use App\Support\HostResolver;
 use App\Support\Webhooks\WebhookSignature;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
-
-/**
- * A HostResolver stub answering every host with one fixed public IP, so a
- * replay's delivery-time DNS validation never touches real DNS.
- */
-function replayResolver(): HostResolver
-{
-    return new class extends HostResolver
-    {
-        public function resolve(string $host): array
-        {
-            return ['93.184.216.34'];
-        }
-    };
-}
+use Tests\Support\StubHostResolver;
 
 beforeEach(function (): void {
-    $this->app->instance(HostResolver::class, replayResolver());
+    $this->app->instance(HostResolver::class, StubHostResolver::returning());
 
     $this->team = Team::factory()->create();
     $this->owner = User::factory()->create();

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -11,6 +11,9 @@ use App\Models\Team;
 use App\Models\User;
 use App\Support\SidebarChannels;
 use Database\Factories\ChannelMemberFactory;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
 
 /*
 |--------------------------------------------------------------------------
@@ -154,4 +157,40 @@ function channelMembership(Channel $channel, User $user, ?Closure $state = null)
     $membership->forceFill($stated->make()->getAttributes())->save();
 
     return $membership;
+}
+
+/*
+|--------------------------------------------------------------------------
+| Guarded egress (#1196)
+|--------------------------------------------------------------------------
+|
+| Every outbound connection to a member-controlled URL goes through
+| `App\Support\Http\GuardedEgress`, which pins each hop to the address the SSRF
+| guard vetted. Proving that took a bespoke capture helper in one of the three
+| callers' test files and nothing at all in the other two, so the pin was
+| asserted at one call site of three. This is that helper, shared.
+|
+| The DNS half lives in `Tests\Support\StubHostResolver`.
+|
+*/
+
+/**
+ * Fake every outbound request, recording the transport options it went out
+ * with, so a test can read back the address curl was pinned to:
+ *
+ *     captureTransportOptions(['https://example.test' => Http::response()], $captured);
+ *     expect($captured[0]['curl'][CURLOPT_RESOLVE])->toBe(['example.test:443:93.184.216.34']);
+ *
+ * @param  array<string, PromiseInterface>  $responses  keyed by requested URL
+ * @param  array<int, array<string, mixed>>|null  $captured
+ */
+function captureTransportOptions(array $responses, ?array &$captured): void
+{
+    $captured = [];
+
+    Http::fake(function (Request $request, array $options) use ($responses, &$captured): PromiseInterface {
+        $captured[] = $options;
+
+        return $responses[$request->url()];
+    });
 }

--- a/tests/Support/StubHostResolver.php
+++ b/tests/Support/StubHostResolver.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use App\Support\HostResolver;
+use Closure;
+use Override;
+
+/**
+ * The one DNS stub the suite uses, so the SSRF guard can be exercised with
+ * deterministic addresses instead of real DNS.
+ *
+ * It replaces six anonymous subclasses that each re-spelled the same two or
+ * three lines under a different name (`resolverReturning`, `webhookResolver`,
+ * `replayResolver`, `resolveHostsTo`, ...), two of them byte-for-byte identical.
+ *
+ * Two named readings, for the two questions a test asks of DNS:
+ *
+ *  - {@see self::returning()} — *this host is at that address*, the fixed answer
+ *    almost every test wants.
+ *  - {@see self::rebinding()} — *this host answers differently each time it is
+ *    asked*, standing in for an authoritative nameserver that rebinds a host
+ *    between the guard's check and the connection.
+ *
+ * Every lookup is recorded, so a test can prove the guard resolved once and
+ * pinned rather than letting curl look the host up again.
+ */
+final class StubHostResolver extends HostResolver
+{
+    /**
+     * The hosts looked up, in the order they were asked for.
+     *
+     * @var list<string>
+     */
+    public array $lookups = [];
+
+    /**
+     * @param  Closure(string, int): array<int, string>  $answer  Given the host and how many lookups preceded this one, the addresses it resolves to.
+     */
+    private function __construct(private readonly Closure $answer) {}
+
+    /**
+     * A resolver answering each host from a fixed map, and everything else with
+     * the same public address.
+     *
+     * @param  array<string, array<int, string>>  $map
+     * @param  array<int, string>  $default
+     */
+    public static function returning(array $map = [], array $default = ['93.184.216.34']): self
+    {
+        return new self(static fn (string $host, int $lookup): array => $map[$host] ?? $default);
+    }
+
+    /**
+     * A resolver answering successive lookups differently, whatever the host.
+     * The final answer repeats once the script runs out.
+     *
+     * @param  non-empty-array<int, array<int, string>>  $answers
+     */
+    public static function rebinding(array $answers): self
+    {
+        return new self(static fn (string $host, int $lookup): array => $answers[$lookup] ?? $answers[array_key_last($answers)]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    #[Override]
+    public function resolve(string $host): array
+    {
+        $lookup = count($this->lookups);
+        $this->lookups[] = $host;
+
+        return ($this->answer)($host, $lookup);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\Http;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
 use Tests\Support\FileSchemaBootstrapLock;
@@ -29,12 +30,20 @@ abstract class TestCase extends BaseTestCase
      * two worker databases — Postgres then kills one of them with a deadlock
      * and an unrelated test errors out (issue #812). The guard lets that first
      * attempt stay fully parallel and re-runs a deadlocked worker on its own.
+     *
+     * No test reaches the network (#1196). Every outbound connection to a
+     * member-controlled URL now goes through one module, so a tenth call site
+     * added later either goes through it — and is faked like the nine before it
+     * — or turns the suite red here. Before this, an unfaked request quietly
+     * dialled whatever host the fixture named, from the developer's machine and
+     * from CI.
      */
     #[\Override]
     protected function setUp(): void
     {
         if (! SchemaBootstrapGuard::shouldGuard()) {
             parent::setUp();
+            Http::preventStrayRequests();
 
             return;
         }
@@ -44,6 +53,8 @@ abstract class TestCase extends BaseTestCase
 
             parent::setUp();
         }, FileSchemaBootstrapLock::forRun());
+
+        Http::preventStrayRequests();
     }
 
     protected function skipUnlessFortifyHas(string $feature, ?string $message = null): void
@@ -170,6 +181,10 @@ abstract class TestCase extends BaseTestCase
         $database = config("database.connections.{$connection}.database");
 
         $this->refreshApplication();
+
+        // The fresh container brought a fresh HTTP factory with it, which has
+        // never been told to refuse an unfaked request. Say so again.
+        Http::preventStrayRequests();
 
         config(["database.connections.{$connection}.database" => $database]);
 

--- a/tests/Unit/GuardedEgressHomeTest.php
+++ b/tests/Unit/GuardedEgressHomeTest.php
@@ -53,13 +53,22 @@ function guardTriplePattern(): string
 }
 
 /**
- * Composing or dispatching an outbound request through the HTTP client, in the
- * facade form every site in this repository uses. The test-only entry points are
- * excluded so this can be replayed against a fake below.
+ * Reaching the HTTP client at all, in any of the three forms that would let a
+ * new site open its own connection: the facade by its short name (which also
+ * catches the fully-qualified call, since the leading `\` is a word boundary),
+ * the facade aliased to another name on import, and the underlying client
+ * factory injected directly.
+ *
+ * The facade's test-only entry points are excluded, so this can be replayed
+ * against a fake below without the tripwire firing on it.
  */
 function outboundClientPattern(): string
 {
-    return '/\bHttp::(?!fake|response|assert|preventStrayRequests|allowStrayRequests)\w+\(/';
+    $facade = '\bHttp::(?!fake|response|assert|preventStrayRequests|allowStrayRequests)\w+\(';
+    $aliased = 'use\s+Illuminate\\\\Support\\\\Facades\\\\Http\s+as\s';
+    $factory = 'use\s+Illuminate\\\\Http\\\\Client\\\\Factory\b';
+
+    return "/{$facade}|{$aliased}|{$factory}/";
 }
 
 test('the guard\'s delivery-time pair is asked from exactly one place', function () use ($sourceRoot): void {
@@ -115,6 +124,11 @@ test('each pattern still catches the code it was written for', function (string 
     'the pin half' => [guardTriplePattern(), '->withOptions($this->guard->transportOptions($url, $pinnedIp))'],
     'a fetch' => [outboundClientPattern(), '$response = Http::timeout(self::TIMEOUT_SECONDS)->get($url);'],
     'a composed delivery' => [outboundClientPattern(), "Http::withHeaders(['X-Desk-Event' => \$type])"],
+    // The three ways round the short name, which a tripwire keyed to `Http::`
+    // alone would wave through.
+    'a fully-qualified call' => [outboundClientPattern(), '\Illuminate\Support\Facades\Http::get($url);'],
+    'an aliased import' => [outboundClientPattern(), 'use Illuminate\Support\Facades\Http as Client;'],
+    'an injected factory' => [outboundClientPattern(), 'use Illuminate\Http\Client\Factory;'],
 ]);
 
 /**
@@ -132,4 +146,7 @@ test('each pattern leaves what it is not about alone', function (string $pattern
     // Faking is what a test does, never what production code does.
     'a fake' => [outboundClientPattern(), "Http::fake(['example.test/*' => Http::response('', 200)]);"],
     'a bare fake' => [outboundClientPattern(), 'Http::fake();'],
+    // Importing the facade under its own name is what every allowed site does;
+    // it is the *call* that the pattern is keyed to.
+    'a plain import of the facade' => [outboundClientPattern(), 'use Illuminate\Support\Facades\Http;'],
 ]);

--- a/tests/Unit/GuardedEgressHomeTest.php
+++ b/tests/Unit/GuardedEgressHomeTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Http\GuardedEgress;
+use App\Support\Http\OutboundUrlGuard;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * {@see OutboundUrlGuard} answers three questions that only mean anything asked
+ * together — is this URL public, what does it resolve to, how must the
+ * connection be pinned — and before #1196 three call sites asked them by hand.
+ * Two of the three then spelled the same forty-five line hop-and-pin walk, and
+ * only one of those caught a transport failure, so an unreachable host degraded
+ * to no image on one path and requeued the job on the other. The pin itself was
+ * asserted at one call site of three.
+ *
+ * {@see GuardedEgress} is now the one home, and this test is what keeps it that
+ * way: a fourth site asking the guard directly, or opening its own connection,
+ * fails here rather than in production on whichever surface was missed. See
+ * ADR-0015.
+ */
+$sourceRoot = dirname(__DIR__, 2);
+
+/**
+ * Every file under `app/` matching the given pattern, as repository-relative
+ * paths.
+ *
+ * @return list<string>
+ */
+function appFilesMatching(string $sourceRoot, string $pattern): array
+{
+    $found = [];
+
+    foreach ((new Finder)->files()->in($sourceRoot.'/app')->name('*.php') as $file) {
+        if (preg_match($pattern, $file->getContents()) === 1) {
+            $found[] = str_replace($sourceRoot.'/', '', $file->getPathname());
+        }
+    }
+
+    sort($found);
+
+    return $found;
+}
+
+/**
+ * The delivery-time half of the guard, called on an instance. The declarations
+ * themselves read `public function resolveDeliveryIp(`, so they do not match.
+ */
+function guardTriplePattern(): string
+{
+    return '/->\s*(resolveDeliveryIp|transportOptions)\(/';
+}
+
+/**
+ * Composing or dispatching an outbound request through the HTTP client, in the
+ * facade form every site in this repository uses. The test-only entry points are
+ * excluded so this can be replayed against a fake below.
+ */
+function outboundClientPattern(): string
+{
+    return '/\bHttp::(?!fake|response|assert|preventStrayRequests|allowStrayRequests)\w+\(/';
+}
+
+test('the guard\'s delivery-time pair is asked from exactly one place', function () use ($sourceRoot): void {
+    expect(appFilesMatching($sourceRoot, guardTriplePattern()))->toBe([
+        'app/Support/Http/GuardedEgress.php',
+    ]);
+});
+
+/**
+ * `isPublic()` is deliberately not in that list. It is a *pre-flight* question —
+ * `PublicWebhookUrl` asks it at validation time, before any request exists, and
+ * `User::routeNotificationForWebPush` asks it where the web-push package owns
+ * the connection — so it stays public and static, and callers outside this
+ * module are expected.
+ */
+test('the pre-flight check is still asked from outside the module', function () use ($sourceRoot): void {
+    expect(appFilesMatching($sourceRoot, '/OutboundUrlGuard::isPublic\(/'))
+        ->toContain('app/Rules/PublicWebhookUrl.php', 'app/Models/User.php');
+});
+
+/**
+ * The four sites that hold the HTTP client, and why each one is allowed to.
+ *
+ * `GuardedEgress` is the module. `DeliverWebhook` *composes* a signed request
+ * and hands it to `GuardedEgress::send()` — it never dispatches one itself.
+ * `GiphyClient` and `UpdateChecker` talk to operator-configured hosts and are
+ * out of scope by decision, not by oversight (ADR-0015 records why: routing them
+ * through a guard each would need to switch off is how a security module stops
+ * being one).
+ *
+ * A fifth entry means a new egress site. Route it through `GuardedEgress` and
+ * this test stays quiet; if it genuinely belongs beside Giphy, say so here and
+ * in the ADR.
+ */
+test('the sites holding the HTTP client are the four that are meant to', function () use ($sourceRoot): void {
+    expect(appFilesMatching($sourceRoot, outboundClientPattern()))->toBe([
+        'app/Jobs/DeliverWebhook.php',
+        'app/Support/GiphyClient.php',
+        'app/Support/Http/GuardedEgress.php',
+        'app/Support/UpdateChecker.php',
+    ]);
+});
+
+/**
+ * A guard nothing can trip proves nothing, and these are regular expressions
+ * over source: a typo makes them match nothing at all and the suite stays green.
+ * Each pattern is replayed here against the copy it was written for.
+ */
+test('each pattern still catches the code it was written for', function (string $pattern, string $source): void {
+    expect(preg_match($pattern, $source))->toBe(1);
+})->with([
+    'the resolve half' => [guardTriplePattern(), '$pinnedIp = $this->guard->resolveDeliveryIp($target);'],
+    'the pin half' => [guardTriplePattern(), '->withOptions($this->guard->transportOptions($url, $pinnedIp))'],
+    'a fetch' => [outboundClientPattern(), '$response = Http::timeout(self::TIMEOUT_SECONDS)->get($url);'],
+    'a composed delivery' => [outboundClientPattern(), "Http::withHeaders(['X-Desk-Event' => \$type])"],
+]);
+
+/**
+ * And what each must stay quiet about, so the guard does not become noise
+ * someone silences by widening the expected list.
+ */
+test('each pattern leaves what it is not about alone', function (string $pattern, string $source): void {
+    expect(preg_match($pattern, $source))->toBe(0);
+})->with([
+    // The declarations, which live on the guard by design.
+    'the resolve declaration' => [guardTriplePattern(), 'public function resolveDeliveryIp(string $url): string|false|null'],
+    'the pin declaration' => [guardTriplePattern(), 'public function transportOptions(string $url, ?string $pinnedIp): array'],
+    // The pre-flight check, which is a different question.
+    'the pre-flight check' => [guardTriplePattern(), 'if (! OutboundUrlGuard::isPublic($url)) {'],
+    // Faking is what a test does, never what production code does.
+    'a fake' => [outboundClientPattern(), "Http::fake(['example.test/*' => Http::response('', 200)]);"],
+    'a bare fake' => [outboundClientPattern(), 'Http::fake();'],
+]);


### PR DESCRIPTION
Closes #1196. Part of #1195 (architecture hardening V).

## What

`OutboundUrlGuard` answers three questions that only mean anything asked together — is this URL public, what does it resolve to, how must the connection be pinned — and three call sites asked them by hand. The two `fetch` sites then spelled the same ~45-line hop-and-pin walk twice.

**One copy had a `try/catch` and the other did not.** `FetchRemoteImage` caught `Throwable` and returned null; `FetchLinkPreview` was unprotected, so an unreachable host raised `ConnectionException` out of `Cache::remember` and out of `UnfurlMessageLinks::handle`, failing and **requeuing the job** — while every sibling egress site degraded to an empty result. The coverage gate could not see it: an uncaught path leaves no line uncovered.

`App\Support\Http\GuardedEgress` is now the one home, in two named readings:

- **`fetch($url, FetchPolicy): ?FetchedBody`** — owns the hop bound, re-guards and re-pins every hop, disables curl-level redirects, enforces the size cap, applies the content-type predicate, and maps every failure (blocked, dead, error status, wrong type, oversize, redirect loop) to one null. Callers supply only what differs: the predicate, the byte cap, and which reading of the cap they want — `FetchPolicy::truncatingAt()` for an unfurl that only parses `<head>`, `refusingOver()` for an image, where half the bytes is a corrupt file rather than a small one.
- **`send($url, PendingRequest, $method): Response`** — the guard triple and the no-redirects rule and nothing else. `DeliverWebhook` adapts in and keeps its own retry, its own `recordFailure`, its own 255-char trim. `fetch()` is built on it, so there is one vetting path.

A refused destination now leaves through the same door as an unreachable one (`BlockedEgress`), which is what collapses `DeliverWebhook`'s three branches into its existing `catch (Throwable)` and what lets `fetch()` catch both.

`OutboundUrlGuard::isPublic()` **stays public and static** — `PublicWebhookUrl` and `User::routeNotificationForWebPush` ask it pre-flight, before any request exists. `resolveDeliveryIp()` and `transportOptions()` keep their home on the guard but gain a single caller.

## Testing

- **The behaviour fix has a test**: an unreachable host on the link-preview path degrades to a null preview and is negatively cached, mirroring `ImageProxyTest`'s `ConnectionException` case.
- **The pin is asserted at all three call sites** (it was asserted at one of three), through one shared `captureTransportOptions()` in `tests/Helpers.php`; `allow_redirects => false` is asserted alongside it, at each.
- **`transportOptions()` gains direct cases** in `OutboundUrlGuardTest` — default port per scheme, an explicit port, and the brackets an IPv6 literal needs.
- **Every hop is re-guarded and re-pinned**, now proven on the image path too (a redirect whose second hop resolves private is refused).
- **Six `HostResolver` stubs collapse** to `Tests\Support\StubHostResolver`, with two named constructors (`returning()`, `rebinding()`).
- **`Http::preventStrayRequests()` runs suite-wide** from `Tests\TestCase::setUp()`, so a tenth egress site added later either goes through the module or turns the suite red.
- **`tests/Unit/GuardedEgressHomeTest.php`** pins the module as the only caller of the guard's delivery-time pair, and the four files allowed to hold the HTTP client — catching an aliased import and an injected `Client\Factory` as well as the literal facade call.

Both gates green: `Total: 100.0 %`, Pint/PHPStan/Rector clean, `lint:check` / `format:check` / `types:check` / `test:js` / `build` clean. A local CodeRabbit pass is clean.

## Docs

- **ADR-0015** records the decision and, more importantly, the scope: why Giphy, `UpdateChecker` and the OIDC calls stay out (routing them through a guard each would need to switch off is how a security module stops being one).
- **`CONTEXT.md`** gains a `GuardedEgress` entry in the named-seams list.
- No operator-facing change — no new `.env` key, config setting or stack step — so `docs/` is untouched.

## Found on the way

- **#1202** — the byte cap is enforced *after* the body is buffered, so it bounds what the module keeps rather than what it reads (a chunked response declares no `Content-Length`). Pre-existing and identical in both copies collapsed here; fixing it means streaming the body rather than moving it, so it is filed rather than folded in. ADR-0015 names it in the out-of-scope list.

## i18n

No user-facing copy added or changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788378125&installation_model_id=428379&pr_number=1203&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1203&signature=caa2bde4f61d55498438d4b1eccbfcb83ba2b5397cd4aab6e7fff04972d9d007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->