### PR TITLE
refactor: project team permissions from the gate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -250,6 +250,19 @@ built; build them once, then reuse.
   and the rules are specified in `tests/Integration/Rules/` with no `route()` in sight. The
   other requests carrying domain logic are #1150's remaining work, taken as their surfaces
   are touched.
+- **A permissions DTO projects from the gate; it never re-states it.**
+  `TeamPermissions` is fifteen booleans the settings page draws itself from, and every one
+  of them is `Gate::allows(...)` on the ability that already decides it — never the rule
+  spelled a second time. Before #1198 it was the second spelling, and `canDeleteTeam` had
+  drifted: `TeamPolicy::delete()` refuses a personal workspace, the copy did not, and
+  `teams/Edit.vue` was quietly patching the difference back out with `&& !team.isPersonal`.
+  A client that has to correct the server is the symptom to watch for. The role is resolved
+  once per projection and released again, so fifteen abilities cost one lookup and a role
+  written between two projections is still read fresh;
+  `tests/Integration/Data/TeamPermissionsTest.php` pins every field to its gate and fails
+  when a new field arrives with no ability behind it. A permission with no gate to project
+  from is a missing ability (`TeamPolicy::manageEmojis()` was one), not a licence to
+  hand-write the clause.
 
 ### Frontend (`resources/js/`)
 
@@ -424,6 +437,9 @@ built; build them once, then reuse.
   somebody already holds, call the gate rather than restating it as a `Rule::exists` chain,
   and if the question is *may this actor do this at all*, it is a policy ability and not a
   rule.
+- A new flag on a permissions DTO → the ability it projects from, asked through the gate.
+  If no ability answers it yet, add the ability; never write the rule out a second time,
+  and never let the page patch the answer it was sent.
 - A new nested resource under `settings/teams/{team}/…` → name its route parameter after
   the relationship that owns it (`{customEmoji}` → `Team::customEmojis()`), and let the
   group's `->scopeBindings()` do the tenancy. A hand-rolled `belongs to this team` check

--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -8,16 +8,32 @@ use App\Enums\TeamPermission;
 use App\Enums\TeamRole;
 use App\Models\Membership;
 use App\Models\Team;
