### PR TITLE
refactor: give the channel page a read-model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,6 +68,8 @@ built; build them once, then reuse.
   eager-loads exactly the relations `MessageData::fromMessage()` reads. Every
   timeline / thread / search / broadcast / edit payload goes through it, so the
   N+1 contract has one home. Never hand-write the `with([...])` relation list.
+  `ScheduledMessage::withScheduledMessageDataRelations()` is the same device for the
+  smaller payload the composer's "Scheduled" list ships.
 - **Visible-channels ACL** _(ADR-0003)_ — the channel authorization boundary,
   **two named readings on `User`** because two different questions share the word
   "visible". `memberChannelIds(Team)` (and `memberChannelIdsAcrossTeams()`) is
@@ -82,6 +84,19 @@ built; build them once, then reuse.
 - **Channel timeline window** _(ADR-0004)_ — the read-model/query object
   that resolves where a channel's initial message window opens (unread anchoring,
   jump context, paging). Takes explicit params; the controller keeps HTTP glue.
+- **`ChannelPage`** _(ADR-0004, amended)_ — the other half of that decision: everything
+  a channel page renders that is *not* its timeline, in one reading per prop group —
+  the channel DTO, the viewer's membership facts, the seven capability gates, the pins
+  **and** their count as a single reading, the roster, the read receipts, the pending
+  schedules, the member count. Constructed from a `Channel`, a `User` and a `Team`,
+  never a `Request`, so every reading is reachable without an HTTP round-trip; the
+  window stays a separate collaborator because it is the only one that answers to
+  `?message=` / `?thread=`, and the controller holds both. `ChannelController::show()`
+  holds no query builder, no `Gate::allows` and no `setAttribute` — the viewer's mute,
+  level and draft reach `ChannelData::fromChannel()` as its `?ChannelMember $membership`
+  parameter rather than being written onto the model for the DTO to find.
+  `ChannelPageQueryCountTest` pins its cost the way `SidebarChannelsQueryCountTest` pins
+  the sidebar's.
 - **Workspace shell read-model** _(ADR-0008)_ — `WorkspaceShell` owns the
   `(authenticated, on a workspace route, with a bound team)` precondition and every
   read-model an in-workspace page draws its shell from (`SidebarChannels`,

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -4,7 +4,9 @@ namespace App\Data;
 
 use App\Enums\NotificationLevel;
 use App\Models\Channel;
+use App\Models\ChannelMember;
 use App\Models\User;
+use App\Support\ChannelPage;
 use App\Support\DirectMessageRoster;
 use Illuminate\Support\Carbon;
 use Spatie\LaravelData\Data;
@@ -43,10 +45,19 @@ class ChannelData extends Data
     /**
      * Build the DTO from a Channel model.
      *
-     * `unread_count`, `mention_count`, `muted` and `notification_level` are the
-     * current user's per-channel state, populated only when the channel was
-     * loaded for their sidebar or view; elsewhere they are absent and fall back
-     * to the defaults (unmuted, "all", zero badges).
+     * `$membership` is the viewer's own row on the channel, and it is where their
+     * per-channel state — mute, notification level, draft, star — is read from
+     * when the caller already holds it: the channel page passes the row
+     * {@see ChannelPage} resolved, so nothing has to be written onto the model to
+     * smuggle it in. A caller with no row to hand over passes none, and a viewer
+     * with no row at all — a non-member reading a public channel — gets the
+     * defaults (unmuted, "all", no draft, unstarred).
+     *
+     * The sidebar is the one caller that passes none and still carries state: its
+     * single query selects every pivot column onto each channel, so those
+     * attributes stand in for the row rather than costing one query per row.
+     * `unread_count` and `mention_count` are only ever attributes — they are
+     * correlated sub-queries, not columns of the pivot — and fall back to zero.
      *
      * The badge counts are suppressed here so the sidebar prop is authoritative:
      * a muted channel or the "nothing" level shows no badge at all, and the
@@ -73,22 +84,31 @@ class ChannelData extends Data
      * channels through {@see DirectMessageRoster} first and naming their direct
      * messages then costs this no query at all.
      */
-    public static function fromChannel(Channel $channel, User $viewer): self
+    public static function fromChannel(Channel $channel, User $viewer, ?ChannelMember $membership = null): self
     {
-        $muted = (bool) ($channel->getAttribute('muted') ?? false);
+        // A handed-over row answers for the whole membership, attributes for the
+        // whole of it, or neither — never half of each, so a null column on the
+        // row reads as "not set" rather than falling through to a stale attribute.
+        $stated = $membership instanceof ChannelMember;
 
-        $level = NotificationLevel::tryFrom((string) ($channel->getAttribute('notification_level') ?? NotificationLevel::All->value)) ?? NotificationLevel::All;
+        $muted = $stated ? $membership->muted : (bool) ($channel->getAttribute('muted') ?? false);
+
+        $level = $stated
+            ? $membership->notification_level
+            : NotificationLevel::tryFrom((string) ($channel->getAttribute('notification_level') ?? NotificationLevel::All->value)) ?? NotificationLevel::All;
 
         $unreadCount = (int) ($channel->getAttribute('unread_count') ?? 0);
         $mentionCount = (int) ($channel->getAttribute('mention_count') ?? 0);
 
-        $draftText = $channel->getAttribute('draft');
+        $draftText = $stated ? $membership->draft : $channel->getAttribute('draft');
         $draft = is_string($draftText) && trim($draftText) !== '' ? $draftText : null;
 
-        $hasDraftAttribute = $channel->getAttribute('has_draft');
+        // The sidebar ships a `has_draft` flag in place of the text it withholds;
+        // everywhere else the presence of the draft is the answer.
+        $hasDraftAttribute = $stated ? null : $channel->getAttribute('has_draft');
         $hasDraft = $hasDraftAttribute !== null ? (bool) $hasDraftAttribute : $draft !== null;
 
-        $starred = (bool) ($channel->getAttribute('starred') ?? false);
+        $starred = $stated ? $membership->starred : (bool) ($channel->getAttribute('starred') ?? false);
 
         $sectionId = $channel->getAttribute('section_id');
         $sectionId = is_string($sectionId) ? $sectionId : null;

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -11,13 +11,9 @@ use App\Actions\Channels\MarkChannelRead;
 use App\Actions\Channels\MarkThreadRead;
 use App\Actions\Channels\UpdateChannel;
 use App\Data\ChannelData;
-use App\Data\ChannelReaderData;
-use App\Data\MessageData;
-use App\Data\ScheduledMessageData;
 use App\Data\UserData;
 use App\Enums\ChannelVisibility;
 use App\Enums\NotificationLevel;
-use App\Enums\UserType;
 use App\Events\UserTyping;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\CreateChannelRequest;
@@ -26,7 +22,7 @@ use App\Http\Requests\Channels\UpdateChannelRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
-use App\Support\ChannelMembership;
+use App\Support\ChannelPage;
 use App\Support\ChannelTimelineWindow;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Http\RedirectResponse;
@@ -93,32 +89,27 @@ class ChannelController extends Controller
 
     /**
      * Show a channel. The channel sidebar is fed by the globally-shared `channels` prop.
+     *
+     * Two read-models, held side by side. {@see ChannelPage} owns the payload —
+     * the channel itself, the viewer's standing in it, the controls, the pins,
+     * the roster, the receipts, the schedules — and {@see ChannelTimelineWindow}
+     * owns where the initial message window opens. They are separate because
+     * only the second one answers to the URL: it takes the raw `?message=` and
+     * `?thread=` values, and a read-model that knows about query strings is what
+     * ADR-0008 keeps out. So this action stays HTTP glue: authorize, resolve the
+     * two params, name the props.
      */
     public function show(Request $request, Team $team, Channel $channel): Response
     {
         Gate::authorize('view', $channel);
 
-        // Surface the current user's own notification preferences on the channel
-        // so the header settings menu opens on the persisted state. A non-member
-        // viewing a public channel has no pivot row, so the DTO defaults apply.
-        $membership = new ChannelMembership($channel, $request->user());
-        $member = $membership->row();
-        $channel->setAttribute('muted', $member->muted ?? false);
-        $channel->setAttribute('notification_level', $member?->notification_level->value ?? NotificationLevel::All->value);
-        // Surface the member's saved draft so the composer restores it on open; a
-        // non-member has no pivot row, so the composer opens empty.
-        $channel->setAttribute('draft', $member?->draft);
+        $page = new ChannelPage($channel, $request->user(), $team);
 
-        // The timeline read-model owns where the initial window opens — jump
-        // anchoring, unread-boundary anchoring, page-size arithmetic — and
-        // assembles the timeline and thread payloads. It takes explicit params
-        // (the raw `?message=` / `?thread=` query values and the read pointer),
-        // so this action stays HTTP glue: resolve params, call it, render.
         $window = new ChannelTimelineWindow(
             channel: $channel,
             viewer: $request->user(),
             requestedJumpId: $request->query('message'),
-            lastReadMessageId: $member?->last_read_message_id,
+            lastReadMessageId: $page->lastReadMessageId(),
             requestedThreadRootId: $request->query('thread'),
         );
 
@@ -128,55 +119,19 @@ class ChannelController extends Controller
                 'name' => $team->name,
                 'slug' => $team->slug,
             ],
-            'channel' => ChannelData::fromChannel($channel, $request->user()),
-            // Drives the header's archive control; authoritative so the button
-            // only appears for a creator or Admin+ on a non-#general channel.
-            'canArchive' => Gate::allows('archive', $channel),
-            // Gates the notification settings menu; only a member of the channel
-            // has preferences to manage.
-            'canManagePreferences' => Gate::allows('updateMembership', $channel),
-            // Gates the channel-details modal's edit mode: any member of a live
-            // standard channel may reword its topic and description.
-            'canEditChannel' => Gate::allows('update', $channel),
-            // Narrows that to the name field, which only the creator or a team
-            // Admin+ may change.
-            'canRenameChannel' => Gate::allows('rename', $channel),
-            // Drives the header's delete control and its confirmation dialog;
-            // only a team Admin+ on a standard, non-#general channel.
-            'canDelete' => Gate::allows('delete', $channel),
-            // Gates the "Leave channel" menu item + modal; a member of a standard
-            // channel that isn't #general may leave.
-            'canLeave' => Gate::allows('leave', $channel),
-            // Gates the reaction affordances; only a member of a non-archived
-            // channel may react, matching the server-side `postMessage` rule.
-            'canReact' => Gate::allows('postMessage', $channel),
-            // Whether the viewer already belongs to the channel. A non-member can
-            // reach a public channel by URL and read it, but the composer is
-            // replaced by a "Join channel" call-to-action until they join.
-            'isMember' => $membership->exists(),
-            // The channel's member count, surfaced in the join call-to-action so a
-            // non-member sees how many teammates are already in the channel. Bots
-            // are integration identities, not seats, so they never count here.
-            'memberCount' => $channel->channelMembers()
-                ->whereRelation('user', 'type', UserType::Human->value)
-                ->count(),
-            // The channel's pin count, driving the masthead's pins-button badge on
-            // first load; later pins/unpins patch it live over MessagePinned.
-            'pinCount' => $channel->pins()->count(),
-            // The channel's pinned messages, most-recently-pinned first, feeding
-            // the pins popover. Each row is a full MessageData (its own `pin`
-            // carries the "Pinned by :name" attribution), so the panel reuses the
-            // same rendering as the timeline. Bounded by the 100-pin cap.
-            'pins' => MessageData::collect(
-                Message::query()
-                    ->withMessageDataRelations()
-                    ->join('message_pins', 'message_pins.message_id', '=', 'messages.id')
-                    ->where('message_pins.channel_id', $channel->id)
-                    ->orderByDesc('message_pins.created_at')
-                    ->orderByDesc('message_pins.id')
-                    ->select('messages.*')
-                    ->get()
-            ),
+            'channel' => $page->channel(),
+            // The seven `can*` props gating the masthead's controls, spread from
+            // the one reading that asks the policy for all of them.
+            ...$page->capabilities(),
+            // Whether the viewer already belongs to the channel, and how many
+            // teammates do — the join call-to-action a non-member sees instead of
+            // the composer reads both.
+            'isMember' => $page->isMember(),
+            'memberCount' => $page->memberCount(),
+            // The pins popover's rows and the masthead badge's count, which are
+            // one reading so they cannot disagree; later pins/unpins patch both
+            // live over MessagePinned.
+            ...$page->pins(),
             // Selectable notification levels for the settings menu.
             'notificationLevels' => NotificationLevel::options(),
             // The message the client should scroll to and highlight on load, or
@@ -186,7 +141,7 @@ class ChannelController extends Controller
             // client's debounced MarkChannelRead advances it. Drives the
             // "New messages" divider so it lands at the last-read boundary on
             // open; null when the channel has never been read.
-            'lastReadMessageId' => $member?->last_read_message_id !== null ? (string) $member->last_read_message_id : null,
+            'lastReadMessageId' => $page->lastReadMessageId(),
             // The open thread's root message, resolved from the `?thread=` query
             // param, or null for a normal visit. The client opens a thread by
             // visiting `?thread=<root>`, which also drives the paginated replies
@@ -197,45 +152,16 @@ class ChannelController extends Controller
             // independent of the main timeline's, and the client's reverse
             // InfiniteScroll pages older replies in above as it scrolls up.
             'threadReplies' => Inertia::scroll(fn (): CursorPaginator => $window->threadReplies()),
-            // The viewer's own pending scheduled messages for this channel, soonest
-            // first, feeding the composer's "Scheduled" affordance. Only pending
-            // rows are listed — sent and cancelled ones drop off. The reply quote
-            // is eager-loaded so an inline-reply schedule renders its parent.
-            'scheduledMessages' => ScheduledMessageData::collect(
-                $channel->scheduledMessages()
-                    ->pending()
-                    ->where('user_id', $request->user()->id)
-                    ->with(['replyTo.user', 'replyTo.mentionedUsers'])
-                    ->orderBy('send_at')
-                    ->get()
-            ),
+            // The viewer's own pending scheduled messages, feeding the composer's
+            // "Scheduled" affordance.
+            'scheduledMessages' => $page->scheduledMessages(),
             // Feeds both the masthead member facepile and the composer's @mention
-            // autocomplete. A standard channel is team-scoped — you may mention
-            // anyone on the team — plus the channel's own bots, which appear in the
-            // roster (badged) but are filtered out of mention autocomplete client
-            // side (a bot has no inbox to reach). A direct message is scoped to its
-            // own participants, since mentioning someone who isn't in the
-            // conversation would never reach them (this generalizes to group DMs).
-            'members' => UserData::collect(
-                $channel->isDirectMessage()
-                    ? $channel->members()->orderBy('name')->get()
-                    : $team->members()->orderBy('name')->get()->concat(
-                        $channel->members()
-                            ->where('users.type', UserType::Bot->value)
-                            ->orderBy('name')
-                            ->get()
-                    )
-            ),
+            // autocomplete.
+            'members' => $page->roster(),
             // Read pointers of the channel's other members who share read receipts,
             // seeding the "Seen by" affordance at open; later advances arrive via the
-            // MessageRead broadcast. The viewer and opted-out members are excluded.
-            'channelReaders' => ChannelReaderData::collect(
-                $channel->channelMembers()
-                    ->where('user_id', '!=', $request->user()->id)
-                    ->whereRelation('user', 'share_read_receipts', true)
-                    ->with('user')
-                    ->get()
-            ),
+            // MessageRead broadcast.
+            'channelReaders' => $page->readers(),
             // Newest 50 first; the InfiniteScroll composer runs in reverse mode, so
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -301,14 +301,15 @@ class Channel extends Model
      * Get the channel's pinned-message rows, most-recently-pinned first.
      *
      * Denormalized onto `channel_id`, so the pin count and the pins panel query
-     * never join through `messages`. Ordered by when each pin was created so the
-     * panel lists the freshest pins on top.
+     * never join through `messages`. Ordered by when each pin was created, then
+     * by id, so the panel lists the freshest pins on top and two pins landing in
+     * the same second still order newest-first rather than by chance.
      *
      * @return HasMany<MessagePin, $this>
      */
     public function pins(): HasMany
     {
-        return $this->hasMany(MessagePin::class)->latest()->orderBy('id');
+        return $this->hasMany(MessagePin::class)->latest()->latest('id');
     }
 
     /**

--- a/app/Models/ScheduledMessage.php
+++ b/app/Models/ScheduledMessage.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Data\MessageReplyData;
+use App\Data\ScheduledMessageData;
 use App\Enums\ScheduledMessageStatus;
 use Database\Factories\ScheduledMessageFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -47,6 +49,21 @@ class ScheduledMessage extends Model
     ];
 
     /**
+     * The relations {@see ScheduledMessageData::fromScheduledMessage()} reads:
+     * the quoted parent, and what {@see MessageReplyData} needs off it to render
+     * the quote. Declared once, for the same reason
+     * {@see Message::MESSAGE_DATA_RELATIONS} is (ADR-0002) — a hand-written
+     * `with([...])` at a call site is an N+1 waiting for the day the DTO reads
+     * one relation more.
+     *
+     * @var list<string>
+     */
+    private const array SCHEDULED_MESSAGE_DATA_RELATIONS = [
+        'replyTo.user',
+        'replyTo.mentionedUsers',
+    ];
+
+    /**
      * Get the channel the message is scheduled for.
      *
      * @return BelongsTo<Channel, $this>
@@ -77,6 +94,17 @@ class ScheduledMessage extends Model
     public function replyTo(): BelongsTo
     {
         return $this->belongsTo(Message::class, 'reply_to_id')->withTrashed();
+    }
+
+    /**
+     * Eager-load exactly the relations a {@see ScheduledMessageData} payload
+     * reads, so no caller spells the set for itself.
+     *
+     * @param  Builder<ScheduledMessage>  $query
+     */
+    protected function scopeWithScheduledMessageDataRelations(Builder $query): void
+    {
+        $query->with(self::SCHEDULED_MESSAGE_DATA_RELATIONS);
     }
 
     /**

--- a/app/Support/ChannelPage.php
+++ b/app/Support/ChannelPage.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\ChannelData;
+use App\Data\ChannelReaderData;
+use App\Data\MessageData;
+use App\Data\ScheduledMessageData;
+use App\Data\UserData;
+use App\Enums\UserType;
+use App\Http\Controllers\Channels\ChannelController;
+use App\Models\Channel;
+use App\Models\ChannelMember;
+use App\Models\Message;
+use App\Models\MessagePin;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Everything a channel page renders that is not its timeline: the channel
+ * itself, the viewer's standing in it, the controls they may reach for, the
+ * pins, the roster, the read receipts and the composer's pending schedules.
+ *
+ * It is the other half of ADR-0004. That decision moved the *window* — where a
+ * channel's initial page of messages opens — out of {@see ChannelController::show()}
+ * and into {@see ChannelTimelineWindow}; the *payload* stayed behind as nineteen
+ * query-builder calls, seven `Gate::allows` and three attributes written onto the
+ * bound `Channel` so the DTO could read them back off it. This is where it went.
+ *
+ * Two properties, the same two {@see WorkspaceShell} has:
+ *
+ * 1. **No request.** The constructor takes a channel, a viewer and a team, so
+ *    every reading below is reachable from a test without an HTTP round-trip.
+ *    The window is *not* built here and is not a collaborator of this: it reads
+ *    `?message=` and `?thread=`, and a read-model that knows about query strings
+ *    is the friction this shape exists to avoid. The controller holds both.
+ * 2. **No ambient state.** The viewer's own mute, notification level and draft
+ *    are read off their membership row and handed to {@see ChannelData::fromChannel()}
+ *    as a parameter (ADR-0011), rather than written onto the model for the DTO to
+ *    find — which is the same ambient-state defect through a side channel.
+ *
+ * The page does not name the props it feeds. That list is the Inertia contract
+ * and stays in the controller, which is glue: it names the props, resolves the
+ * two query params the window takes, and computes none of it.
+ */
+final class ChannelPage
+{
+    private bool $membershipResolved = false;
+
+    private ?ChannelMember $membership = null;
+
+    public function __construct(
+        private readonly Channel $channel,
+        private readonly User $viewer,
+        private readonly Team $team,
+    ) {}
+
+    /**
+     * The channel as the viewer sees it, carrying their own membership state.
+     */
+    public function channel(): ChannelData
+    {
+        return ChannelData::fromChannel($this->channel, $this->viewer, $this->membership());
+    }
+
+    /**
+     * Whether the viewer already belongs to the channel.
+     *
+     * A non-member can reach a public channel by URL and read it, but the
+     * composer is replaced by a "Join channel" call-to-action until they join.
+     */
+    public function isMember(): bool
+    {
+        return $this->membership() instanceof ChannelMember;
+    }
+
+    /**
+     * The viewer's read pointer, captured before the client's debounced
+     * `MarkChannelRead` advances it.
+     *
+     * Two consumers, which is why it is a reading of its own: it drives the
+     * "New messages" divider so it lands at the last-read boundary on open, and
+     * it is what anchors {@see ChannelTimelineWindow}'s initial window. Null when
+     * the channel has never been read, or was never joined.
+     */
+    public function lastReadMessageId(): ?string
+    {
+        $lastReadMessageId = $this->membership()?->last_read_message_id;
+
+        return $lastReadMessageId !== null ? (string) $lastReadMessageId : null;
+    }
+
+    /**
+     * The controls the page may offer this viewer, as the props that gate them.
+     *
+     * Seven abilities asked of the policy rather than derived from the viewer's
+     * role here, so an affordance and the endpoint behind it can never answer
+     * differently. They travel together because they are one question — "what
+     * may this person do on this page?" — and because a control added to the
+     * masthead should be one entry here, not a ninth `Gate::allows` in a
+     * render array.
+     *
+     * @return array<string, bool>
+     */
+    public function capabilities(): array
+    {
+        return [
+            // Drives the header's archive control; authoritative so the button
+            // only appears for a creator or Admin+ on a non-#general channel.
+            'canArchive' => $this->allows('archive'),
+            // Gates the notification settings menu; only a member of the channel
+            // has preferences to manage.
+            'canManagePreferences' => $this->allows('updateMembership'),
+            // Gates the channel-details modal's edit mode: any member of a live
+            // standard channel may reword its topic and description.
+            'canEditChannel' => $this->allows('update'),
+            // Narrows that to the name field, which only the creator or a team
+            // Admin+ may change.
+            'canRenameChannel' => $this->allows('rename'),
+            // Drives the header's delete control and its confirmation dialog;
+            // only a team Admin+ on a standard, non-#general channel.
+            'canDelete' => $this->allows('delete'),
+            // Gates the "Leave channel" menu item + modal; a member of a standard
+            // channel that isn't #general may leave.
+            'canLeave' => $this->allows('leave'),
+            // Gates the reaction affordances; only a member of a non-archived
+            // channel may react, matching the server-side `postMessage` rule.
+            'canReact' => $this->allows('postMessage'),
+        ];
+    }
+
+    /**
+     * How many teammates are in the channel, surfaced in the join
+     * call-to-action so a non-member sees who is already there.
+     *
+     * Bots are integration identities, not seats, so they never count — even
+     * though they do appear on the roster below.
+     */
+    public function memberCount(): int
+    {
+        return $this->channel->channelMembers()
+            ->whereRelation('user', 'type', UserType::Human->value)
+            ->count();
+    }
+
+    /**
+     * The channel's pinned messages and how many there are, as one reading.
+     *
+     * Most-recently-pinned first, each row a full {@see MessageData} (its own
+     * `pin` carries the "Pinned by :name" attribution) so the pins popover reuses
+     * the timeline's rendering. Bounded by the 100-pin cap, which is what lets
+     * the badge count what the panel holds rather than ask separately: the two
+     * are named in `lib/reloadProps` as a pair that must move together, and two
+     * independent queries are two answers that can disagree.
+     *
+     * @return array{pins: array<int, MessageData>, pinCount: int}
+     */
+    public function pins(): array
+    {
+        // The pin rows carry the order and the ids; their messages are fetched
+        // in one further go through the load-set scope (ADR-0002) rather than
+        // joined to. Deleting a message unpins it, so a pin whose message is a
+        // tombstone is only ever a race — `Message::query()` withholds it, and
+        // it drops out of the list and the count together, which two independent
+        // queries could not manage.
+        $pins = $this->channel->pins()->get();
+
+        $messages = Message::query()
+            ->withMessageDataRelations()
+            ->whereKey($pins->pluck('message_id'))
+            ->get()
+            ->keyBy('id');
+
+        $rows = MessageData::collect(
+            $pins->map(fn (MessagePin $pin): ?Message => $messages->get($pin->message_id))->filter()->values(),
+            'array',
+        );
+
+        return ['pins' => $rows, 'pinCount' => count($rows)];
+    }
+
+    /**
+     * The people the page may name: the masthead's member facepile and the
+     * composer's `@mention` autocomplete.
+     *
+     * A standard channel is team-scoped — you may mention anyone on the team —
+     * plus the channel's own bots, which appear in the roster (badged) but are
+     * filtered out of mention autocomplete client side (a bot has no inbox to
+     * reach). A direct message is scoped to its own participants, since
+     * mentioning someone who isn't in the conversation would never reach them
+     * (this generalizes to group DMs).
+     *
+     * @return array<int, UserData>
+     */
+    public function roster(): array
+    {
+        $roster = $this->channel->isDirectMessage()
+            ? $this->channel->members()->orderBy('name')->get()
+            : $this->team->members()->orderBy('name')->get()->concat(
+                $this->channel->members()
+                    ->where('users.type', UserType::Bot->value)
+                    ->orderBy('name')
+                    ->get()
+            );
+
+        return UserData::collect($roster, 'array');
+    }
+
+    /**
+     * The read pointers of the channel's other members who share read receipts,
+     * seeding the "Seen by" affordance at open; later advances arrive over the
+     * `MessageRead` broadcast.
+     *
+     * The viewer is excluded — nobody is shown their own receipt — and so is
+     * anyone who opted out of sharing theirs.
+     *
+     * @return array<int, ChannelReaderData>
+     */
+    public function readers(): array
+    {
+        $readers = $this->channel->channelMembers()
+            ->where('user_id', '!=', $this->viewer->id)
+            ->whereRelation('user', 'share_read_receipts', true)
+            ->with('user')
+            ->get();
+
+        return ChannelReaderData::collect($readers, 'array');
+    }
+
+    /**
+     * The viewer's own pending scheduled messages for this channel, soonest
+     * first, feeding the composer's "Scheduled" affordance.
+     *
+     * Only pending rows are listed — sent and cancelled ones drop off — and each
+     * one's quote is eager-loaded through the model's own scope, so an
+     * inline-reply schedule renders its parent (ADR-0002).
+     *
+     * @return array<int, ScheduledMessageData>
+     */
+    public function scheduledMessages(): array
+    {
+        $scheduled = $this->channel->scheduledMessages()
+            ->pending()
+            ->where('user_id', $this->viewer->id)
+            ->withScheduledMessageDataRelations()
+            ->orderBy('send_at')
+            ->get();
+
+        return ScheduledMessageData::collect($scheduled, 'array');
+    }
+
+    /**
+     * Whether the viewer holds an ability on this channel.
+     *
+     * Asked for the viewer explicitly rather than of the ambient session, which
+     * is what keeps every capability above reachable without signing in.
+     */
+    private function allows(string $ability): bool
+    {
+        return Gate::forUser($this->viewer)->allows($ability, $this->channel);
+    }
+
+    /**
+     * The viewer's membership row, or null when they do not belong.
+     *
+     * Read through {@see ChannelMembership}, the one module that resolves the
+     * pivot, and memoized: the channel DTO, the member flag and the read pointer
+     * all ask, and a page render should pay for it once.
+     */
+    private function membership(): ?ChannelMember
+    {
+        if (! $this->membershipResolved) {
+            $this->membership = new ChannelMembership($this->channel, $this->viewer)->row();
+            $this->membershipResolved = true;
+        }
+
+        return $this->membership;
+    }
+}

--- a/dev-docs/adr/0004-timeline-window-as-read-model.md
+++ b/dev-docs/adr/0004-timeline-window-as-read-model.md
@@ -1,8 +1,51 @@
 # ADR-0004: Resolve the channel timeline window in a read-model, not the controller
 
-- Status: Accepted
+- Status: Accepted — amended: the payload follows the window out of the controller (2026-08-03)
 - Date: 2026-07-10
-- Relates to: epic architecture-hardening (child: Channel timeline window)
+- Relates to: epic architecture-hardening (child: Channel timeline window); epic architecture-hardening V ([#1195](https://github.com/deskhq/the-desk/issues/1195), child: [#1197](https://github.com/deskhq/the-desk/issues/1197))
+
+> **Status note (2026-08-03).** As accepted, this moved the *window* and said `show`
+> "shrinks to a thin action consistent with its siblings". The window did move. The
+> **payload did not**, and the consequence above was therefore never true: `show()`
+> stayed ~150 lines holding 19 of the ~40 query-builder calls in the whole controller
+> tree — the member count, the pin count, a raw `join('message_pins', ...)`, the
+> scheduled messages, the roster union and the read receipts, plus seven `Gate::allows`
+> flattened into `can*` props.
+>
+> The sharpest of them was not a query at all. `show()` wrote three synthetic
+> attributes — `muted`, `notification_level`, `draft` — onto the bound `Channel` so
+> `ChannelData::fromChannel()` could read them back off it. ADR-0011 gave that DTO an
+> explicit viewer precisely so it would stop depending on ambient state; handing it the
+> same state through a side channel is that defect wearing a different coat. The DTO now
+> takes `?ChannelMember $membership` and no caller writes to the model.
+>
+> Two smaller breaches rode along and are closed with it: a hand-written `with([...])`
+> the scheduled-message payload spelled for itself, which ADR-0002 says never to do (it
+> is now `ScheduledMessage::withScheduledMessageDataRelations()`); and `pins` /
+> `pinCount`, computed by two independent queries that had already diverged — the count
+> included a pin whose message was a tombstone and the panel did not — despite being
+> named in `lib/reloadProps` as a pair that must move together. They are one reading now,
+> so the badge counts what the panel holds by construction.
+>
+> **The decision below is unchanged and now finished.** It gains a second module rather
+> than a wider one: `App\Support\ChannelPage`, constructed from `(Channel, User, Team)`
+> and never a `Request`, holding the payload; `ChannelTimelineWindow` keeps the window.
+> The controller constructs both and holds both. The alternative — one read-model taking
+> the raw `?message=` / `?thread=` values and building the window internally — was
+> rejected: two collaborators in a controller is not friction, and a read-model that
+> knows about query strings is exactly what ADR-0008 keeps out.
+>
+> `ChannelPage`'s readings are stated directly in
+> `tests/Integration/Support/ChannelPageTest.php` (no HTTP round-trip, the bar ADR-0012
+> named), and its cost is pinned by `ChannelPageQueryCountTest` the way
+> `SidebarChannelsQueryCountTest` pins the sidebar's.
+>
+> Deliberately **out of scope**, so the next review does not read the omission as an
+> oversight: `ChannelPolicy`. `postMessage` omits the `belongsToTeam` clause its five
+> siblings spell, and `administers` / `create` each carry one that cannot change their
+> answer. All real, all authorization questions, and fixing them inside a payload
+> refactor would turn it into a security change. They belong with the `Api/V1` policy
+> restatements in a later sweep.
 
 ## Context
 

--- a/tests/Integration/Data/ChannelDataTest.php
+++ b/tests/Integration/Data/ChannelDataTest.php
@@ -2,8 +2,11 @@
 
 use App\Actions\Channels\OpenDirectMessage;
 use App\Data\ChannelData;
+use App\Enums\NotificationLevel;
 use App\Models\Channel;
+use App\Models\User;
 use App\Support\DirectMessageRoster;
+use Database\Factories\ChannelMemberFactory;
 use Illuminate\Support\Facades\DB;
 
 /*
@@ -85,6 +88,50 @@ test('a group direct message lists the other participants in name order', functi
         // The viewer never appears in their own participant list.
         ->and(collect($anaView->dmParticipants)->pluck('name')->all())->toBe(['Owner', 'Tomas K'])
         ->and($anaView->name)->toBe('Owner, Tomas K');
+});
+
+test('the viewer per-channel state is read off the membership it is handed', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+
+    $membership = channelMembership(
+        $general,
+        $owner,
+        fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory
+            ->muted()
+            ->starred()
+            ->draft('half a thought')
+            ->notificationLevel(NotificationLevel::Mentions),
+    );
+
+    $view = ChannelData::fromChannel($general, $owner, $membership);
+
+    expect($view->muted)->toBeTrue()
+        ->and($view->notificationLevel)->toBe(NotificationLevel::Mentions)
+        ->and($view->draft)->toBe('half a thought')
+        ->and($view->hasDraft)->toBeTrue()
+        ->and($view->starred)->toBeTrue();
+});
+
+test('a non-member viewing a public channel gets the defaults, not another member state', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+
+    channelMembership(
+        $general,
+        $owner,
+        fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->muted()->draft('mine alone'),
+    );
+
+    // Someone who reached the public channel by URL has no pivot row at all, so
+    // the DTO answers with its own defaults rather than with anybody else's.
+    $stranger = User::factory()->create();
+
+    $view = ChannelData::fromChannel($general, $stranger);
+
+    expect($view->muted)->toBeFalse()
+        ->and($view->notificationLevel)->toBe(NotificationLevel::All)
+        ->and($view->draft)->toBeNull()
+        ->and($view->hasDraft)->toBeFalse()
+        ->and($view->starred)->toBeFalse();
 });
 
 test('a batched roster costs the DTO no query of its own', function (): void {

--- a/tests/Integration/Data/ChannelDataTest.php
+++ b/tests/Integration/Data/ChannelDataTest.php
@@ -3,6 +3,7 @@
 use App\Actions\Channels\OpenDirectMessage;
 use App\Data\ChannelData;
 use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\User;
 use App\Support\DirectMessageRoster;
@@ -113,19 +114,26 @@ test('the viewer per-channel state is read off the membership it is handed', fun
 });
 
 test('a non-member viewing a public channel gets the defaults, not another member state', function (): void {
-    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    // A public channel nobody is auto-joined to, so the newcomer below can read
+    // it by URL without belonging to it.
+    $public = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+    $public->members()->attach($owner->id);
 
     channelMembership(
-        $general,
+        $public,
         $owner,
         fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->muted()->draft('mine alone'),
     );
 
-    // Someone who reached the public channel by URL has no pivot row at all, so
-    // the DTO answers with its own defaults rather than with anybody else's.
+    // On the team, so the channel is theirs to open — and with no pivot row on
+    // it, so the DTO answers with its own defaults rather than with anybody
+    // else's.
     $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
 
-    $view = ChannelData::fromChannel($general, $stranger);
+    $view = ChannelData::fromChannel($public, $stranger);
 
     expect($view->muted)->toBeFalse()
         ->and($view->notificationLevel)->toBe(NotificationLevel::All)

--- a/tests/Integration/Support/ChannelPageQueryCountTest.php
+++ b/tests/Integration/Support/ChannelPageQueryCountTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\MessagePin;
+use App\Models\ScheduledMessage;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\ChannelPage;
+use Database\Factories\ChannelMemberFactory;
+use Illuminate\Support\Facades\DB;
+
+/*
+|--------------------------------------------------------------------------
+| What the channel payload costs (#1197)
+|--------------------------------------------------------------------------
+|
+| Every reading on `ChannelPage` is a fixed number of queries by construction —
+| the pins, the roster, the receipts and the schedules each cost their own query
+| plus their eager loads, whatever they hold. Nothing enforces that but a test
+| that counts, so this is the channel page's equivalent of
+| `SidebarChannelsQueryCountTest` for the sidebar, and of `MessageLoadSetScopeTest`
+| for ADR-0002.
+|
+| The pin is a constant rather than a comparison against a baseline, so a
+| regression that adds a query to *both* sizes is caught as well as one that
+| scales with the page's contents.
+|
+*/
+
+/**
+ * Everything a channel render asks the database, with nothing on the page:
+ * the membership, the capability gates, the member count, the pins, the roster,
+ * the receipts, the schedules, and each reading's eager loads.
+ */
+const CHANNEL_PAGE_QUERY_BUDGET = 28;
+
+/**
+ * Draw every prop group the channel page ships and report the queries it took.
+ *
+ * @return array{queries: int, page: array<string, mixed>}
+ */
+function channelPageRender(Channel $channel, User $viewer, Team $team): array
+{
+    $page = new ChannelPage($channel, $viewer, $team);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $drawn = [
+        'channel' => $page->channel(),
+        'capabilities' => $page->capabilities(),
+        'isMember' => $page->isMember(),
+        'memberCount' => $page->memberCount(),
+        'pins' => $page->pins(),
+        'roster' => $page->roster(),
+        'readers' => $page->readers(),
+        'scheduledMessages' => $page->scheduledMessages(),
+    ];
+
+    $queries = count(DB::connection()->getQueryLog());
+
+    DB::connection()->disableQueryLog();
+
+    return ['queries' => $queries, 'page' => $drawn];
+}
+
+/**
+ * Put one more of everything the page lists onto the channel: a member, a
+ * pinned message, a read receipt and a pending schedule.
+ */
+function fillChannelPage(Channel $channel, User $author, int $times): void
+{
+    for ($i = 0; $i < $times; $i++) {
+        $member = teamMemberInChannel($channel);
+
+        $message = Message::factory()->for($channel)->for($author)->create();
+        MessagePin::factory()->for($message)->for($channel)->for($member, 'pinnedBy')->create();
+
+        channelMembership(
+            $channel,
+            $member,
+            fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->state(['last_read_message_id' => $message->id]),
+        );
+
+        ScheduledMessage::factory()->for($channel)->for($author)->create(['reply_to_id' => $message->id]);
+    }
+}
+
+it('renders the channel payload in a constant number of queries however much the page holds', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    fillChannelPage($general, $viewer, 2);
+
+    $small = channelPageRender($general, $viewer, $team);
+
+    fillChannelPage($general, $viewer, 4);
+
+    $large = channelPageRender($general, $viewer, $team);
+
+    expect($small['queries'])->toBe(CHANNEL_PAGE_QUERY_BUDGET)
+        ->and($large['queries'])->toBe(CHANNEL_PAGE_QUERY_BUDGET);
+
+    // Sanity-check the renders actually held something, so the counts above are
+    // not passing on a page that resolved to nothing.
+    expect($small['page']['pins']['pinCount'])->toBe(2)
+        ->and($large['page']['pins']['pinCount'])->toBe(6)
+        ->and($large['page']['readers'])->toHaveCount(6)
+        ->and($large['page']['scheduledMessages'])->toHaveCount(6)
+        ->and($large['page']['memberCount'])->toBe(7);
+});

--- a/tests/Integration/Support/ChannelPageQueryCountTest.php
+++ b/tests/Integration/Support/ChannelPageQueryCountTest.php
@@ -51,6 +51,7 @@ function channelPageRender(Channel $channel, User $viewer, Team $team): array
         'channel' => $page->channel(),
         'capabilities' => $page->capabilities(),
         'isMember' => $page->isMember(),
+        'lastReadMessageId' => $page->lastReadMessageId(),
         'memberCount' => $page->memberCount(),
         'pins' => $page->pins(),
         'roster' => $page->roster(),

--- a/tests/Integration/Support/ChannelPageTest.php
+++ b/tests/Integration/Support/ChannelPageTest.php
@@ -171,6 +171,42 @@ test('the pins and their count are one reading, most-recently-pinned first', fun
         ->and($pins['pinCount'])->toBe(count($pins['pins']));
 });
 
+test('two pins landing in the same second still list newest first', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $first = Message::factory()->for($general)->for($viewer)->create();
+    $second = Message::factory()->for($general)->for($viewer)->create();
+
+    // Same instant, so the timestamp cannot separate them and the tiebreak is
+    // the whole answer — it used to run the other way from the panel's order.
+    $pinnedAt = now();
+    MessagePin::factory()->for($first)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => $pinnedAt]);
+    MessagePin::factory()->for($second)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => $pinnedAt]);
+
+    expect(array_column(new ChannelPage($general, $viewer, $team)->pins()['pins'], 'id'))
+        ->toBe([$second->id, $first->id]);
+});
+
+test('a pin whose message has been deleted leaves the panel and the badge together', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $live = Message::factory()->for($general)->for($viewer)->create();
+    $deleted = Message::factory()->for($general)->for($viewer)->create();
+
+    MessagePin::factory()->for($live)->for($general)->for($viewer, 'pinnedBy')->create();
+    MessagePin::factory()->for($deleted)->for($general)->for($viewer, 'pinnedBy')->create();
+
+    // Deleting a message unpins it, so a surviving pin over a tombstone is only
+    // ever a race. It used to be counted by the badge and withheld from the
+    // panel, which is the disagreement one reading makes impossible.
+    $deleted->delete();
+
+    $pins = new ChannelPage($general, $viewer, $team)->pins();
+
+    expect($pins['pinCount'])->toBe(1)
+        ->and(array_column($pins['pins'], 'id'))->toBe([$live->id]);
+});
+
 test('a pinned message carries its attribution, so the panel renders it like the timeline', function (): void {
     ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
 

--- a/tests/Integration/Support/ChannelPageTest.php
+++ b/tests/Integration/Support/ChannelPageTest.php
@@ -1,0 +1,275 @@
+<?php
+
+use App\Actions\Channels\OpenDirectMessage;
+use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\MessagePin;
+use App\Models\ScheduledMessage;
+use App\Models\User;
+use App\Support\ChannelPage;
+use Database\Factories\ChannelMemberFactory;
+
+/*
+|--------------------------------------------------------------------------
+| The channel page read-model (#1197)
+|--------------------------------------------------------------------------
+|
+| ADR-0004 moved the channel timeline's *window* out of the controller and left
+| its *payload* behind: nineteen query-builder calls, seven `Gate::allows` and
+| three synthetic attributes written onto the bound `Channel` so the DTO could
+| read them. This is where that payload went, and it is constructed from a
+| channel, a viewer and a team — never a `Request` — so every reading below is
+| reachable without an HTTP round-trip, the bar `WorkspaceShell` set (ADR-0008)
+| and ADR-0012 named.
+|
+| `tests/Feature/Channels/*` keeps the HTTP half: that `channels/Show` ships
+| each of these as a prop. What the readings *hold* is stated here.
+|
+*/
+
+test('the page is constructible from a channel, a viewer and a team alone', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $page = new ChannelPage($general, $viewer, $team);
+
+    expect($page->channel()->slug)->toBe($general->slug)
+        ->and($page->isMember())->toBeTrue()
+        ->and($page->lastReadMessageId())->toBeNull()
+        ->and($page->memberCount())->toBe(1)
+        ->and($page->pins())->toBe(['pins' => [], 'pinCount' => 0])
+        ->and(array_column($page->roster(), 'id'))->toBe([$viewer->id])
+        ->and($page->readers())->toBe([])
+        ->and($page->scheduledMessages())->toBe([]);
+});
+
+test('the channel DTO carries the viewer own membership state without it being written onto the model', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    channelMembership(
+        $general,
+        $viewer,
+        fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory
+            ->muted()
+            ->draft('half a thought')
+            ->notificationLevel(NotificationLevel::Mentions),
+    );
+
+    $channel = Channel::query()->findOrFail($general->id);
+
+    expect(new ChannelPage($channel, $viewer, $team)->channel())
+        ->muted->toBeTrue()
+        ->notificationLevel->toBe(NotificationLevel::Mentions)
+        ->draft->toBe('half a thought')
+        // The row was read, not smuggled in: the model itself never learnt any
+        // of it, which is the whole point of handing the DTO its membership.
+        ->and($channel->getAttribute('muted'))->toBeNull()
+        ->and($channel->getAttribute('notification_level'))->toBeNull()
+        ->and($channel->getAttribute('draft'))->toBeNull();
+});
+
+test('a non-member reading a public channel is not a member and gets the DTO defaults', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    // A public channel the newcomer never joined — joining the team auto-joins
+    // #general, so that one would not answer the question.
+    $public = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+    $public->members()->attach($owner->id);
+
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    $page = new ChannelPage($public, $stranger, $team);
+
+    expect($page->isMember())->toBeFalse()
+        ->and($page->lastReadMessageId())->toBeNull()
+        ->and($page->channel())
+        ->muted->toBeFalse()
+        ->notificationLevel->toBe(NotificationLevel::All)
+        ->draft->toBeNull();
+});
+
+test('the read pointer is the viewer own, as a string the client can compare ids with', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $message = Message::factory()->for($general)->for($viewer)->create();
+
+    channelMembership(
+        $general,
+        $viewer,
+        fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->state(['last_read_message_id' => $message->id]),
+    );
+
+    expect(new ChannelPage($general, $viewer, $team)->lastReadMessageId())->toBe($message->id);
+});
+
+test('the capabilities are the seven gates the page draws its controls from', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $member = teamMemberInChannel($general);
+
+    // A standard channel the member belongs to, so the membership-gated controls
+    // separate from the ownership-gated ones on one arrange.
+    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+    $channel->members()->attach([$owner->id, $member->id]);
+
+    expect(new ChannelPage($channel, $owner, $team)->capabilities())->toBe([
+        'canArchive' => true,
+        'canManagePreferences' => true,
+        'canEditChannel' => true,
+        'canRenameChannel' => true,
+        'canDelete' => true,
+        'canLeave' => true,
+        'canReact' => true,
+    ]);
+
+    // #general is the protected channel: it cannot be archived, renamed, deleted
+    // or left, however senior the viewer is.
+    expect(new ChannelPage($general, $owner, $team)->capabilities())->toBe([
+        'canArchive' => false,
+        'canManagePreferences' => true,
+        'canEditChannel' => true,
+        'canRenameChannel' => true,
+        'canDelete' => false,
+        'canLeave' => false,
+        'canReact' => true,
+    ]);
+});
+
+test('the member count is the humans in the channel, never its bots', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    teamMemberInChannel($general);
+
+    // A bot is an integration identity, not a seat, so it is on the roster and
+    // out of the count.
+    $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
+    channelMembership($general, $bot);
+
+    $page = new ChannelPage($general, $viewer, $team);
+
+    expect($page->memberCount())->toBe(2)
+        ->and(array_column($page->roster(), 'name'))->toContain('Deploy Bot');
+});
+
+test('the pins and their count are one reading, most-recently-pinned first', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $older = Message::factory()->for($general)->for($viewer)->create();
+    $newer = Message::factory()->for($general)->for($viewer)->create();
+
+    MessagePin::factory()->for($older)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => now()->subMinute()]);
+    MessagePin::factory()->for($newer)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => now()]);
+
+    $pins = new ChannelPage($general, $viewer, $team)->pins();
+
+    expect($pins['pinCount'])->toBe(2)
+        ->and(array_column($pins['pins'], 'id'))->toBe([$newer->id, $older->id])
+        // The badge counts what the panel lists, by construction, so a pin the
+        // panel does not carry can never still be counted.
+        ->and($pins['pinCount'])->toBe(count($pins['pins']));
+});
+
+test('a pinned message carries its attribution, so the panel renders it like the timeline', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $pinner = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $message = Message::factory()->for($general)->for($viewer)->create(['body' => 'the pinned one']);
+    MessagePin::factory()->for($message)->for($general)->for($pinner, 'pinnedBy')->create();
+
+    $pins = new ChannelPage($general, $viewer, $team)->pins();
+
+    expect($pins['pins'][0]->body)->toBe('the pinned one')
+        ->and($pins['pins'][0]->pin?->pinnedBy->name)->toBe('Ada Lovelace');
+});
+
+test('the roster of a standard channel is the whole team plus the channel own bots', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $viewer->update(['name' => 'Marie Curie']);
+
+    // On the team but not in this channel: still mentionable, so still listed.
+    $elsewhere = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    $channel = Channel::factory()->for($team)->create(['created_by' => $viewer->id]);
+    $channel->members()->attach($viewer->id);
+
+    $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
+    channelMembership($channel, $bot);
+
+    // A bot that belongs to another channel is not this channel's to list.
+    $otherBot = User::factory()->bot($team)->create(['name' => 'Other Bot']);
+    channelMembership($general, $otherBot);
+
+    expect(array_column(new ChannelPage($channel, $viewer, $team)->roster(), 'name'))
+        ->toBe(['Ada Lovelace', 'Marie Curie', 'Deploy Bot'])
+        ->and($elsewhere->name)->toBe('Ada Lovelace');
+});
+
+test('the roster of a direct message is its own participants and nobody else', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $viewer->update(['name' => 'Marie Curie']);
+
+    $other = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    teamMemberInChannel($general, ['name' => 'Not In The Conversation']);
+
+    $dm = app(OpenDirectMessage::class)->handle($team, $viewer, $other);
+
+    expect(array_column(new ChannelPage($dm, $viewer, $team)->roster(), 'name'))
+        ->toBe(['Ada Lovelace', 'Marie Curie']);
+});
+
+test('the readers are the other members who share read receipts', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $message = Message::factory()->for($general)->for($viewer)->create();
+
+    $reader = teamMemberInChannel(
+        $general,
+        ['name' => 'Ada Lovelace'],
+        state: fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->state(['last_read_message_id' => $message->id]),
+    );
+
+    // Someone who opted out of read receipts is withheld entirely.
+    joinTeamAndChannel($general, User::factory()->withoutReadReceipts()->create(['name' => 'Private Pat']));
+
+    // And the viewer never reports their own position back to themselves.
+    channelMembership(
+        $general,
+        $viewer,
+        fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->state(['last_read_message_id' => $message->id]),
+    );
+
+    $readers = new ChannelPage($general, $viewer, $team)->readers();
+
+    expect($readers)->toHaveCount(1)
+        ->and($readers[0]->user->name)->toBe('Ada Lovelace')
+        ->and($readers[0]->lastReadMessageId)->toBe($message->id)
+        ->and($reader->name)->toBe('Ada Lovelace');
+});
+
+test('the scheduled messages are the viewer own pending ones, soonest first, quotes resolved', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $quoted = Message::factory()->for($general)->for($viewer)->create(['body' => 'the parent']);
+
+    $later = ScheduledMessage::factory()->for($general)->for($viewer)->create([
+        'body' => 'the later one',
+        'send_at' => now()->addHours(3),
+    ]);
+    $sooner = ScheduledMessage::factory()->for($general)->for($viewer)->create([
+        'body' => 'the sooner one',
+        'send_at' => now()->addHour(),
+        'reply_to_id' => $quoted->id,
+    ]);
+
+    // Somebody else's schedule, and one of the viewer's already sent: neither is
+    // the composer's to offer.
+    ScheduledMessage::factory()->for($general)->for(teamMemberInChannel($general))->create();
+    ScheduledMessage::factory()->for($general)->for($viewer)->sent()->create();
+
+    $scheduled = new ChannelPage($general, $viewer, $team)->scheduledMessages();
+
+    expect(array_column($scheduled, 'id'))->toBe([$sooner->id, $later->id])
+        ->and($scheduled[0]->replyTo?->body)->toBe('the parent')
+        ->and($scheduled[1]->replyTo)->toBeNull();
+});


