### PR TITLE
refactor: give the paged admin log one home per concern

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -121,6 +121,23 @@ built; build them once, then reuse.
   new call site is a sign the event seam was skipped. Neither depends on the live
   `Request` — `RecordSecurityEvents` captures the device context and passes it in,
   which is what lets a queued job record.
+- **Paged admin log read-models** — the read half of that pair. `AuditLog` and
+  `SecurityLog` are **two** read-models sharing **three** modules, not one
+  parameterised log: each takes `(Team, ...$filters)` and never a `Request`, and
+  each owns the one thing that genuinely differs — its scope and its filter
+  column. What they share is `SimplePage` (the page size, the newest-first
+  `simplePaginate` walk and the `{data, prevPageUrl, nextPageUrl}` envelope, whose
+  client half is `SimplePage<T>` in `resources/js/types/pagination.ts`) and
+  `LogActors` (the actor-filter facet, derived from the log's own scope so it only
+  ever offers a name with rows behind it). Staying two is what gives
+  `SecurityLog::ofCurrentMembers()` a home: a security event is recorded against an
+  *account*, so a workspace's log is a **live** join to that team's current
+  membership — removing a member drops their events from it at once, and that rule
+  is asserted directly rather than through a rendered page. Both controllers hold
+  HTTP glue only; `tests/Unit/PagedAdminLogHomeTest.php` fails if a third log
+  re-spells the walk, the envelope or the facet. Cursor-paged surfaces
+  (`MessagePage`, `ThreadInboxPage`) are a different envelope for a different
+  pagination mode and are deliberately not retrofitted onto `SimplePage`.
 - **`ExportLifecycle`** — the one lifecycle every asynchronous file export runs:
   resolve-or-bail, write, mark ready, send the ready notice, and fail cleanly.
   `GenerateAuditExport` and `ExportUserData` are adapters over it, supplying only

--- a/app/Http/Controllers/Teams/AuditController.php
+++ b/app/Http/Controllers/Teams/AuditController.php
@@ -2,39 +2,27 @@
 
 namespace App\Http\Controllers\Teams;
 
-use App\Data\AuditEventData;
 use App\Enums\AuditAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\ViewAuditLogRequest;
-use App\Models\AuditActivity;
 use App\Models\Team;
-use App\Models\User;
+use App\Support\AuditLog;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class AuditController extends Controller
 {
     /**
-     * The number of audit entries shown per page.
-     */
-    private const int PER_PAGE = 30;
-
-    /**
      * Show the workspace's audit log, newest first, filterable by action and actor.
      */
     public function index(ViewAuditLogRequest $request, Team $team): Response
     {
+        /** @var string|null $action */
         $action = $request->validated('action');
-        $actorId = $request->validated('actor');
+        /** @var string|null $actor */
+        $actor = $request->validated('actor');
 
-        $entries = AuditActivity::query()
-            ->where('team_id', $team->id)
-            ->when($action, fn ($query) => $query->where('event', $action))
-            ->when($actorId, fn ($query) => $query->where('causer_id', $actorId))
-            ->with('causer')->latest()
-            ->orderByDesc('id')
-            ->simplePaginate(self::PER_PAGE)
-            ->withQueryString();
+        $log = new AuditLog($team, $action, $actor);
 
         return Inertia::render('teams/Audit', [
             'team' => [
@@ -42,41 +30,13 @@ class AuditController extends Controller
                 'name' => $team->name,
                 'slug' => $team->slug,
             ],
-            'entries' => [
-                'data' => collect($entries->items())
-                    ->map(fn (AuditActivity $entry): AuditEventData => AuditEventData::fromActivity($entry))
-                    ->all(),
-                'prevPageUrl' => $entries->previousPageUrl(),
-                'nextPageUrl' => $entries->nextPageUrl(),
-            ],
+            'entries' => $log->entries(),
             'filters' => [
                 'action' => $action,
-                'actor' => $actorId,
+                'actor' => $actor,
             ],
             'actionOptions' => AuditAction::options(),
-            'actors' => $this->actors($team),
+            'actors' => $log->actors(),
         ]);
-    }
-
-    /**
-     * List the distinct actors who appear in the team's audit log, for the
-     * actor filter dropdown.
-     *
-     * @return array<int, array{id: string, name: string}>
-     */
-    private function actors(Team $team): array
-    {
-        $actorIds = AuditActivity::query()
-            ->where('team_id', $team->id)
-            ->whereNotNull('causer_id')
-            ->distinct()
-            ->pluck('causer_id');
-
-        return User::query()
-            ->whereIn('id', $actorIds)
-            ->orderBy('name')
-            ->get(['id', 'name'])
-            ->map(fn (User $user): array => ['id' => $user->id, 'name' => $user->name])
-            ->all();
     }
 }

--- a/app/Http/Controllers/Teams/SecurityLogController.php
+++ b/app/Http/Controllers/Teams/SecurityLogController.php
@@ -2,46 +2,28 @@
 
 namespace App\Http\Controllers\Teams;
 
-use App\Data\TeamSecurityEventData;
 use App\Enums\SecurityEventType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\ViewSecurityLogRequest;
-use App\Models\SecurityEvent;
 use App\Models\Team;