+use App\Models\UserGroup;
+use App\Policies\TeamPolicy;
 use App\Support\WorkspaceUnread;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
 
 trait HasTeams
 {
+    /**
+     * The role this user holds on a team, memoised for the length of a single
+     * {@see toTeamPermissions()} projection and no longer.
+     *
+     * The projection asks the gate about one membership fifteen times over, and
+     * each ability would otherwise resolve the row again. It is deliberately
+     * not kept for the request: a role rewritten between two projections must
+     * be answered from the database, not from a copy taken before the write.
+     *
+     * @var array<string, TeamRole|null>
+     */
+    private array $projectedTeamRoles = [];
+
     /**
      * Get all of the teams the user belongs to.
      *
@@ -123,6 +139,10 @@ trait HasTeams
      */
     public function teamRole(Team $team): ?TeamRole
     {
+        if (array_key_exists($team->id, $this->projectedTeamRoles)) {
+            return $this->projectedTeamRoles[$team->id];
+        }
+
         return $this->teamMemberships()
             ->where('team_id', $team->id)
             ->first()
@@ -173,30 +193,43 @@ trait HasTeams
 
     /**
      * Get the standard permissions for a team as a TeamPermissions object.
+     *
+     * Every field is projected from the ability that already decides it, so the
+     * page draws exactly what the server would let through. Re-stating those
+     * rules here is what let `canDeleteTeam` say yes on a personal workspace
+     * that {@see TeamPolicy::delete()} refuses; `TeamPermissionsTest` pins the
+     * two together field by field.
      */
     public function toTeamPermissions(Team $team): TeamPermissions
     {
-        $role = $this->teamRole($team);
+        $gate = Gate::forUser($this);
 
-        return new TeamPermissions(
-            canUpdateTeam: $role?->hasPermission(TeamPermission::UpdateTeam) ?? false,
-            canDeleteTeam: $role?->hasPermission(TeamPermission::DeleteTeam) ?? false,
-            canAddMember: $role?->hasPermission(TeamPermission::AddMember) ?? false,
-            canUpdateMember: $role?->hasPermission(TeamPermission::UpdateMember) ?? false,
-            canRemoveMember: $role?->hasPermission(TeamPermission::RemoveMember) ?? false,
-            canCreateInvitation: $role?->hasPermission(TeamPermission::CreateInvitation) ?? false,
-            canCancelInvitation: $role?->hasPermission(TeamPermission::CancelInvitation) ?? false,
-            canTransferOwnership: ! $team->is_personal && $role === TeamRole::Owner,
-            canViewAudit: ! $team->is_personal && ($role?->isAtLeast(TeamRole::Admin) ?? false),
-            canViewSecurityLog: ! $team->is_personal && ($role?->isAtLeast(TeamRole::Admin) ?? false),
-            canViewAnalytics: ! $team->is_personal && ($role?->isAtLeast(TeamRole::Admin) ?? false),
-            // Not withheld from a personal workspace: its owner can delete a
-            // channel there, so they need the panel that undoes it.
-            canViewDeletedChannels: $role?->isAtLeast(TeamRole::Admin) ?? false,
-            canManageEmojis: ! $team->is_personal && ($role?->isAtLeast(TeamRole::Admin) ?? false),
-            canManageIntegrations: ! $team->is_personal && ($role?->hasPermission(TeamPermission::ManageIntegrations) ?? false),
-            canManageUserGroups: ! $team->is_personal && ($role?->hasPermission(TeamPermission::ManageUserGroups) ?? false),
-        );
+        // One lookup answers all fifteen abilities below, which each resolve the
+        // same membership. Released again straight after, so the next caller
+        // sees any role written in between.
+        $this->projectedTeamRoles[$team->id] = $this->teamRole($team);
+
+        try {
+            return new TeamPermissions(
+                canUpdateTeam: $gate->allows('update', $team),
+                canDeleteTeam: $gate->allows('delete', $team),
+                canAddMember: $gate->allows('addMember', $team),
+                canUpdateMember: $gate->allows('updateMember', $team),
+                canRemoveMember: $gate->allows('removeMember', $team),
+                canCreateInvitation: $gate->allows('inviteMember', $team),
+                canCancelInvitation: $gate->allows('cancelInvitation', $team),
+                canTransferOwnership: $gate->allows('transferOwnership', $team),
+                canViewAudit: $gate->allows('viewAudit', $team),
+                canViewSecurityLog: $gate->allows('viewSecurityLog', $team),
+                canViewAnalytics: $gate->allows('viewAnalytics', $team),
+                canViewDeletedChannels: $gate->allows('viewDeletedChannels', $team),
+                canManageEmojis: $gate->allows('manageEmojis', $team),
+                canManageIntegrations: $gate->allows('manageIntegrations', $team),
+                canManageUserGroups: $gate->allows('viewAny', [UserGroup::class, $team]),
+            );
+        } finally {
+            unset($this->projectedTeamRoles[$team->id]);
+        }
     }
 
     public function fallbackTeam(?Team $excluding = null): ?Team

--- a/app/Policies/CustomEmojiPolicy.php
+++ b/app/Policies/CustomEmojiPolicy.php
@@ -2,10 +2,10 @@
 
 namespace App\Policies;
 
-use App\Enums\TeamRole;
 use App\Models\CustomEmoji;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Facades\Gate;
 
 class CustomEmojiPolicy
 {
@@ -22,9 +22,10 @@ class CustomEmojiPolicy
     /**
      * Determine whether the user can remove a custom emoji.
      *
-     * A member may delete their own upload; an admin (or owner) of a real
-     * workspace may revoke anyone's. The single ability backs both the
-     * self-service "Delete" and the admin "Revoke" affordances.
+     * A member may delete their own upload; whoever curates the registry
+     * ({@see TeamPolicy::manageEmojis()}) may revoke anyone's. The single
+     * ability backs both the self-service "Delete" and the admin "Revoke"
+     * affordances.
      */
     public function delete(User $user, CustomEmoji $emoji): bool
     {
@@ -32,9 +33,6 @@ class CustomEmojiPolicy
             return true;
         }
 
-        $team = $emoji->team;
-
-        return ! $team->is_personal
-            && ($user->teamRole($team)?->isAtLeast(TeamRole::Admin) ?? false);
+        return Gate::forUser($user)->allows('manageEmojis', $emoji->team);
     }
 }

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -162,6 +162,20 @@ class TeamPolicy
     }
 
     /**
+     * Determine whether the user can curate the team's custom emoji registry.
+     *
+     * Any member may add an emoji and remove their own ({@see
+     * CustomEmojiPolicy}); revoking someone else's is the moderation half, and
+     * it is scoped to admins and the owner of a real (non-personal) workspace —
+     * a one-person workspace has nobody else's upload to revoke.
+     */
+    public function manageEmojis(User $user, Team $team): bool
+    {
+        return ! $team->is_personal
+            && ($user->teamRole($team)?->isAtLeast(TeamRole::Admin) ?? false);
+    }
+
+    /**
      * Determine whether the user can manage the team's integrations.
      *
      * The integrations surface mints bot credentials and webhook secrets, so it

--- a/resources/js/pages/teams/Edit.invitations.test.ts
+++ b/resources/js/pages/teams/Edit.invitations.test.ts
@@ -337,11 +337,29 @@ describe('the danger zone', () => {
         expect(stub(host, 'DeleteTeamModal')).toBeNull();
     });
 
+    // A personal workspace cannot be deleted, and the server is what says so:
+    // its owner arrives with `canDeleteTeam: false` (#1198).
     it('withholds it on a personal team', () => {
-        const host = mount({ team: team({ isPersonal: true }) });
+        const host = mount({
+            team: team({ isPersonal: true }),
+            permissions: teamPermissions({ canDeleteTeam: false }),
+        });
 
         expect(find(host, 'delete-team-button')).toBeNull();
         expect(stub(host, 'DeleteTeamModal')).toBeNull();
+    });
+
+    // The permission alone decides. The page used to re-check `isPersonal` on
+    // top of it, which is what let the server's own copy of the rule drift
+    // unnoticed: re-adding that patch fails here.
+    it('takes the permission at its word rather than re-deciding it', () => {
+        const host = mount({
+            team: team({ isPersonal: true }),
+            permissions: teamPermissions({ canDeleteTeam: true }),
+        });
+
+        expect(find(host, 'delete-team-button')).not.toBeNull();
+        expect(stub(host, 'DeleteTeamModal')).not.toBeNull();
     });
 
     it('opens the deletion dialog from the button', async () => {

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -150,7 +150,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
         <AdminLinks :team="team" :permissions="permissions" />
 
         <DangerZone
-            v-if="permissions.canDeleteTeam && !team.isPersonal"
+            v-if="permissions.canDeleteTeam"
             @delete="deleteDialogOpen = true"
         />
     </div>
@@ -185,7 +185,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
     />
 
     <DeleteTeamModal
-        v-if="permissions.canDeleteTeam && !team.isPersonal"
+        v-if="permissions.canDeleteTeam"
         :team="team"
         :open="deleteDialogOpen"
         @update:open="deleteDialogOpen = $event"

--- a/tests/Integration/Data/TeamPermissionsTest.php
+++ b/tests/Integration/Data/TeamPermissionsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Data\TeamPermissions;
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\UserGroup;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+
+/*
+|--------------------------------------------------------------------------
+| The permissions DTO projects from the gate (#1198)
+|--------------------------------------------------------------------------
+|
+| Every field of `TeamPermissions` is an ability the policies already hold, so
+| the projection asks them rather than re-stating them. It used to re-state
+| them, and `canDeleteTeam` drifted: `TeamPolicy::delete()` refuses a personal
+| workspace, the copy did not, and `teams/Edit.vue` patched the difference back
+| out in the template.
+|
+| This file is what keeps the projection honest. The map below names the ability
+| behind each field; the first test proves it covers the DTO exhaustively, so a
+| new permission with no gate behind it fails here rather than shipping as a
+| sixteenth hand-written clause.
+|
+*/
+
+/**
+ * The ability behind each field of {@see TeamPermissions}.
+ *
+ * @return array<string, Closure(User, Team): bool>
+ */
+function teamPermissionGates(): array
+{
+    return [
+        'canUpdateTeam' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('update', $team),
+        'canDeleteTeam' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('delete', $team),
+        'canAddMember' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('addMember', $team),
+        'canUpdateMember' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('updateMember', $team),
+        'canRemoveMember' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('removeMember', $team),
+        'canCreateInvitation' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('inviteMember', $team),
+        'canCancelInvitation' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('cancelInvitation', $team),
+        'canTransferOwnership' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('transferOwnership', $team),
+        'canViewAudit' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('viewAudit', $team),
+        'canViewSecurityLog' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('viewSecurityLog', $team),
+        'canViewAnalytics' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('viewAnalytics', $team),
+        'canViewDeletedChannels' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('viewDeletedChannels', $team),
+        'canManageEmojis' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('manageEmojis', $team),
+        'canManageIntegrations' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('manageIntegrations', $team),
+        'canManageUserGroups' => fn (User $user, Team $team): bool => Gate::forUser($user)->allows('viewAny', [UserGroup::class, $team]),
+    ];
+}
+
+/**
+ * A workspace of the given kind with the user holding the given role on it, or
+ * holding none at all when the role is null.
+ */
+function workspaceFor(User $user, ?TeamRole $role, bool $isPersonal): Team
+{
+    $team = ($isPersonal ? Team::factory()->personal() : Team::factory())->create();
+
+    if ($role instanceof TeamRole) {
+        $team->members()->attach($user, ['role' => $role->value]);
+    }
+
+    return $team;
+}
+
+test('every field of the permissions DTO names an ability', function (): void {
+    $fields = array_map(
+        fn (ReflectionParameter $parameter): string => $parameter->getName(),
+        (new ReflectionClass(TeamPermissions::class))->getConstructor()?->getParameters() ?? [],
+    );
+
+    expect(array_keys(teamPermissionGates()))->toEqualCanonicalizing($fields);
+});
+
+test('every field of the permissions DTO answers what its gate answers', function (?TeamRole $role, bool $isPersonal): void {
+    $user = User::factory()->create();
+    $team = workspaceFor($user, $role, $isPersonal);
+
+    $permissions = $user->toTeamPermissions($team);
+
+    $projected = [];
+    $granted = [];
+
+    foreach (teamPermissionGates() as $field => $gate) {
+        $projected[$field] = $permissions->{$field};
+        $granted[$field] = $gate($user, $team);
+    }
+
+    expect($projected)->toBe($granted);
+})->with([
+    'the owner of a real workspace' => [TeamRole::Owner, false],
+    'an admin of a real workspace' => [TeamRole::Admin, false],
+    'a member of a real workspace' => [TeamRole::Member, false],
+    'the owner of a personal workspace' => [TeamRole::Owner, true],
+    'an admin of a personal workspace' => [TeamRole::Admin, true],
+    'a member of a personal workspace' => [TeamRole::Member, true],
+    'someone who does not belong to the workspace' => [null, false],
+]);
+
+test('the owner of a personal workspace may not delete it', function (): void {
+    $user = User::factory()->create();
+    $personal = $user->personalTeam();
+
+    expect($user->toTeamPermissions($personal)->canDeleteTeam)->toBeFalse()
+        ->and(Gate::forUser($user)->allows('delete', $personal))->toBeFalse();
+});
+
+test('the projection resolves the role once, not once per ability', function (): void {
+    $user = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($user, ['role' => TeamRole::Admin->value]);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $user->toTeamPermissions($team);
+
+    $queries = DB::connection()->getQueryLog();
+    DB::connection()->disableQueryLog();
+
+    expect($queries)->toHaveCount(1);
+});
+
+test('a role written after a projection is answered fresh', function (): void {
+    $user = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($user, ['role' => TeamRole::Member->value]);
+
+    expect($user->toTeamPermissions($team)->canUpdateTeam)->toBeFalse();
+
+    $team->members()->updateExistingPivot($user->id, ['role' => TeamRole::Admin->value]);
+
+    expect($user->toTeamPermissions($team)->canUpdateTeam)->toBeTrue();
+});


