### PR TITLE
test: prove the palette's dialog, predicate and theme seams in the live shell

### DIFF
--- a/tests/Browser/CommandPaletteTest.php
+++ b/tests/Browser/CommandPaletteTest.php
@@ -14,10 +14,60 @@ use App\Models\MessageReminder;
  * does it cross a seam already proven here? — and writes a test only when the
  * answer is no. Four tests in one file is that rule, written down as code.
  *
- * The `?nav=` pin is the seam this child owns; the rest arrive with the next one.
+ * So, before adding one: does the verb claim a `ShortcutId`? Then nothing at
+ * all — the derivation guard covers it and the shortcut suite is its behaviour.
+ * Does it open a dialog, pin a `?nav=` destination, carry an `isAvailable`, or
+ * write the theme? Then a unit test only: those four seams are proven below.
+ * Does it do something none of the four covers? That is a new seam, and it earns
+ * the fifth test here.
+ *
  * The selectors stay `@quick-switcher-*`: the surface was renamed, its 96
  * opaque selectors were deliberately not.
  */
+
+/**
+ * Whether focus sits somewhere inside the dialog holding the given control.
+ *
+ * Read once the palette has gone rather than while it is going: the palette's
+ * own focus restore fires on its teardown (see `DialogFocusRestoreTest`), so a
+ * reading taken before that would pass on a shell that yanks focus back to the
+ * trigger a frame later.
+ */
+function focusIsInsideTheDialogHolding(string $test): string
+{
+    return <<<JS
+    (() => {
+        const dialog = document
+            .querySelector('[data-test="{$test}"]')
+            ?.closest('[role="dialog"]');
+
+        return Boolean(dialog?.contains(document.activeElement));
+    })()
+    JS;
+}
+
+/**
+ * A script resolving once the document element carries the dark palette.
+ *
+ * The write is synchronous inside `run`, but the click that reaches it is not:
+ * `assertScript` is a one-shot evaluation with no retry (#947), so the frames
+ * between the row being pressed and reka answering its `select` are polled out
+ * rather than slept through.
+ */
+function documentGoesDark(): string
+{
+    return <<<'JS'
+    (async () => {
+        const dark = () => document.documentElement.classList.contains('dark');
+
+        for (let frame = 0; frame < 120 && ! dark(); frame++) {
+            await new Promise(requestAnimationFrame);
+        }
+
+        return dark();
+    })()
+    JS;
+}
 test('a command pinning a destination lands it on the current route', function (): void {
     ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
 
@@ -43,4 +93,77 @@ test('a command pinning a destination lands it on the current route', function (
         // later, so settle before reading the URL (#937).
         ->assertScript(queryParamSettles('nav', 'reminders'), true)
         ->assertQueryStringHas('nav', 'reminders');
+});
+
+test('a command opening a dialog leaves focus inside it, not back on the trigger', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@quick-switcher-trigger')
+        ->click('@quick-switcher-new-message')
+        // Two entries of one `DialogHost` mid-transition: the palette dismisses
+        // as the picker mounts in its place. Waiting for the palette to be gone
+        // is what puts its focus restore behind us — the reading below is of the
+        // settled shell, not of the frame the handover happened on.
+        ->assertNotPresent('@quick-switcher-input')
+        ->assertPresent('@new-dm-input')
+        ->assertScript(geometrySettles(elementBox('[data-test="new-dm-input"]')), true)
+        ->assertScript(focusIsInsideTheDialogHolding('new-dm-input'), true);
+});
+
+test('the availability predicates read prop paths a real page carries', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Four rows, three distinct prop paths: `currentTeam` for the first two,
+    // `auth.user.dnd` for the resume, `canInviteToCurrentTeam` for the invite.
+    // All three fail the same silent way — a path that is not there reads
+    // `undefined`, falls to false, and the row vanishes for everyone — and a
+    // unit stub written from the same wrong path agrees with it. Only a real
+    // page can say the strings are right.
+    $alice->forceFill(['dnd_until' => now()->addMinutes(30)])->save();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@quick-switcher-trigger')
+        ->assertPresent('@quick-switcher-new-message')
+        ->assertPresent('@quick-switcher-browse-channels')
+        ->assertPresent('@quick-switcher-invite-people')
+        ->assertPresent('@quick-switcher-resume-notifications')
+        // The other half of the gate: the modal is mounted only for a viewer who
+        // may invite, so a row that renders has to reach something listening.
+        ->click('@quick-switcher-invite-people')
+        ->assertPresent('@invite-submit');
+
+    // The opposite polarity on the same page, so a predicate stuck true is told
+    // apart from one stuck false: a plain member, with nothing paused.
+    signInThroughBrowser($bob)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@quick-switcher-trigger')
+        ->assertPresent('@quick-switcher-new-message')
+        ->assertPresent('@quick-switcher-browse-channels')
+        // Absent, never disabled: the list is the set of things this viewer can
+        // do rather than a list of things they cannot.
+        ->assertNotPresent('@quick-switcher-invite-people')
+        ->assertNotPresent('@quick-switcher-resume-notifications');
+});
+
+test('a theme command repaints the document', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // One row of the trio, because light and system are this code path with a
+    // different argument — and *system* answers to the harness's
+    // `prefers-color-scheme`, which is a Playwright question rather than a
+    // palette one. Nothing else in the repo switches appearance through the UI:
+    // every audit wanting dark forces it (see `switchToDarkTheme()`), which is
+    // why the one real switch earns a browser test.
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@quick-switcher-trigger')
+        ->click('@quick-switcher-theme-dark')
+        ->assertScript(documentGoesDark(), true);
 });