-use App\Models\User;
-use Illuminate\Contracts\Database\Query\Builder;
+use App\Support\SecurityLog;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class SecurityLogController extends Controller
 {
     /**
-     * The number of security events shown per page.
-     */
-    private const int PER_PAGE = 30;
-
-    /**
      * Show the workspace's security log, newest first, filterable by type and
      * actor.
-     *
-     * Events are account-level and carry no team scope, so the log is a live
-     * join to the team's current membership: an event surfaces only while its
-     * user is a member. Removing a member immediately drops their events here.
      */
     public function index(ViewSecurityLogRequest $request, Team $team): Response
     {
+        /** @var string|null $type */
         $type = $request->validated('type');
-        $actorId = $request->validated('actor');
+        /** @var string|null $actor */
+        $actor = $request->validated('actor');
 
-        $events = SecurityEvent::query()
-            ->whereIn('user_id', $this->memberIds($team))
-            ->when($type, fn ($query) => $query->where('type', $type))
-            ->when($actorId, fn ($query) => $query->where('user_id', $actorId))
-            ->with('user')
-            ->latest()
-            ->orderByDesc('id')
-            ->simplePaginate(self::PER_PAGE)
-            ->withQueryString();
+        $log = new SecurityLog($team, $type, $actor);
 
         return Inertia::render('teams/SecurityLog', [
             'team' => [
@@ -49,49 +31,13 @@ class SecurityLogController extends Controller
                 'name' => $team->name,
                 'slug' => $team->slug,
             ],
-            'events' => [
-                'data' => collect($events->items())
-                    ->map(fn (SecurityEvent $event): TeamSecurityEventData => TeamSecurityEventData::fromEvent($event))
-                    ->all(),
-                'prevPageUrl' => $events->previousPageUrl(),
-                'nextPageUrl' => $events->nextPageUrl(),
-            ],
+            'events' => $log->events(),
             'filters' => [
                 'type' => $type,
-                'actor' => $actorId,
+                'actor' => $actor,
             ],
             'typeOptions' => SecurityEventType::options(),
-            'actors' => $this->actors($team),
+            'actors' => $log->actors(),
         ]);
-    }
-
-    /**
-     * A subquery selecting the ids of the team's current members, used to scope
-     * the account-level events to the workspace via a live membership join.
-     */
-    private function memberIds(Team $team): Builder
-    {
-        return $team->members()->getQuery()->select('users.id');
-    }
-
-    /**
-     * List the current members who appear in the team's security log, for the
-     * actor filter dropdown.
-     *
-     * @return array<int, array{id: string, name: string}>
-     */
-    private function actors(Team $team): array
-    {
-        $actorIds = SecurityEvent::query()
-            ->whereIn('user_id', $this->memberIds($team))
-            ->distinct()
-            ->pluck('user_id');
-
-        return User::query()
-            ->whereIn('id', $actorIds)
-            ->orderBy('name')
-            ->get(['id', 'name'])
-            ->map(fn (User $user): array => ['id' => $user->id, 'name' => $user->name])
-            ->all();
     }
 }

--- a/app/Support/AuditLog.php
+++ b/app/Support/AuditLog.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\AuditEventData;
+use App\Models\AuditActivity;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * The read model behind a workspace's audit log: what an admin did in this team,
+ * newest first, narrowed by action and by actor.
+ *
+ * Constructed from a team and its two filters, never a `Request`, so both
+ * readings are reachable without an HTTP round-trip (ADR-0012). The controller
+ * keeps the HTTP glue: it validates the filters and names the props.
+ *
+ * It is a sibling of {@see SecurityLog}, not a copy of it. The two share the
+ * envelope ({@see SimplePage}) and the actor facet ({@see LogActors}) but keep
+ * their own scope, because that is where they genuinely differ: an audit entry
+ * carries the team it was recorded against, while a security event is
+ * account-level and has to be joined to the membership.
+ */
+final readonly class AuditLog
+{
+    public function __construct(
+        private Team $team,
+        private ?string $action = null,
+        private ?string $actor = null,
+    ) {}
+
+    /**
+     * One page of the team's audit entries, newest first, as the log renders
+     * them.
+     */
+    public function entries(): SimplePage
+    {
+        $entries = $this->recorded()
+            ->when($this->action, fn (Builder $query): Builder => $query->where('event', $this->action))
+            ->when($this->actor, fn (Builder $query): Builder => $query->where('causer_id', $this->actor))
+            ->with('causer');
+
+        return SimplePage::newestFirst($entries, AuditEventData::fromActivity(...));
+    }
+
+    /**
+     * The distinct people who appear in this log, for the actor filter.
+     *
+     * Entries with no human causer — a scheduled sweep disabling a webhook, say —
+     * are excluded, since there is nobody to offer as a choice.
+     *
+     * @return array<int, array{id: string, name: string}>
+     */
+    public function actors(): array
+    {
+        return new LogActors($this->recorded()->whereNotNull('causer_id'), 'causer_id')->all();
+    }
+
+    /**
+     * Everything recorded against this team.
+     *
+     * An audit entry is written with the team it belongs to, so the scope is the
+     * column — no join, and no rule about who may still be a member: the log is
+     * a record of what happened here, and it does not change when someone leaves.
+     *
+     * @return Builder<AuditActivity>
+     */
+    private function recorded(): Builder
+    {
+        return AuditActivity::query()->where('team_id', $this->team->id);
+    }
+}

--- a/app/Support/LogActors.php
+++ b/app/Support/LogActors.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * The people who appear in an admin log, as the log's actor filter offers them.
+ *
+ * One facet shared by {@see AuditLog} and {@see SecurityLog}, because it is the
+ * same question asked of two different logs: which users does this log actually
+ * name, and what are they called. Both used to spell it out — the same distinct
+ * pluck, the same `whereIn` by name, the same `{id, name}` map (#1199).
+ *
+ * It is derived from the log's own scoped query rather than from the team's
+ * roster, so the filter only ever offers a name that has something behind it: a
+ * member with no entries is not a choice, and neither is one whose rows the log
+ * withholds.
+ *
+ * @template TModel of Model
+ */
+final readonly class LogActors
+{
+    /**
+     * @param  Builder<TModel>  $log  the log's scoped query, before its filters
+     * @param  string  $actorColumn  the column naming the acting user
+     */
+    public function __construct(
+        private Builder $log,
+        private string $actorColumn,
+    ) {}
+
+    /**
+     * The named actors, alphabetically, for the filter dropdown.
+     *
+     * @return array<int, array{id: string, name: string}>
+     */
+    public function all(): array
+    {
+        $actorIds = $this->log->distinct()->pluck($this->actorColumn);
+
+        return User::query()
+            ->whereIn('id', $actorIds)
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (User $user): array => ['id' => $user->id, 'name' => $user->name])
+            ->all();
+    }
+}