### PR DESCRIPTION
Closes #1197. Part of #1195.

## What

ADR-0004 moved the timeline *window* out of `ChannelController::show` and said `show` "shrinks to a thin action consistent with its siblings". The window moved; the payload did not. `show()` held 19 of the ~40 query-builder calls in the whole controller tree, seven `Gate::allows`, and three synthetic attributes written onto the bound `Channel` so `ChannelData::fromChannel()` could read them back off it — the ambient state ADR-0011 gave that DTO a viewer parameter to remove, arriving through a side channel instead.

`App\Support\ChannelPage` is where the payload went. Constructed from `(Channel, User, Team)` — never a `Request`, no `auth()` — with one reading per prop group: the channel DTO, the membership facts (`isMember()`, `lastReadMessageId()`), the capabilities, the pins pair, the roster, the readers, the scheduled messages, the member count.

The controller constructs `ChannelTimelineWindow` and `ChannelPage` separately and holds both. Two collaborators in a controller is not friction; a read-model that knows about query strings is, which is why the window — the only one answering to `?message=` / `?thread=` — stays its own module. `show()` now holds no query builder, no `Gate::allows` and no `setAttribute`.

## Why it is not only tidiness

- **`pins` / `pinCount` had already diverged.** Two independent queries: the count was `$channel->pins()->count()`, the panel a raw `join('message_pins', ...)` through `Message::query()`, which withholds tombstones. A pin surviving over a soft-deleted message was counted by the badge and withheld from the panel. They are one reading now, so the badge counts what the panel holds by construction — and `lib/reloadProps` already named them as a pair that must move together.
- **`Channel::pins()` ordered its tiebreak the other way from the panel** (`created_at DESC, id ASC` against the panel's `created_at DESC, id DESC`). The relation is now the single home of that order, spelled the way the panel shipped it.
- **`ChannelData::fromChannel` takes `?ChannelMember $membership`.** A handed-over row answers for the whole membership, attributes for the whole of it, never half of each — so a null column on the row reads as "not set" rather than falling through to a stale attribute. The sidebar keeps passing none: its single query already selects every pivot column onto each channel.
- **The hand-written `with([...])` at the scheduled-message payload is gone.** `ScheduledMessage::withScheduledMessageDataRelations()` is ADR-0002's device applied to the smaller payload the composer's "Scheduled" list ships.

## Records

- **ADR-0004 amended, not superseded** — status is now `Accepted — amended: the payload follows the window out of the controller (2026-08-03)`, with a status note in the shape ADR-0003 and ADR-0005 use for their second passes. It records the rejected alternative (one read-model taking the raw query params) and the deliberate `ChannelPolicy` omission, so the next review does not read it as an oversight.
- **`CONTEXT.md`** gains a `ChannelPage` entry in the named-seams list, plus a clause on the ADR-0002 entry for the scheduled-message scope.

## Out of scope, per the epic

`ChannelPolicy`. `postMessage` omits the `belongsToTeam` clause its five siblings spell, and `administers` / `create` each carry one that cannot change their answer. All real, all authorization questions — fixing them inside a payload refactor turns it into a security change. They belong with the `Api/V1` policy restatements in a later sweep.

## How tested

- `tests/Integration/Support/ChannelPageTest.php` — 14 cases constructing `ChannelPage` directly and asserting each reading, with no HTTP round-trip: the bar `WorkspaceShell` set and ADR-0012 named. Includes a non-member on a public channel getting the DTO defaults, the pins tiebreak on two pins in the same second, and a pin over a tombstone leaving the panel and the badge together.
- `tests/Integration/Support/ChannelPageQueryCountTest.php` — pins one full render at a constant 28 queries across two page sizes, the way `SidebarChannelsQueryCountTest` pins the sidebar's and `MessageLoadSetScopeTest` pins ADR-0002's. A constant, not a comparison, so a regression adding a query to both sizes is caught too.
- `tests/Integration/Data/ChannelDataTest.php` — the explicit membership parameter, and the non-member defaults.
- Both gates green: `composer test` at `Total: 100.0 %`, and `lint:check` / `format:check` / `types:check` / `test:js` / `build`. The 737 existing channel feature tests are unchanged and passing.

No user-facing copy and no operator-facing setting changed, so no i18n keys and no `docs/` update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788382055&installation_model_id=428379&pr_number=1212&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1212&signature=ce4fa7d17094ce2bd6f62cd1db64bcaecb765f2459b5714cceb929863bc34897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->