### PR DESCRIPTION
Closes #1221.

The last child of #1217. The registry is proven in Vitest and the list shape in the component suite; three things only the live shell can show were not. This adds them to `tests/Browser/CommandPaletteTest.php`, beside the `?nav=` pin the previous child moved there.

## What

**1. A dialog opens while the palette dismisses** — represented by *New message*. Asserts the palette is gone, the picker is mounted, and focus is inside it. The palette-gone assertion is ordered first on purpose: the palette's own focus restore fires on its teardown, so a reading taken before that would pass on a shell that yanks focus back to `@quick-switcher-trigger` a frame later.

**2. Predicates reading real prop paths** — one test, two sign-ins. An owner with DND running sees *New message*, *Browse channels*, *Invite people* and *Resume notifications*, and clicking *Invite people* mounts the invite modal (the gate's other half — the modal is only mounted for a viewer who may invite). A plain member with nothing paused sees the first two and neither of the last two. Both polarities, so a predicate stuck `false` is told apart from one stuck `true`.

Widened from permission deliberately: four rows read three distinct prop paths, all three fail the same silent way (wrong path -> `undefined` -> falsy -> the row vanishes for everyone), and a unit stub written from the same wrong path agrees with it.

**3. The theme repaint** — run *Use dark theme*, assert `documentElement` carries `dark`. One row of the trio, no reload, and no walk to `/settings/appearance`. This is the first UI-driven appearance switch in the repo: every other test wanting dark forces it via `switchToDarkTheme()`.

The file header now carries the rule itself, since the file *is* the rule: claims a `ShortcutId` -> no test; opens a dialog / pins a `?nav=` / carries an `isAvailable` / writes the theme -> unit only; anything else -> a new seam, and the fifth test here.

## How tested

`sail bin pest tests/Browser/CommandPaletteTest.php` — 4 passed, 25 assertions.

Mutation-checked rather than assumed green: a wrong `canInviteToCurrentTeam` prop path turns test 2 red, and `theme-dark` calling `updateAppearance('light')` turns test 3 red. Test 1 resisted both mutations I tried (reordering `runCommand`, disabling the `inert` mirror) — reka's focus trap bounces any escape back into the modal, so that assertion's teeth are "the picker mounted and holds focus", which it does prove.

`composer ci:check` green, and a separate raw coverage run reports `Total: 100.0 %`.

## i18n / docs

Neither applies: the diff is one browser-test file. No user-facing copy, no operator-facing change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788435861&installation_model_id=428379&pr_number=1230&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1230&signature=c92fe635e25aecfa5ba8daee020b42f7947b059c3da58dce4246ad3c76ad5a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->