--- a/app/Support/SecurityLog.php
+++ b/app/Support/SecurityLog.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\TeamSecurityEventData;
+use App\Models\SecurityEvent;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * The read model behind a workspace's security log: what the team's members did
+ * with their accounts — signed in, changed a password, added a passkey — newest
+ * first, narrowed by type and by actor.
+ *
+ * Constructed from a team and its two filters, never a `Request`, so both
+ * readings are reachable without an HTTP round-trip (ADR-0012). The controller
+ * keeps the HTTP glue: it validates the filters and names the props.
+ *
+ * It is a sibling of {@see AuditLog}, sharing the envelope ({@see SimplePage})
+ * and the actor facet ({@see LogActors}). What it does not share is its scope,
+ * and that is the whole reason the two are separate read-models rather than one
+ * parameterised log: {@see SecurityLog::ofCurrentMembers()} is a domain rule with
+ * consequences, and folding it into a generic log would leave it homeless.
+ */
+final readonly class SecurityLog
+{
+    public function __construct(
+        private Team $team,
+        private ?string $type = null,
+        private ?string $actor = null,
+    ) {}
+
+    /**
+     * One page of the team's security events, newest first, as the log renders
+     * them.
+     */
+    public function events(): SimplePage
+    {
+        $events = $this->ofCurrentMembers()
+            ->when($this->type, fn (Builder $query): Builder => $query->where('type', $this->type))
+            ->when($this->actor, fn (Builder $query): Builder => $query->where('user_id', $this->actor))
+            ->with('user');
+
+        return SimplePage::newestFirst($events, TeamSecurityEventData::fromEvent(...));
+    }
+
+    /**
+     * The members who appear in this log, for the actor filter.
+     *
+     * @return array<int, array{id: string, name: string}>
+     */
+    public function actors(): array
+    {
+        return new LogActors($this->ofCurrentMembers(), 'user_id')->all();
+    }
+
+    /**
+     * **The membership rule.** A security event is recorded against an account,
+     * not a workspace — one login is one row however many teams the person
+     * belongs to — so a workspace's view of it is a *live* join to that team's
+     * current membership, evaluated on every read.
+     *
+     * The consequence is deliberate and is what the rule is for: removing
+     * someone from the team drops their events from this log immediately, and
+     * re-adding them brings the history back intact. An admin's window onto a
+     * teammate's account activity lasts exactly as long as the teammate is their
+     * teammate, and no copy of it is left behind here when they leave.
+     *
+     * It is also what {@see TeamSecurityEventData}'s non-nullable `actorName`
+     * rests on: the join guarantees the user exists.
+     *
+     * @return Builder<SecurityEvent>
+     */
+    private function ofCurrentMembers(): Builder
+    {
+        return SecurityEvent::query()
+            ->whereIn('user_id', $this->team->members()->getQuery()->select('users.id'));
+    }
+}

--- a/app/Support/SimplePage.php
+++ b/app/Support/SimplePage.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\LaravelData\Data;
+
+/**
+ * One page of a simply-paginated admin log: the rows, and the URLs either side.
+ *
+ * Simple pagination is the right envelope for a log. It asks for one row more
+ * than it shows to learn whether a next page exists, rather than counting the
+ * whole table for a page count nobody reads — an audit log grows without bound
+ * and is walked, not jumped around in.
+ *
+ * The walk is the point of this class. Both admin logs used to spell it out
+ * themselves — the page size, `latest()->orderByDesc('id')`, `simplePaginate`,
+ * `withQueryString()`, then the same three envelope keys — which is four places
+ * for one decision to drift in (#1199). It is declared once, here, and the two
+ * read-models supply only what genuinely differs: their scoped query and the DTO
+ * each row becomes.
+ *
+ * @implements Arrayable<string, mixed>
+ */
+final readonly class SimplePage implements Arrayable
+{
+    /**
+     * How many rows a page of an admin log shows.
+     */
+    public const int PER_PAGE = 30;
+
+    /**
+     * @param  array<int, array<string, mixed>>  $rows
+     */
+    private function __construct(
+        private array $rows,
+        private ?string $previousPageUrl,
+        private ?string $nextPageUrl,
+    ) {}
+
+    /**
+     * Page the given query newest-first and turn each row into its DTO.
+     *
+     * `latest()` alone is not a total order: an audit entry and a security event
+     * are both written in bursts, and rows sharing a `created_at` to the second
+     * would otherwise be free to swap places between two requests — which in a
+     * paged walk means a row shown twice and another never shown at all. The id
+     * breaks the tie, so the sequence a reader pages through is stable.
+     *
+     * `withQueryString()` carries the active filters onto the prev/next links, so
+     * paging a filtered log stays filtered.
+     *
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @param  Closure(TModel): Data  $row
+     */
+    public static function newestFirst(Builder $query, Closure $row): self
+    {
+        $paginator = $query
+            ->latest()
+            ->orderByDesc('id')
+            ->simplePaginate(self::PER_PAGE)
+            ->withQueryString();
+
+        return new self(
+            array_map(static fn ($model): array => $row($model)->toArray(), $paginator->items()),
+            $paginator->previousPageUrl(),
+            $paginator->nextPageUrl(),
+        );
+    }
+
+    /**
+     * The page as the client reads it, matching `SimplePage<T>` in
+     * `resources/js/types/pagination.ts`.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->rows,
+            'prevPageUrl' => $this->previousPageUrl,
+            'nextPageUrl' => $this->nextPageUrl,
+        ];
+    }
+}

--- a/app/Support/SimplePage.php
+++ b/app/Support/SimplePage.php
@@ -18,6 +18,13 @@ use Spatie\LaravelData\Data;
  * whole table for a page count nobody reads — an audit log grows without bound
  * and is walked, not jumped around in.
  *
+ * It is deliberately *not* a cursor. A cursor would page a deep log more cheaply,
+ * but these two surfaces are admin screens read from the top and filtered, and
+ * their prev/next controls are page URLs the client already speaks. Switching
+ * modes is a change to what a page *is*, not a deduplication — the cursor-paged
+ * surfaces ({@see ThreadInboxPage}, `MessagePage`) are their own envelope for that
+ * reason, and #1199 deliberately left them alone in both directions.
+ *
  * The walk is the point of this class. Both admin logs used to spell it out
  * themselves — the page size, `latest()->orderByDesc('id')`, `simplePaginate`,
  * `withQueryString()`, then the same three envelope keys — which is four places

--- a/database/factories/AuditActivityFactory.php
+++ b/database/factories/AuditActivityFactory.php
@@ -57,6 +57,18 @@ class AuditActivityFactory extends Factory
     }
 
     /**
+     * Record the entry with no human behind it, the way a scheduled sweep or a
+     * system action is recorded.
+     */
+    public function uncaused(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'causer_type' => null,
+            'causer_id' => null,
+        ]);
+    }
+
+    /**
      * Attribute the entry to a specific actor.
      */
     public function causedBy(User $user): static

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -6,6 +6,7 @@ export * from './dataExport';
 export * from './locale';
 export * from './messages';
 export * from './navigation';