### PR DESCRIPTION
Closes #1198.

## What

`TeamPermissions` re-stated thirteen abilities `TeamPolicy` / `UserGroupPolicy` already held, and one of the copies had drifted: `TeamPolicy::delete()` refuses a personal workspace, the copy did not, so a personal workspace's owner arrived with `canDeleteTeam: true` from a gate that would have refused them. `teams/Edit.vue` was patching the difference back out with `&& !team.isPersonal`, twice — the rule was spelled three times, in two languages, and the middle spelling was the wrong one.

Every field of `TeamPermissions` is now projected from the ability that decides it, so `canDeleteTeam === Gate::allows('delete', $team)` by construction.

## How

- `HasTeams::toTeamPermissions()` asks the gate for all fifteen fields instead of re-deriving them from the role.
- **`TeamPolicy::manageEmojis()` is new.** `canManageEmojis` was the one field with no ability behind it; `CustomEmojiPolicy::delete()` now delegates its "revoke anyone else's" half to it rather than spelling the same clause a second time.
- **Not N+1.** The role is resolved once per projection and released again in a `finally`, so fifteen abilities cost one lookup — and a role written between two projections is still read fresh rather than answered from a stale copy.
- **Both client patches go away** (`Edit.vue:153`, `:188`): the page draws `permissions.canDeleteTeam` and nothing else.
- The three non-drifted judgement calls are untouched, per the issue: `canViewDeletedChannels` still deliberately omits the personal-workspace guard, and `HandleInertiaRequests`' null-guards are out of scope.

## Testing

New `tests/Integration/Data/TeamPermissionsTest.php`:

- a field → ability map, plus a reflection test proving it covers the DTO exhaustively — a new permission with no gate behind it fails there rather than shipping as a sixteenth hand-written clause;
- every field agrees with its gate for owner / admin / member on both a personal and a real workspace, and for a non-member;
- a personal workspace's owner gets `canDeleteTeam: false`, asserted against both the DTO and the gate;
- the projection costs exactly one query;
- a role written after a projection is answered fresh.

`Edit.invitations.test.ts` keeps the personal-workspace case (now driven by the permission the server actually sends) and gains one that fails if the `!team.isPersonal` patch is ever re-added.

Both gates green: `composer test` at `Total: 100.0 %`, and lint / format / types / 2642 Vitest tests / build.

## Docs & i18n

`CONTEXT.md` gains the seam entry and a quick-reference line — a permissions DTO projects from the gate, it never re-states it; a flag with no ability behind it is a missing ability. No ADR, per the issue. No user-facing copy changed, so no new translation keys; nothing operator-facing, so no `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788384617&installation_model_id=428379&pr_number=1214&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1214&signature=5c643cb2c9abb2a73af353a2bb38c45449ca46f149f1e21eb5f9126d20de78ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->