### PR TITLE
feat: a command registry the palette and the keyboard share

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1501,5 +1501,9 @@
   "Photos": "Photos",
   "Camera": "Appareil photo",
   "Voice": "Vocal",
-  "Command": "Commande"
+  "Command": "Commande",
+  "Resume notifications": "Reprendre les notifications",
+  "Use light theme": "Utiliser le thème clair",
+  "Use dark theme": "Utiliser le thème sombre",
+  "Match system theme": "Suivre le thème du système"
 }

--- a/resources/js/composables/commands.test.ts
+++ b/resources/js/composables/commands.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { visit, destroy } = vi.hoisted(() => ({
+    visit: vi.fn(),
+    destroy: vi.fn(),
+}));
+
+/**
+ * Hoisted, all of it: the registry calls its composables at
+ * module-*evaluation* time, so a plain `const` here would still be in its
+ * temporal dead zone by the time a mock factory is first asked for it.
+ */
+const page = vi.hoisted(() => ({
+    url: '/t/acme/c/general',
+    props: {} as Record<string, unknown>,
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { visit, delete: destroy, put: vi.fn(), flushAll: vi.fn() },
+    usePage: () => page,
+}));
+
+const { pinUrl } = vi.hoisted(() => ({ pinUrl: vi.fn() }));
+
+vi.mock('@/lib/pinUrl', () => ({ pinUrl }));
+
+import { browse } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { destroy as destroyDndPause } from '@/actions/App/Http/Controllers/Settings/DndController';
+import { COMMANDS } from '@/composables/commands';
+import { SHORTCUTS } from '@/composables/keyboardShortcuts';
+import { SHELL_DIALOG_NAMES, useDialog } from '@/composables/useDialog';
+import type { ShellDialog } from '@/composables/useDialog';
+
+/** A workspace the viewer is standing in, with the invite permission. */
+function seed(props: Record<string, unknown> = {}): void {
+    page.props = {
+        currentTeam: { id: 't1', slug: 'acme' },
+        canInviteToCurrentTeam: true,
+        auth: { user: { dnd: null, timezone: 'UTC' } },
+        ...props,
+    };
+}
+
+/** Run the command with this id, failing loudly when nothing carries it. */
+function run(id: string): void {
+    const command = COMMANDS.find((candidate) => candidate.id === id);
+
+    expect(command, `no command is registered as "${id}"`).toBeDefined();
+
+    command?.run();
+}
+
+/** jsdom has no `matchMedia`; the "system" theme resolves through it. */
+function stubMatchMedia(): void {
+    window.matchMedia = ((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+    })) as unknown as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    stubMatchMedia();
+    localStorage.clear();
+    page.url = '/t/acme/c/general';
+    seed();
+});
+
+describe('the derivation guard', () => {
+    it('has exactly one command claiming every dispatchable shortcut', () => {
+        const dispatchable = SHORTCUTS.filter(
+            (shortcut) => !shortcut.displayOnly,
+        ).map((shortcut) => shortcut.id);
+
+        for (const id of dispatchable) {
+            expect(
+                COMMANDS.filter((command) => command.shortcutId === id),
+            ).toHaveLength(1);
+        }
+    });
+
+    it('claims no shortcut the dispatcher never fires', () => {
+        const displayOnly = SHORTCUTS.filter(
+            (shortcut) => shortcut.displayOnly,
+        ).map((shortcut) => shortcut.id);
+
+        for (const command of COMMANDS) {
+            expect(displayOnly).not.toContain(command.shortcutId);
+        }
+    });
+
+    it('gives every command its own id', () => {
+        const ids = COMMANDS.map((command) => command.id);
+
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+});
+
+describe('the theme trio', () => {
+    it.each([
+        ['theme-light', 'light'],
+        ['theme-dark', 'dark'],
+        ['theme-system', 'system'],
+    ])('%s asks for the %s appearance', (id, expected) => {
+        run(id);
+
+        expect(localStorage.getItem('appearance')).toBe(expected);
+    });
+});
+
+/**
+ * Which of the shell's dialogs each dialog-opening command reaches for. Five
+ * entries or nine, the assertion below is the same one: the key names a real
+ * {@link ShellDialog} and running the command flips its singleton. `useDialog`
+ * is the genuine article here rather than a mock, as it is in
+ * `useShellShortcuts.test.ts` — the singleton is the observable effect.
+ */
+const DIALOG_COMMANDS: Record<string, ShellDialog> = {
+    'command-palette': 'switcher',
+    'show-shortcuts': 'shortcuts',
+    'new-message': 'newMessage',
+    'set-status': 'status',
+    'pause-notifications': 'dnd',
+    'invite-people': 'invite',
+};
+
+describe('the dialog verbs', () => {
+    it.each(Object.entries(DIALOG_COMMANDS))(
+        '%s opens the %s dialog',
+        (id, dialog) => {
+            for (const name of SHELL_DIALOG_NAMES) {
+                useDialog(name).close();
+            }
+
+            run(id);
+
+            expect(useDialog(dialog).isOpen.value).toBe(true);
+        },
+    );
+});
+
+/**
+ * The two dock verbs write `?nav=` onto the current route and let the dock's own
+ * watcher adopt it — the same channel a deep link uses. They must *not* reach
+ * for `useNavPanel()`, whose state is per-instance: a module-scope call would
+ * drive a panel nobody renders, and it would type-check.
+ */
+describe('the dock verbs', () => {
+    it.each([
+        ['reminders', 'reminders'],
+        ['search', 'search'],
+    ])('%s pins its destination on the current route', (id, destination) => {
+        run(id);
+
+        expect(pinUrl).toHaveBeenCalledWith(
+            `/t/acme/c/general?nav=${destination}`,
+        );
+    });
+
+    it('keeps the query params the route already carries', () => {
+        page.url = '/t/acme/c/general?thread=m1';
+
+        run('search');
+
+        expect(pinUrl).toHaveBeenCalledWith(
+            '/t/acme/c/general?thread=m1&nav=search',
+        );
+    });
+});
+
+describe('browse-channels', () => {
+    it('visits the current workspace’s browse route', () => {
+        run('browse-channels');
+
+        expect(visit).toHaveBeenCalledWith(browse('acme').url);
+    });
+});
+
+/**
+ * Routed through {@see useUserMenu}, which already owns this call *and* its
+ * error toast — which is what lets `run` be fire-and-forget without
+ * `CommandDefinition` growing a result channel.
+ */
+describe('resume-notifications', () => {
+    it('ends the running pause', () => {
+        run('resume-notifications');
+
+        expect(destroy).toHaveBeenCalledWith(
+            destroyDndPause().url,
+            expect.anything(),
+        );
+    });
+
+    it('is offered only while do-not-disturb is actually running', () => {
+        const command = COMMANDS.find(
+            (candidate) => candidate.id === 'resume-notifications',
+        );
+
+        expect(command?.isAvailable?.()).toBe(false);
+
+        seed({
+            auth: {
+                user: {
+                    dnd: { until: '2999-01-01T00:00:00Z' },
+                    timezone: 'UTC',
+                },
+            },
+        });
+
+        expect(command?.isAvailable?.()).toBe(true);
+    });
+});
+
+/**
+ * A predicate that reaches one level too deep (`currentTeam.slug` where
+ * `currentTeam` was meant) does not quietly hide its own row — it throws inside
+ * the computed that builds the list, and takes the whole palette's render with
+ * it. So every predicate has to survive a page carrying nothing.
+ */
+describe('availability on a bare page', () => {
+    it('answers false rather than raising', () => {
+        page.props = {};
+
+        for (const command of COMMANDS) {
+            expect(
+                () => command.isAvailable?.(),
+                `${command.id} raised on an empty page`,
+            ).not.toThrow();
+
+            expect(command.isAvailable?.() ?? false).toBe(false);
+        }
+    });
+});
+
+/**
+ * The strongest assertion here, and the one that costs nothing when verb
+ * seventeen lands. Because the registry is module-scope, *importing the file is
+ * what calls the composables* — so a spy around the import catches the entire
+ * silent-cliff class at once, for every entry ever added, rather than one entry
+ * at a time. A `run` closing over something that only works inside a component
+ * instance (an `onMounted`, an `inject`) warns here instead of at 3am in a
+ * console nobody is reading.
+ */
+describe('module-scope hygiene', () => {
+    it('emits no Vue warning when the registry is imported', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        vi.resetModules();
+        await import('@/composables/commands');
+
+        expect(warn).not.toHaveBeenCalled();
+
+        warn.mockRestore();
+    });
+});

--- a/resources/js/composables/commands.ts
+++ b/resources/js/composables/commands.ts
@@ -1,0 +1,259 @@
+import { router, usePage } from '@inertiajs/vue3';
+import {
+    AlarmClock,
+    ArrowDown,
+    ArrowUp,
+    Bell,
+    BellOff,
+    BellRing,
+    Hash,
+    Keyboard,
+    Monitor,
+    Moon,
+    Search,
+    SmilePlus,
+    SquarePen,
+    Sun,
+    UserPlus,
+} from '@lucide/vue';
+import type { LucideIcon } from '@lucide/vue';
+import {
+    browse,
+    show,
+} from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { adjacentSlug } from '@/composables/keyboardShortcuts';
+import type { ShortcutId } from '@/composables/keyboardShortcuts';
+import { useAppearance } from '@/composables/useAppearance';
+import { useDialog } from '@/composables/useDialog';
+import { urlForDestination } from '@/composables/useNavPanel';
+import { useShellFocus } from '@/composables/useShellFocus';
+import { useUserMenu } from '@/composables/useUserMenu';
+import { isDndActiveNow } from '@/lib/dnd';
+import { pinUrl } from '@/lib/pinUrl';
+
+/**
+ * How a command names itself. A command that claims a keyboard shortcut
+ * inherits that shortcut's description and renders its keys by lookup, so the
+ * union is what stops a label from growing a second home: the compiler refuses
+ * a `title` beside a `shortcutId`.
+ */
+type CommandNaming =
+    | { shortcutId: ShortcutId; title?: never }
+    | { title: string; shortcutId?: never };
+
+/**
+ * Whether a command is a row in the palette. Everything is, bar the one command
+ * that opens the palette — which must never be a row inside it, and so carries
+ * no icon either. The mirror of {@see ShortcutDefinition.displayOnly}: that is
+ * "listed in the help modal but never dispatched globally", this is "dispatched
+ * globally but never listed in the palette".
+ */
+type CommandPresence =
+    { icon: LucideIcon; hidden?: never } | { hidden: true; icon?: never };
+
+export type CommandDefinition = {
+    /** Unique, untranslated. The row's `value` and its `data-test` suffix. */
+    id: string;
+    /**
+     * Whether to offer this here and now, covering permission and applicability
+     * alike. Synchronous and reading only state already on the wire: the list
+     * highlights its first row on every keystroke, so a row that popped in a
+     * beat late would change what `Enter` runs under the user's fingers.
+     */
+    isAvailable?: () => boolean;
+    run: () => void;
+} & CommandNaming &
+    CommandPresence;
+
+const page = usePage();
+const { focusNotificationRail } = useShellFocus();
+const { updateAppearance } = useAppearance();
+const { resumeNotifications } = useUserMenu();
+
+/**
+ * Jump `delta` channels along the sidebar list from the active one, wrapping at
+ * either end. Does nothing until a team and its channels are loaded.
+ */
+function moveChannel(delta: number): void {
+    const team = page.props.currentTeam;
+
+    if (!team) {
+        return;
+    }
+
+    const activeSlug =
+        (page.props.channel as { slug?: string } | undefined)?.slug ?? null;
+
+    const slug = adjacentSlug(
+        (page.props.channels ?? []).map((channel) => channel.slug),
+        activeSlug,
+        delta,
+    );
+
+    if (slug) {
+        router.visit(show({ team: team.slug, channel: slug }).url);
+    }
+}
+
+/**
+ * Everything the shell can be asked to do, authored once.
+ *
+ * Static and module-scope, which is the property that matters: a test can
+ * import and walk this array without mounting anything, so the guarantee that
+ * no verb is half-wired is total rather than sampled. Every `run` closes over a
+ * module singleton — `useDialog`, `usePage`, `useShellFocus`, `router`,
+ * `pinUrl` — all of which work outside a component instance.
+ *
+ * The cost of that, recorded so it is not rediscovered as a bug: a `run` calls
+ * its composable at *module-evaluation* time, so a verb needing genuinely
+ * per-component state has no way in and would fail silently. Such a verb is not
+ * a command; it is a component's own affair. `commands.test.ts` spies on Vue's
+ * warnings around this module's import to make that cliff loud.
+ */
+export const COMMANDS: readonly CommandDefinition[] = [
+    {
+        id: 'command-palette',
+        shortcutId: 'command-palette',
+        hidden: true,
+        run: () => useDialog('switcher').toggle(),
+    },
+    {
+        id: 'previous-channel',
+        shortcutId: 'previous-channel',
+        icon: ArrowUp,
+        run: () => moveChannel(-1),
+    },
+    {
+        id: 'next-channel',
+        shortcutId: 'next-channel',
+        icon: ArrowDown,
+        run: () => moveChannel(1),
+    },
+    {
+        id: 'focus-notifications',
+        shortcutId: 'focus-notifications',
+        icon: Bell,
+        run: () => focusNotificationRail(),
+    },
+    {
+        id: 'show-shortcuts',
+        shortcutId: 'show-shortcuts',
+        icon: Keyboard,
+        run: () => useDialog('shortcuts').toggle(),
+    },
+    {
+        id: 'new-message',
+        title: 'New message',
+        icon: SquarePen,
+        isAvailable: () => Boolean(page.props.currentTeam),
+        run: () => useDialog('newMessage').open(),
+    },
+    {
+        id: 'browse-channels',
+        title: 'Browse channels',
+        icon: Hash,
+        isAvailable: () => Boolean(page.props.currentTeam),
+        run: () => {
+            const team = page.props.currentTeam;
+
+            if (team) {
+                router.visit(browse(team.slug).url);
+            }
+        },
+    },
+    {
+        /**
+         * Writes the URL and lets the dock's own `watch(() => page.url)` adopt
+         * it, which is the channel a deep link already uses. Calling
+         * `useNavPanel()` here would type-check and do nothing: it hands back
+         * per-instance state, so a module-scope call drives a panel that is not
+         * on screen.
+         */
+        id: 'reminders',
+        title: 'Reminders',
+        icon: AlarmClock,
+        run: () => pinUrl(urlForDestination(page.url, 'reminders')),
+    },
+    {
+        id: 'search',
+        title: 'Search',
+        icon: Search,
+        run: () => pinUrl(urlForDestination(page.url, 'search')),
+    },
+    {
+        id: 'set-status',
+        title: 'Set a status',
+        icon: SmilePlus,
+        run: () => useDialog('status').open(),
+    },
+    {
+        id: 'pause-notifications',
+        title: 'Pause notifications',
+        icon: BellOff,
+        run: () => useDialog('dnd').open(),
+    },
+    {
+        /**
+         * Through the user menu, which already owns this call *and* the error
+         * toast it raises — which is what lets `run` be fire-and-forget without
+         * {@link CommandDefinition} growing a result channel.
+         *
+         * The mutation the catalogue carries is this one rather than *Log out*:
+         * the list highlights its first row as you type, so a mutating verb has
+         * to be cheap to be wrong about. An accidental resume is undone by the
+         * *Pause notifications* row in the same list; a sign-out is not.
+         */
+        id: 'resume-notifications',
+        title: 'Resume notifications',
+        icon: BellRing,
+        isAvailable: () =>
+            isDndActiveNow(
+                page.props.auth?.user.dnd,
+                page.props.auth?.user.timezone,
+            ),
+        run: () => resumeNotifications(),
+    },
+    {
+        /**
+         * Gated because the modal is only *mounted* for a viewer who may
+         * invite ({@see DialogHost}), so an ungated command would flip a ref
+         * with nothing listening — a silent no-op rather than a refusal.
+         */
+        id: 'invite-people',
+        title: 'Invite people',
+        icon: UserPlus,
+        isAvailable: () => page.props.canInviteToCurrentTeam === true,
+        run: () => useDialog('invite').open(),
+    },
+    {
+        id: 'theme-light',
+        title: 'Use light theme',
+        icon: Sun,
+        run: () => updateAppearance('light'),
+    },
+    {
+        id: 'theme-dark',
+        title: 'Use dark theme',
+        icon: Moon,
+        run: () => updateAppearance('dark'),
+    },
+    {
+        id: 'theme-system',
+        title: 'Match system theme',
+        icon: Monitor,
+        run: () => updateAppearance('system'),
+    },
+];
+
+/**
+ * The dispatcher's handler map, derived from {@link COMMANDS} in full — there
+ * is no literal map beside it to drift away from. A claimed command's `run`
+ * *is* the shortcut's handler, so the keyboard and the palette invoke the one
+ * function.
+ */
+export const SHORTCUT_HANDLERS: Partial<Record<ShortcutId, () => void>> =
+    Object.fromEntries(
+        COMMANDS.filter((command) => command.shortcutId !== undefined).map(
+            (command) => [command.shortcutId, command.run],
+        ),
+    );

--- a/resources/js/composables/useAppearance.test.ts
+++ b/resources/js/composables/useAppearance.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { initializeTheme, useAppearance } from '@/composables/useAppearance';
+
+/**
+ * Exactly the surface the module-scope lift moved, and no more: `initializeTheme`
+ * now owns the rehydration that used to sit behind `useAppearance`'s `onMounted`,
+ * which a command's `run` cannot reach from outside a component instance.
+ *
+ * A browser test is structurally blind to this regressing. `initializeTheme`
+ * already painted the right theme at boot without the ref, so dropping or
+ * misordering the rehydration leaves the shell the right colour while
+ * `appearance.value` sits at 'system' and storage says 'dark' — and the symptom
+ * is the wrong radio selected on /settings/appearance, not a wrong-coloured page.
+ */
+/** jsdom has no `matchMedia`; the "system" theme resolves through it. */
+function systemPrefers(scheme: 'dark' | 'light'): void {
+    window.matchMedia = ((query: string) => ({
+        matches: scheme === 'dark',
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+    })) as unknown as typeof window.matchMedia;
+}
+
+describe('useAppearance', () => {
+    beforeEach(() => {
+        systemPrefers('light');
+        localStorage.clear();
+        document.documentElement.classList.remove('dark');
+        useAppearance().appearance.value = 'system';
+    });
+
+    describe('initializeTheme', () => {
+        it('rehydrates the stored appearance into the shared ref', () => {
+            localStorage.setItem('appearance', 'dark');
+
+            initializeTheme();
+
+            expect(useAppearance().appearance.value).toBe('dark');
+        });
+
+        it('paints the stored theme', () => {
+            localStorage.setItem('appearance', 'dark');
+
+            initializeTheme();
+
+            expect(document.documentElement.classList.contains('dark')).toBe(
+                true,
+            );
+        });
+
+        it('leaves the ref on system when nothing is stored', () => {
+            initializeTheme();
+
+            expect(useAppearance().appearance.value).toBe('system');
+        });
+    });
+
+    describe('updateAppearance', () => {
+        it('records the choice in storage, the cookie and the class', () => {
+            useAppearance().updateAppearance('dark');
+
+            expect(localStorage.getItem('appearance')).toBe('dark');
+            expect(document.cookie).toContain('appearance=dark');
+            expect(document.documentElement.classList.contains('dark')).toBe(
+                true,
+            );
+        });
+
+        it('takes the class back off for the light theme', () => {
+            useAppearance().updateAppearance('dark');
+            useAppearance().updateAppearance('light');
+
+            expect(useAppearance().appearance.value).toBe('light');
+            expect(document.documentElement.classList.contains('dark')).toBe(
+                false,
+            );
+        });
+    });
+});

--- a/resources/js/composables/useAppearance.ts
+++ b/resources/js/composables/useAppearance.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { writeClientCookie } from '@/lib/cookies';
 import type { Appearance, ResolvedAppearance } from '@/types';
 
@@ -65,30 +65,35 @@ const handleSystemThemeChange = () => {
     updateTheme(currentAppearance || 'system');
 };
 
+const appearance = ref<Appearance>('system');
+
+/**
+ * Adopt the stored preference at boot: paint it, hold it in {@link appearance}
+ * for the surfaces that show which one is picked, and follow the system theme
+ * from here on. Called once by `app.ts`.
+ *
+ * The rehydration used to sit behind an `onMounted` inside
+ * {@link useAppearance}, which re-read storage for every component that called
+ * the composable and left the shared ref unreachable from module scope — where
+ * the command registry's theme verbs live. One place, once, at boot.
+ */
 export function initializeTheme(): void {
     if (typeof window === 'undefined') {
         return;
     }
 
     const savedAppearance = getStoredAppearance();
+
+    if (savedAppearance) {
+        appearance.value = savedAppearance;
+    }
+
     updateTheme(savedAppearance || 'system');
 
     mediaQuery()?.addEventListener('change', handleSystemThemeChange);
 }
 
-const appearance = ref<Appearance>('system');
-
 export function useAppearance(): UseAppearanceReturn {
-    onMounted(() => {
-        const savedAppearance = localStorage.getItem(
-            'appearance',
-        ) as Appearance | null;
-
-        if (savedAppearance) {
-            appearance.value = savedAppearance;
-        }
-    });
-
     const resolvedAppearance = computed<ResolvedAppearance>(() => {
         if (appearance.value === 'system') {
             return prefersDark() ? 'dark' : 'light';

--- a/resources/js/composables/useShellShortcuts.test.ts
+++ b/resources/js/composables/useShellShortcuts.test.ts
@@ -1,11 +1,16 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { App } from 'vue';
-import { createApp, h, reactive } from 'vue';
+import { createApp, h } from 'vue';
 
 const { visit } = vi.hoisted(() => ({ visit: vi.fn() }));
 
-const page = reactive<{ props: Record<string, unknown> }>({ props: {} });
+/**
+ * Hoisted, because the registry the shortcuts are derived from calls
+ * `usePage()` at module-evaluation time — a plain `const` here would still be
+ * in its temporal dead zone by the time the mock is first asked for it.
+ */
+const page = vi.hoisted(() => ({ props: {} as Record<string, unknown> }));
 
 vi.mock('@inertiajs/vue3', () => ({
     router: { visit },

--- a/resources/js/composables/useShellShortcuts.ts
+++ b/resources/js/composables/useShellShortcuts.ts
@@ -1,59 +1,14 @@
-import { router, usePage } from '@inertiajs/vue3';
-import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
-import { adjacentSlug } from '@/composables/keyboardShortcuts';
-import { useDialog } from '@/composables/useDialog';
+import { SHORTCUT_HANDLERS } from '@/composables/commands';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
-import { useShellFocus } from '@/composables/useShellFocus';
 
 /**
- * The app-wide shortcuts the workspace shell answers, for the lifetime of the
- * shell that binds them.
+ * Bind the app-wide shortcuts for the lifetime of the shell that mounts them.
  *
- * They live together because they are all *shell* gestures — two open a dialog
- * the shell mounts, two walk the sidebar the shell renders, one hands the caret
- * to the shell's notification rail — and because keeping the registry's handler
- * map in one place is what stops a shortcut from being half-wired: declared in
- * `keyboardShortcuts.ts`, documented in the help modal, and bound to nothing.
- *
- * What each shortcut *is* still belongs to {@see SHORTCUTS}; this is only what
- * the shell does when one fires.
+ * What each shortcut *is* belongs to {@see SHORTCUTS}; what it *does* belongs to
+ * {@see COMMANDS}, which owns the handler and offers the same verb as a palette
+ * row. Nothing is written twice, so a shortcut cannot be declared, documented in
+ * the help modal, and bound to nothing.
  */
 export function useShellShortcuts(): void {
-    const page = usePage();
-    const { focusNotificationRail } = useShellFocus();
-    const switcher = useDialog('switcher');
-    const shortcuts = useDialog('shortcuts');
-
-    /**
-     * Jump `delta` channels along the sidebar list from the active one, wrapping
-     * at either end. Does nothing until a team and its channels are loaded.
-     */
-    function moveChannel(delta: number): void {
-        const team = page.props.currentTeam;
-
-        if (!team) {
-            return;
-        }
-
-        const activeSlug =
-            (page.props.channel as { slug?: string } | undefined)?.slug ?? null;
-
-        const slug = adjacentSlug(
-            (page.props.channels ?? []).map((channel) => channel.slug),
-            activeSlug,
-            delta,
-        );
-
-        if (slug) {
-            router.visit(show({ team: team.slug, channel: slug }).url);
-        }
-    }
-
-    useKeyboardShortcuts({
-        'command-palette': () => switcher.toggle(),
-        'previous-channel': () => moveChannel(-1),
-        'next-channel': () => moveChannel(1),
-        'focus-notifications': () => focusNotificationRail(),
-        'show-shortcuts': () => shortcuts.toggle(),
-    });
+    useKeyboardShortcuts(SHORTCUT_HANDLERS);
 }


### PR DESCRIPTION
Closes #1219.

## What

One static, module-scope `readonly CommandDefinition[]` in `resources/js/composables/commands.ts`, holding the sixteen entries the issue specifies. A command may claim a `ShortcutId`, in which case it inherits that shortcut's title and *becomes* its handler — so `useShellShortcuts`' parallel literal handler map is deleted and derived from the registry **in full**, with no residual map beside it.

Nothing renders in this child. The registry exists, the keyboard already runs off it, and it is proven in Vitest. The palette starts reading it in #1220.

## Why

A verb's identity and its behaviour lived in different places: the palette's one verb was hardcoded into its template, and the shortcut handlers sat in a literal map maintained by hand beside the declarative table describing them. Nothing stopped one drifting from the other.

## How

- `CommandDefinition` encodes *one string, one home* in the type: the `{ shortcutId } | { title }` union means the compiler refuses a `title` on a command that claims a shortcut. A second union makes the one hidden entry (`command-palette`, which must never be a row inside the palette it opens) carry no icon.
- `run: () => void` closes over module singletons. The two dock verbs go through `pinUrl(urlForDestination(...))` rather than `useNavPanel()`, whose per-instance state a module-scope call would silently drive off-screen; *Resume notifications* goes through `useUserMenu`, which already owns the call and its error toast.
- **The appearance lift (§9):** `useAppearance()` called `onMounted()`, which warns outside a component instance. That block moves into `initializeTheme()`, which `app.ts` already calls at boot. This is a correctness improvement in its own right — the module-scope ref used to re-hydrate from `localStorage` on every component that called the composable.

## How tested

`resources/js/composables/commands.test.ts`, beside the registry it guards:

- **The derivation guard** — every dispatchable (`!displayOnly`) `ShortcutId` is claimed by exactly one command, and no command claims a display-only one. This is the acceptance criterion: total rather than sampled.
- **Module-scope hygiene** — a `console.warn` spy around a fresh import of the registry. Because `COMMANDS` is module-scope, *importing the file is what calls the composables*, so one test makes the entire silent-cliff class loud for every entry ever added. Mutation-checked: re-introducing the `onMounted` the lift removed turns it red.
- **No `isAvailable` throws on a bare page** — a predicate reaching one level too deep would not hide its row, it would kill the render of the whole list. Mutation-checked: `currentTeam.slug` where `currentTeam` was meant fails the test by name.
- Per-verb only where an argument can be silently wrong: the two `?nav=` pins, *Browse channels*, *Resume notifications*, and the theme trio. One collective assertion, driven off the array, that each dialog-opening command names a real `ShellDialog` and flips its singleton (against the real `useDialog`, not a mock).

`resources/js/composables/useAppearance.test.ts` covers exactly the surface the lift moves, and no more. A browser test is structurally blind to this regressing: `initializeTheme` already painted correctly without the ref, so dropping the rehydration leaves the shell the right colour while the wrong radio is selected on `/settings/appearance`.

`useShellShortcuts.test.ts` keeps its four behavioural tests unchanged — they are the proof the derivation did not change what the keyboard does. Its `page` double is now hoisted, because the registry calls `usePage()` at module-evaluation time and a plain `const` would still be in its temporal dead zone.

## i18n

Seven of the eleven new titles already existed in `lang/fr.json` and are reused rather than near-duplicated. Four are added: *Resume notifications*, *Use light theme*, *Use dark theme*, *Match system theme*. Per §7 the registry stores untranslated English source strings and the renderer wraps them — calling `t()` on a module-scope array would freeze the locale, which is the bug this repo hit in #776.

No docs change: nothing here is operator-facing.

## Gates

Backend `Total: 100.0 %`; Vitest 2667 passed; lint, format, types and build green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788390802&installation_model_id=428379&pr_number=1228&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1228&signature=cd6fbe18cfb253c41885302da939913f2f0691115349b555a594a85305d8b454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->