+export * from './pagination';
 export * from './people';
 export * from './security';
 export * from './sessions';

--- a/resources/js/types/pagination.ts
+++ b/resources/js/types/pagination.ts
@@ -1,0 +1,16 @@
+/**
+ * One page of a simply-paginated list: the rows, and the links either side.
+ *
+ * Simple (prev/next) pagination is what the admin logs use, so a log can be
+ * paged through in full without a bounded cap and without counting the whole
+ * table for a page number nobody reads. `App\Support\SimplePage` is the server
+ * half; the two are one envelope, and this is the only place it is spelled.
+ *
+ * Cursor-paged surfaces (`MessagePage`, `ThreadInboxPage`) are a different
+ * envelope for a different pagination mode and deliberately do not use this.
+ */
+export type SimplePage<T> = {
+    data: T[];
+    prevPageUrl: string | null;
+    nextPageUrl: string | null;
+};

--- a/resources/js/types/security.ts
+++ b/resources/js/types/security.ts
@@ -1,3 +1,5 @@
+import type { SimplePage } from './pagination';
+
 /**
  * A recorded security-relevant account event as shown on the Security settings
  * page.
@@ -21,12 +23,5 @@ export type SecurityLogActor = {
     name: string;
 };
 
-/**
- * One page of admin security-log events. Uses simple (prev/next) pagination so
- * the log can be paged through in full without a bounded cap.
- */
-export type SecurityEventsPage = {
-    data: TeamSecurityEvent[];
-    prevPageUrl: string | null;
-    nextPageUrl: string | null;
-};
+/** One page of admin security-log events. */
+export type SecurityEventsPage = SimplePage<TeamSecurityEvent>;

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -1,3 +1,5 @@
+import type { SimplePage } from './pagination';
+
 /** A member's standing in a workspace. Backed by the PHP enum. */
 export type TeamRole = App.Enums.TeamRole;
 
@@ -119,15 +121,8 @@ export type AuditActor = {
     name: string;
 };
 
-/**
- * One page of audit entries. Uses simple (prev/next) pagination so the log can
- * be paged through in full without a bounded cap.
- */
-export type AuditEntriesPage = {
-    data: AuditEntry[];
-    prevPageUrl: string | null;
-    nextPageUrl: string | null;
-};
+/** One page of audit entries. */
+export type AuditEntriesPage = SimplePage<AuditEntry>;
 
 /** A single headline metric on the analytics dashboard. */
 export type AnalyticsStat = App.Data.AnalyticsStatData;

--- a/tests/Integration/Support/AuditLogTest.php
+++ b/tests/Integration/Support/AuditLogTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\AuditAction;
+use App\Enums\TeamRole;
+use App\Models\AuditActivity;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\AuditLog;
+use App\Support\SimplePage;
+
+/*
+|--------------------------------------------------------------------------
+| The audit-log read-model (#1199)
+|--------------------------------------------------------------------------
+|
+| `AuditController` and `SecurityLogController` were line-for-line twins across
+| seven concerns — the page size, the two filters, the `when` pair, the
+| `simplePaginate` walk, the envelope and a fourteen-line actor lookup written
+| out twice. The two logs genuinely differ in scope and filter column, so this
+| is one of two read-models sharing three modules rather than one parameterised
+| log.
+|
+| Constructed from a team and its two filters — never a `Request` — so every
+| reading below is reachable without an HTTP round-trip, the bar ADR-0012 named.
+| `tests/Feature/Teams/AuditLogTest.php` keeps the HTTP half.
+|
+*/
+
+/**
+ * Create a real (non-personal) team owned by a fresh user.
+ *
+ * @return array{0: User, 1: Team}
+ */
+function auditLogReadModelTeam(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    return [$owner, $team];
+}
+
+/**
+ * Attach a member to a team with the given role.
+ */
+function auditLogReadModelMember(Team $team, TeamRole $role = TeamRole::Member): User
+{
+    $member = User::factory()->create();
+    $team->members()->attach($member, ['role' => $role->value]);
+
+    return $member;
+}
+
+test('the log is constructible from a team alone and reads its own entries', function (): void {
+    [$owner, $team] = auditLogReadModelTeam();
+
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+    AuditActivity::factory()->forTeam(Team::factory()->create())->ofAction(AuditAction::TeamRenamed)->create();
+
+    $entries = new AuditLog($team)->entries()->toArray();
+
+    expect($entries['data'])->toHaveCount(1)
+        ->and($entries['data'][0]['action'])->toBe(AuditAction::ChannelCreated->value)
+        ->and($entries['prevPageUrl'])->toBeNull()
+        ->and($entries['nextPageUrl'])->toBeNull();
+});
+
+test('the action filter narrows the log to one kind of entry', function (): void {
+    [$owner, $team] = auditLogReadModelTeam();
+
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::MemberRemoved)->create();
+
+    $entries = new AuditLog($team, action: AuditAction::MemberRemoved->value)->entries()->toArray();
+
+    expect(array_column($entries['data'], 'action'))->toBe([AuditAction::MemberRemoved->value]);
+});
+
+test('the actor filter narrows the log to one person', function (): void {
+    [$owner, $team] = auditLogReadModelTeam();
+    $admin = auditLogReadModelMember($team, TeamRole::Admin);
+
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+    AuditActivity::factory()->forTeam($team)->causedBy($admin)->ofAction(AuditAction::MemberRemoved)->create();
+
+    $entries = new AuditLog($team, actor: $admin->id)->entries()->toArray();
+
+    expect(array_column($entries['data'], 'actorName'))->toBe([$admin->name]);
+});
+
+test('the actor facet offers only the people the log names', function (): void {
+    [$owner, $team] = auditLogReadModelTeam();
+    $admin = auditLogReadModelMember($team, TeamRole::Admin);
+    auditLogReadModelMember($team, TeamRole::Admin);
+
+    AuditActivity::factory()->forTeam($team)->causedBy($admin)->ofAction(AuditAction::MemberRemoved)->create();
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+    // Recorded with no human causer, so there is nobody to offer as a choice.
+    AuditActivity::factory()->forTeam($team)->uncaused()->ofAction(AuditAction::WebhookSubscriptionAutoDisabled)->create();
+
+    $actors = new AuditLog($team)->actors();
+
+    expect($actors)->toHaveCount(2)
+        ->and(array_column($actors, 'name'))->toBe(collect([$owner->name, $admin->name])->sort()->values()->all());
+});
+
+test('a page is capped and carries the link to the next one', function (): void {
+    [$owner, $team] = auditLogReadModelTeam();
+
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)
+        ->count(SimplePage::PER_PAGE + 5)
+        ->create();
+
+    $entries = new AuditLog($team)->entries()->toArray();
+
+    expect($entries['data'])->toHaveCount(SimplePage::PER_PAGE)
+        ->and($entries['nextPageUrl'])->toContain('page=2')
+        ->and($entries['prevPageUrl'])->toBeNull();
+});

--- a/tests/Integration/Support/AuditLogTest.php
+++ b/tests/Integration/Support/AuditLogTest.php
@@ -1,11 +1,9 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\AuditAction;
 use App\Enums\TeamRole;
 use App\Models\AuditActivity;
 use App\Models\Team;
-use App\Models\User;
 use App\Support\AuditLog;
 use App\Support\SimplePage;
 
@@ -27,32 +25,8 @@ use App\Support\SimplePage;
 |
 */
 
-/**
- * Create a real (non-personal) team owned by a fresh user.
- *
- * @return array{0: User, 1: Team}
- */
-function auditLogReadModelTeam(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-
-    return [$owner, $team];
-}
-
-/**
- * Attach a member to a team with the given role.
- */
-function auditLogReadModelMember(Team $team, TeamRole $role = TeamRole::Member): User
-{
-    $member = User::factory()->create();
-    $team->members()->attach($member, ['role' => $role->value]);
-
-    return $member;
-}
-
 test('the log is constructible from a team alone and reads its own entries', function (): void {
-    [$owner, $team] = auditLogReadModelTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
     AuditActivity::factory()->forTeam(Team::factory()->create())->ofAction(AuditAction::TeamRenamed)->create();
@@ -66,7 +40,7 @@ test('the log is constructible from a team alone and reads its own entries', fun
 });
 
 test('the action filter narrows the log to one kind of entry', function (): void {
-    [$owner, $team] = auditLogReadModelTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::MemberRemoved)->create();
@@ -77,8 +51,8 @@ test('the action filter narrows the log to one kind of entry', function (): void
 });
 
 test('the actor filter narrows the log to one person', function (): void {
-    [$owner, $team] = auditLogReadModelTeam();
-    $admin = auditLogReadModelMember($team, TeamRole::Admin);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
 
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
     AuditActivity::factory()->forTeam($team)->causedBy($admin)->ofAction(AuditAction::MemberRemoved)->create();
@@ -89,9 +63,9 @@ test('the actor filter narrows the log to one person', function (): void {
 });
 
 test('the actor facet offers only the people the log names', function (): void {
-    [$owner, $team] = auditLogReadModelTeam();
-    $admin = auditLogReadModelMember($team, TeamRole::Admin);
-    auditLogReadModelMember($team, TeamRole::Admin);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $admin = teamMemberInChannel($general, role: TeamRole::Admin);
+    teamMemberInChannel($general, role: TeamRole::Admin);
 
     AuditActivity::factory()->forTeam($team)->causedBy($admin)->ofAction(AuditAction::MemberRemoved)->create();
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
@@ -105,7 +79,7 @@ test('the actor facet offers only the people the log names', function (): void {
 });
 
 test('a page is capped and carries the link to the next one', function (): void {
-    [$owner, $team] = auditLogReadModelTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)
         ->count(SimplePage::PER_PAGE + 5)

--- a/tests/Integration/Support/SecurityLogTest.php
+++ b/tests/Integration/Support/SecurityLogTest.php
@@ -1,10 +1,7 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Enums\SecurityEventType;
-use App\Enums\TeamRole;
 use App\Models\SecurityEvent;
-use App\Models\Team;
 use App\Models\User;
 use App\Support\SecurityLog;
 use App\Support\SimplePage;
@@ -26,33 +23,9 @@ use App\Support\SimplePage;
 |
 */
 
-/**
- * Create a real (non-personal) team owned by a fresh user.
- *
- * @return array{0: User, 1: Team}
- */
-function securityLogReadModelTeam(): array
-{
-    $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, 'Acme');
-
-    return [$owner, $team];
-}
-
-/**
- * Attach a member to a team with the given role.
- */
-function securityLogReadModelMember(Team $team, TeamRole $role = TeamRole::Member): User
-{
-    $member = User::factory()->create();
-    $team->members()->attach($member, ['role' => $role->value]);
-
-    return $member;
-}
-
 test('the log is constructible from a team alone and reads its members events', function (): void {
-    [$owner, $team] = securityLogReadModelTeam();
-    $member = securityLogReadModelMember($team);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
     $stranger = User::factory()->create();
 
     SecurityEvent::factory()->for($owner)->create();
@@ -74,8 +47,8 @@ test('the log is constructible from a team alone and reads its members events', 
  * history from this workspace's view of them at once.
  */
 test('an event leaves the log the moment its user leaves the team', function (): void {
-    [$owner, $team] = securityLogReadModelTeam();
-    $member = securityLogReadModelMember($team);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     SecurityEvent::factory()->for($owner)->create();
     SecurityEvent::factory()->for($member)->create();
@@ -91,7 +64,7 @@ test('an event leaves the log the moment its user leaves the team', function ():
 });
 
 test('the type filter narrows the log to one kind of event', function (): void {
-    [$owner, $team] = securityLogReadModelTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     SecurityEvent::factory()->for($owner)->ofType(SecurityEventType::LoggedIn)->create();
     SecurityEvent::factory()->for($owner)->ofType(SecurityEventType::PasswordChanged)->create();
@@ -102,8 +75,8 @@ test('the type filter narrows the log to one kind of event', function (): void {
 });
 
 test('the actor filter narrows the log to one person', function (): void {
-    [$owner, $team] = securityLogReadModelTeam();
-    $member = securityLogReadModelMember($team);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
 
     SecurityEvent::factory()->for($owner)->create();
     SecurityEvent::factory()->for($member)->create();
@@ -114,9 +87,9 @@ test('the actor filter narrows the log to one person', function (): void {
 });
 
 test('the actor facet offers only the members the log names', function (): void {
-    [$owner, $team] = securityLogReadModelTeam();
-    $member = securityLogReadModelMember($team);
-    securityLogReadModelMember($team);
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
+    teamMemberInChannel($general);
     $stranger = User::factory()->create();
 
     SecurityEvent::factory()->for($owner)->create();
@@ -130,7 +103,7 @@ test('the actor facet offers only the members the log names', function (): void 
 });
 
 test('a page is capped and carries the link to the next one', function (): void {
-    [$owner, $team] = securityLogReadModelTeam();
+    ['owner' => $owner, 'team' => $team] = teamWithChannel();
 
     SecurityEvent::factory()->for($owner)->count(SimplePage::PER_PAGE + 5)->create();
 

--- a/tests/Integration/Support/SecurityLogTest.php
+++ b/tests/Integration/Support/SecurityLogTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\SecurityEventType;
+use App\Enums\TeamRole;
+use App\Models\SecurityEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\SecurityLog;
+use App\Support\SimplePage;
+
+/*
+|--------------------------------------------------------------------------
+| The security-log read-model (#1199)
+|--------------------------------------------------------------------------
+|
+| The sibling of `AuditLog`. They share the envelope and the actor facet and
+| keep their own scope, and this one's scope is the reason they are two
+| read-models rather than one parameterised log: a security event is recorded
+| against an *account*, not a team, so the workspace log is a live join to the
+| team's current membership. That rule used to live unnamed inside a controller
+| and had no test of its own.
+|
+| Constructed from a team and its two filters — never a `Request` (ADR-0012).
+| `tests/Feature/Teams/SecurityLogTest.php` keeps the HTTP half.
+|
+*/
+
+/**
+ * Create a real (non-personal) team owned by a fresh user.
+ *
+ * @return array{0: User, 1: Team}
+ */
+function securityLogReadModelTeam(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    return [$owner, $team];
+}
+
+/**
+ * Attach a member to a team with the given role.
+ */
+function securityLogReadModelMember(Team $team, TeamRole $role = TeamRole::Member): User
+{
+    $member = User::factory()->create();
+    $team->members()->attach($member, ['role' => $role->value]);
+
+    return $member;
+}
+
+test('the log is constructible from a team alone and reads its members events', function (): void {
+    [$owner, $team] = securityLogReadModelTeam();
+    $member = securityLogReadModelMember($team);
+    $stranger = User::factory()->create();
+
+    SecurityEvent::factory()->for($owner)->create();
+    SecurityEvent::factory()->for($member)->create();
+    SecurityEvent::factory()->for($stranger)->create();
+
+    $events = new SecurityLog($team)->events()->toArray();
+
+    expect($events['data'])->toHaveCount(2)
+        ->and(array_column($events['data'], 'actorName'))->not->toContain($stranger->name)
+        ->and($events['prevPageUrl'])->toBeNull()
+        ->and($events['nextPageUrl'])->toBeNull();
+});
+
+/**
+ * The membership rule, stated on its own. An account-level event surfaces in a
+ * workspace's log only *while* its user is a member — the scope is a live join,
+ * not a copy taken when the row was written — so removing someone drops their
+ * history from this workspace's view of them at once.
+ */
+test('an event leaves the log the moment its user leaves the team', function (): void {
+    [$owner, $team] = securityLogReadModelTeam();
+    $member = securityLogReadModelMember($team);
+
+    SecurityEvent::factory()->for($owner)->create();
+    SecurityEvent::factory()->for($member)->create();
+
+    expect(new SecurityLog($team)->events()->toArray()['data'])->toHaveCount(2);
+
+    $team->members()->detach($member);
+
+    $log = new SecurityLog($team);
+
+    expect($log->events()->toArray()['data'])->toHaveCount(1)
+        ->and(array_column($log->actors(), 'id'))->toBe([$owner->id]);
+});
+
+test('the type filter narrows the log to one kind of event', function (): void {
+    [$owner, $team] = securityLogReadModelTeam();
+
+    SecurityEvent::factory()->for($owner)->ofType(SecurityEventType::LoggedIn)->create();
+    SecurityEvent::factory()->for($owner)->ofType(SecurityEventType::PasswordChanged)->create();
+
+    $events = new SecurityLog($team, type: SecurityEventType::PasswordChanged->value)->events()->toArray();
+
+    expect(array_column($events['data'], 'type'))->toBe([SecurityEventType::PasswordChanged->value]);
+});
+
+test('the actor filter narrows the log to one person', function (): void {
+    [$owner, $team] = securityLogReadModelTeam();
+    $member = securityLogReadModelMember($team);
+
+    SecurityEvent::factory()->for($owner)->create();
+    SecurityEvent::factory()->for($member)->create();
+
+    $events = new SecurityLog($team, actor: $member->id)->events()->toArray();
+
+    expect(array_column($events['data'], 'actorName'))->toBe([$member->name]);
+});
+
+test('the actor facet offers only the members the log names', function (): void {
+    [$owner, $team] = securityLogReadModelTeam();
+    $member = securityLogReadModelMember($team);
+    securityLogReadModelMember($team);
+    $stranger = User::factory()->create();
+
+    SecurityEvent::factory()->for($owner)->create();
+    SecurityEvent::factory()->for($member)->create();
+    SecurityEvent::factory()->for($stranger)->create();
+
+    $actors = new SecurityLog($team)->actors();
+
+    expect($actors)->toHaveCount(2)
+        ->and(array_column($actors, 'name'))->toBe(collect([$owner->name, $member->name])->sort()->values()->all());
+});
+
+test('a page is capped and carries the link to the next one', function (): void {
+    [$owner, $team] = securityLogReadModelTeam();
+
+    SecurityEvent::factory()->for($owner)->count(SimplePage::PER_PAGE + 5)->create();
+
+    $events = new SecurityLog($team)->events()->toArray();
+
+    expect($events['data'])->toHaveCount(SimplePage::PER_PAGE)
+        ->and($events['nextPageUrl'])->toContain('page=2')
+        ->and($events['prevPageUrl'])->toBeNull();
+});

--- a/tests/Unit/PagedAdminLogHomeTest.php
+++ b/tests/Unit/PagedAdminLogHomeTest.php
@@ -61,6 +61,16 @@ function pageEnvelopePattern(): string
     return '/\bprevPageUrl\b|\bnextPageUrl\b/';
 }
 
+/**
+ * Building a query, in both spellings — through `::query()` and through a model's
+ * static passthrough (`AuditActivity::where(...)`), which is the same thing with
+ * one call elided and is how the duplication would grow back unnoticed.
+ */
+function controllerQueryPattern(): string
+{
+    return '/::query\(|::where\(|::when\(|->where\(|->when\(/';
+}
+
 test('the pagination walk and its page size are declared in one place', function () use ($sourceRoot): void {
     expect(pagedLogFilesMatching($sourceRoot, 'app', '*.php', simplePaginationWalkPattern()))->toBe([
         'app/Support/SimplePage.php',
@@ -104,7 +114,7 @@ test('the actor facet is one module, called by both logs', function () use ($sou
  * duplication growing back.
  */
 test('neither log controller holds a query', function () use ($sourceRoot): void {
-    expect(pagedLogFilesMatching($sourceRoot, 'app/Http/Controllers/Teams', '*.php', '/::query\(\)|->where\(|->when\(/'))
+    expect(pagedLogFilesMatching($sourceRoot, 'app/Http/Controllers/Teams', '*.php', controllerQueryPattern()))
         ->not->toContain(
             'app/Http/Controllers/Teams/AuditController.php',
             'app/Http/Controllers/Teams/SecurityLogController.php',
@@ -123,6 +133,9 @@ test('each pattern still catches the code it was written for', function (string 
     'the page size' => [simplePaginationWalkPattern(), 'private const int PER_PAGE = 30;'],
     'the prev key' => [pageEnvelopePattern(), "'prevPageUrl' => \$entries->previousPageUrl(),"],
     'the next key' => [pageEnvelopePattern(), '    nextPageUrl: string | null;'],
+    'a query built through the builder' => [controllerQueryPattern(), '$entries = AuditActivity::query()'],
+    'a query built through the static passthrough' => [controllerQueryPattern(), "AuditActivity::where('team_id', \$team->id)"],
+    'a filter applied inline' => [controllerQueryPattern(), "->when(\$action, fn (\$query) => \$query->where('event', \$action))"],
 ]);
 
 /**

--- a/tests/Unit/PagedAdminLogHomeTest.php
+++ b/tests/Unit/PagedAdminLogHomeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\AuditLog;
+use App\Support\LogActors;
+use App\Support\SecurityLog;
+use App\Support\SimplePage;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * The paged admin log was written four times, twice in each language (#1199).
+ * {@see AuditLog} and {@see SecurityLog} were line-for-line twins across seven
+ * concerns, and the envelope leaked to the client as two more copies.
+ *
+ * {@see SimplePage} is now the one home for the walk and the envelope, and
+ * {@see LogActors} the one home for the actor facet. This is what keeps it that
+ * way: a third admin log that spells its own `simplePaginate` — or a fourth copy
+ * of the `{data, prevPageUrl, nextPageUrl}` keys — fails here, where the drift
+ * is cheap to undo, rather than years later when the two have quietly stopped
+ * agreeing about what a page is.
+ */
+$sourceRoot = dirname(__DIR__, 2);
+
+/**
+ * Every file under the given directory matching the pattern, as
+ * repository-relative paths.
+ *
+ * @return list<string>
+ */
+function pagedLogFilesMatching(string $sourceRoot, string $directory, string $extension, string $pattern): array
+{
+    $found = [];
+
+    foreach (new Finder()->files()->in($sourceRoot.'/'.$directory)->name($extension) as $file) {
+        if (preg_match($pattern, $file->getContents()) === 1) {
+            $found[] = str_replace($sourceRoot.'/', '', $file->getPathname());
+        }
+    }
+
+    sort($found);
+
+    return $found;
+}
+
+/**
+ * Paging a query one page at a time — the walk itself, along with the page size
+ * it is asked for.
+ */
+function simplePaginationWalkPattern(): string
+{
+    return '/->\s*simplePaginate\(|\bPER_PAGE\b\s*=/';
+}
+
+/**
+ * The envelope's own keys, in either language. A copy is a copy whether it is
+ * spelled in an Inertia payload or in a TypeScript type.
+ */
+function pageEnvelopePattern(): string
+{
+    return '/\bprevPageUrl\b|\bnextPageUrl\b/';
+}
+
+test('the pagination walk and its page size are declared in one place', function () use ($sourceRoot): void {
+    expect(pagedLogFilesMatching($sourceRoot, 'app', '*.php', simplePaginationWalkPattern()))->toBe([
+        'app/Support/SimplePage.php',
+    ]);
+});
+
+test('the envelope is declared once on the server', function () use ($sourceRoot): void {
+    expect(pagedLogFilesMatching($sourceRoot, 'app', '*.php', pageEnvelopePattern()))->toBe([
+        'app/Support/SimplePage.php',
+    ]);
+});
+
+/**
+ * And once on the client. `SimplePage<T>` is a client-only view model of the
+ * kind `CONTEXT.md` blesses, not a shadowed DTO — there is no `Page` class in
+ * `app/Data/` for it to restate, so ADR-0013 is not what is being asked here.
+ * What is being asked is that the two log pages parameterise it instead of
+ * re-spelling it.
+ */
+test('the envelope is declared once on the client', function () use ($sourceRoot): void {
+    expect(pagedLogFilesMatching($sourceRoot, 'resources/js', '*.ts', pageEnvelopePattern()))->toBe([
+        'resources/js/types/pagination.ts',
+    ]);
+});
+
+/**
+ * The actor facet is the sharpest of the seven duplications: fourteen lines of
+ * distinct-pluck-then-name, written out twice. Both logs ask for it here, and a
+ * third would get it for free.
+ */
+test('the actor facet is one module, called by both logs', function () use ($sourceRoot): void {
+    expect(pagedLogFilesMatching($sourceRoot, 'app', '*.php', '/new LogActors\(/'))->toBe([
+        'app/Support/AuditLog.php',
+        'app/Support/SecurityLog.php',
+    ]);
+});
+
+/**
+ * The controllers are glue now: they validate, they name the props, and they
+ * compute none of it. A query builder reappearing in either one is the
+ * duplication growing back.
+ */
+test('neither log controller holds a query', function () use ($sourceRoot): void {
+    expect(pagedLogFilesMatching($sourceRoot, 'app/Http/Controllers/Teams', '*.php', '/::query\(\)|->where\(|->when\(/'))
+        ->not->toContain(
+            'app/Http/Controllers/Teams/AuditController.php',
+            'app/Http/Controllers/Teams/SecurityLogController.php',
+        );
+});
+
+/**
+ * A tripwire nothing can trip proves nothing, and these are regular expressions
+ * over source: a typo makes them match nothing and the suite stays green. Each
+ * pattern is replayed against the copy it was written to catch.
+ */
+test('each pattern still catches the code it was written for', function (string $pattern, string $source): void {
+    expect(preg_match($pattern, $source))->toBe(1);
+})->with([
+    'the walk' => [simplePaginationWalkPattern(), '->simplePaginate(self::PER_PAGE)'],
+    'the page size' => [simplePaginationWalkPattern(), 'private const int PER_PAGE = 30;'],
+    'the prev key' => [pageEnvelopePattern(), "'prevPageUrl' => \$entries->previousPageUrl(),"],
+    'the next key' => [pageEnvelopePattern(), '    nextPageUrl: string | null;'],
+]);
+
+/**
+ * And what each must leave alone, so the tripwire does not become noise someone
+ * silences by widening the expected list.
+ */
+test('each pattern leaves what it is not about alone', function (string $pattern, string $source): void {
+    expect(preg_match($pattern, $source))->toBe(0);
+})->with([
+    // A cursor-paged surface is a different envelope for a different pagination
+    // mode, and `CONTEXT.md` blesses it: `ThreadInboxPage` and `MessagePage`
+    // carry cursors, not page URLs, and are deliberately not retrofitted here.
+    'a cursor page' => [pageEnvelopePattern(), "'next_cursor' => \$this->metadata->getNextPage(),"],
+    'a cursor paginator' => [simplePaginationWalkPattern(), '->cursorPaginate($perPage)'],
+    // Laravel's default length-aware paginator on the REST contract is a third
+    // envelope on a different promise. Also not this.
+    'the API paginator' => [simplePaginationWalkPattern(), '->paginate(50)'],
+    // Reading the page size is not declaring it.
+    'reading the page size' => [simplePaginationWalkPattern(), 'expect($entries)->toHaveCount(SimplePage::PER_PAGE);'],
+]);


### PR DESCRIPTION
Closes #1199. Part of #1195.

## What

`AuditController` and `SecurityLogController` were line-for-line twins across seven concerns — the page size, the two `validated()` filters, the `when` pair, the `latest()->orderByDesc('id')->simplePaginate()->withQueryString()` walk, the `{id, name, slug}` team literal, the `{data, prevPageUrl, nextPageUrl}` envelope, and a fourteen-line `actors()` written out twice. The envelope leaked to the client as two more copies, each with its own near-identical docblock.

**Two read-models sharing three modules**, as the issue specifies — not one parameterised log:

- **`App\Support\AuditLog`** and **`App\Support\SecurityLog`**, each `(Team, ...$filters)` and never a `Request`, each owning the one thing that genuinely differs: its scope (`where team_id` vs. the membership join) and its filter column (`event` vs. `type`).
- **`App\Support\SimplePage`** owns `PER_PAGE`, the newest-first walk and the envelope, and is the only place any of the three is spelled.
- **`App\Support\LogActors`** is the actor facet, derived from the log's own scoped query so the filter only ever offers a name with rows behind it.
- Client-side, `SimplePage<T>` lands in `resources/js/types/pagination.ts` and the two page types become one-line parameterisations of it.

Both controllers now hold HTTP glue only: they validate, they name the props, and they compute none of it.

## Why it is not only tidiness

Staying **two** read-models is what gives `SecurityLog::ofCurrentMembers()` a home. A security event is recorded against an *account*, so a workspace's log is a **live** join to that team's current membership — removing a member drops their events from it at once, and re-adding them brings the history back intact. That rule sat unnamed inside a controller with no test of its own; it now has both, asserted directly on the read-model rather than through a rendered page. It is also what `TeamSecurityEventData`'s non-nullable `actorName` rests on.

Folding both logs into one generic read-model taking a query builder would have hidden only the envelope and cost that rule its home.

## Not an ADR-0013 violation

Worth restating so nobody "fixes" it the wrong way: `AuditEntriesPage` / `SecurityEventsPage` restate a pagination *envelope*, not a DTO — there is no `Page` class in `app/Data/`. `CONTEXT.md` already blesses `MessagePage` and `ThreadInboxPage` as client-only view models of exactly this kind. Sharpening four copies of one envelope into `SimplePage<T>` is that pattern applied, not an alias over a DTO.

## How tested

- `tests/Integration/Support/AuditLogTest.php` and `SecurityLogTest.php` — new, 11 tests. Each read-model constructed from a team and its filters with no HTTP round-trip (ADR-0012), covering the scope, both filters, the actor facet and the page cap. One test states the membership rule on its own: an event leaves the log the moment its user leaves the team.
- `tests/Unit/PagedAdminLogHomeTest.php` — new, the repo's home-test idiom (`GuardedEgressHomeTest`, `VisibleChannelsAclHomeTest`). Fails if the walk, the envelope (in either language) or the actor facet grows a second copy, or if a query reappears in either controller. Both tripwire patterns are replayed against the code they were written to catch **and** against the cursor-paged and length-aware envelopes they must leave alone.
- `tests/Feature/Teams/{Audit,Security}LogTest.php` keep the HTTP half and are unchanged — the Inertia payload is byte-identical, which is what makes this a refactor.
- Full gate green: `composer test` at `Total: 100.0 %`, plus `lint:check`, `format:check`, `types:check`, `test:js` and `build`.

## Out of scope, per the issue

`MessagePage` / `ThreadInboxPage` are **not** retrofitted onto `SimplePage` — they carry cursors, not page URLs, which is a different envelope for a different pagination mode. `Api/V1/MessageController`'s `->paginate(50)`, the `{id, name, slug}` team literal and the `Inertia::flash('toast', ...)` copies are likewise left alone.

No i18n or docs changes: nothing user-facing or operator-facing moved. `CONTEXT.md` gains the paged-admin-log entry the issue asks for.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788387677&installation_model_id=428379&pr_number=1225&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1225&signature=1026fd17d94b0655143977403345e5311eb120a08e8a9dad81f972edbf84e4b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->