### PR TITLE
feat: point a slash-command query at the composer

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -580,6 +580,7 @@
   "Ready to download": "Prêt à télécharger",
   "Recent activity": "Activité récente",
   "Recent shows before you type · commands rank as you type": "Les récents s'affichent avant la saisie · les commandes se classent au fil de la saisie",
+  "/:name is a message command. Type it in a channel to use it.": "/:name est une commande de message. Tapez-la dans un canal pour l’utiliser.",
   "Reconnected — 1 queued message sent, you're caught up.": "Reconnecté — 1 message en attente envoyé, vous êtes à jour.",
   "Reconnected — :count queued messages sent, you're caught up.": "Reconnecté — :count messages en attente envoyés, vous êtes à jour.",
   "Reconnecting": "Reconnexion",

--- a/resources/js/components/CommandPalette.doubles.ts
+++ b/resources/js/components/CommandPalette.doubles.ts
@@ -14,6 +14,25 @@ import type { PersonRef } from '@/types/people';
  * through live beside this, in `CommandPalette.stubs`.
  */
 
+/**
+ * The workspace-wide props the palette reads that are nobody's in particular.
+ * The slash-command manifest rides every workspace page unscoped to a team, so
+ * the palette can read it even where no composer is on screen; mutable, because
+ * emptying it or taking it away is what turns the hint off.
+ */
+export const workspace = {
+    slashCommands: undefined as App.Data.SlashCommandData[] | undefined,
+};
+
+/** The manifest a real workspace page carries, in the order the registry lists. */
+const SHIPPED_SLASH_COMMANDS: App.Data.SlashCommandData[] = [
+    'gif',
+    'poll',
+    'shrug',
+    'tableflip',
+    'unflip',
+].map((name) => ({ name, description: name, argumentHint: null }));
+
 /** The viewer and the route, as `usePage()` reports them. */
 export const viewer = {
     url: '/t/acme/c/general',
@@ -63,6 +82,9 @@ const page = {
         },
         get canInviteToCurrentTeam(): boolean {
             return viewer.canInvite;
+        },
+        get slashCommands(): App.Data.SlashCommandData[] | undefined {
+            return workspace.slashCommands;
         },
         customEmojis: {},
         userGroups: [],
@@ -160,6 +182,7 @@ export function searchActionDouble(): Record<string, unknown> {
 
 /** Reset every double's state between tests, so a suite reads in any order. */
 export function resetDoubles(): void {
+    workspace.slashCommands = SHIPPED_SLASH_COMMANDS;
     viewer.url = '/t/acme/c/general';
     viewer.timezone = null;
     viewer.canInvite = false;

--- a/resources/js/components/CommandPalette.slashCommands.test.ts
+++ b/resources/js/components/CommandPalette.slashCommands.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Covers the one line the palette holds below its list when a query plainly
+ * names a slash command: when it fires, what it reads, what it takes the place
+ * of below the breakpoint, and — the property the whole shape exists for — that
+ * it is a paragraph outside the list rather than anything `Enter` can reach.
+ *
+ * Its own file rather than the destinations suite because that suite is at the
+ * line budget; the preamble below is the same one every palette suite carries.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble } = await import('./CommandPalette.doubles');
+
+    return inertiaDouble();
+});
+
+vi.mock('@lucide/vue', async () => {
+    const { lucideDouble } = await import('./CommandPalette.stubs');
+
+    return lucideDouble();
+});
+
+vi.mock('reka-ui', async () => {
+    const { rekaDouble } = await import('./CommandPalette.stubs');
+
+    return rekaDouble();
+});
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/ChannelController',
+    async () => {
+        const { channelActionDouble } =
+            await import('./CommandPalette.doubles');
+
+        return channelActionDouble();
+    },
+);
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/SearchController',
+    async () => {
+        const { searchActionDouble } = await import('./CommandPalette.doubles');
+
+        return searchActionDouble();
+    },
+);
+
+vi.mock('@/components/PresenceDot.vue', async () => {
+    const { presenceDotDouble } = await import('./CommandPalette.stubs');
+
+    return presenceDotDouble();
+});
+
+vi.mock('@/components/SafeHtml.vue', async () => {
+    const { safeHtmlDouble } = await import('./CommandPalette.stubs');
+
+    return safeHtmlDouble();
+});
+
+vi.mock('@/components/ui/button', async () => {
+    const { buttonDouble } = await import('./CommandPalette.stubs');
+
+    return buttonDouble();
+});
+
+vi.mock('@/components/ui/command', async () => {
+    const { commandDouble } = await import('./CommandPalette.stubs');
+
+    return commandDouble();
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { dialogDouble } = await import('./CommandPalette.stubs');
+
+    return dialogDouble();
+});
+
+vi.mock('@/components/ui/sidebar', async () => {
+    const { sidebarDouble } = await import('./CommandPalette.doubles');
+
+    return sidebarDouble();
+});
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { isMobileDouble } = await import('./CommandPalette.doubles');
+
+    return isMobileDouble();
+});
+
+vi.mock('@/composables/useMessageSearch', async () => {
+    const { messageSearchDouble } = await import('./CommandPalette.doubles');
+
+    return messageSearchDouble();
+});
+
+vi.mock('@/composables/useOpenDirectMessage', async () => {
+    const { openDirectMessageDouble } =
+        await import('./CommandPalette.doubles');
+
+    return openDirectMessageDouble();
+});
+
+vi.mock('@/lib/pinUrl', async () => {
+    const { pinUrlDouble } = await import('./CommandPalette.doubles');
+
+    return pinUrlDouble();
+});
+
+import {
+    find,
+    isMobile,
+    mountSwitcher,
+    resetDoubles,
+    type,
+    unmountAll,
+    workspace,
+} from './CommandPalette.doubles';
+import CommandPalette from './CommandPalette.vue';
+
+/** The line the slot below the list holds, or null when it holds nothing. */
+function hint(host: HTMLElement): string | null {
+    return (
+        find(host, 'quick-switcher-slash-command-hint')?.textContent?.trim() ??
+        null
+    );
+}
+
+beforeEach(() => {
+    resetDoubles();
+});
+
+afterEach(() => {
+    unmountAll();
+});
+
+describe('the slash-command hint', () => {
+    it('names where a query naming a slash command actually leads', async () => {
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, 'gif');
+
+        expect(hint(host)).toBe(
+            '/gif is a message command. Type it in a channel to use it.',
+        );
+    });
+
+    it('reads the same query with its leading slash typed', async () => {
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, '/gif');
+
+        expect(hint(host)).toBe(
+            '/gif is a message command. Type it in a channel to use it.',
+        );
+    });
+
+    it('matches the manifest whatever the case, and names it back in its own', async () => {
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, 'TableFlip');
+
+        expect(hint(host)).toBe(
+            '/tableflip is a message command. Type it in a channel to use it.',
+        );
+    });
+
+    it('stays silent for a prefix of a command', async () => {
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, 'g');
+        expect(hint(host)).toBeNull();
+
+        // The whole point of matching outright: someone typing towards a
+        // channel called #giraffes is not asking about /gif.
+        await type(host, 'gi');
+        expect(hint(host)).toBeNull();
+    });
+
+    it('stays silent for a query naming no command at all', async () => {
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, 'quokka');
+
+        expect(hint(host)).toBeNull();
+    });
+
+    it('is disabled outright by an empty manifest', async () => {
+        workspace.slashCommands = [];
+
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, 'gif');
+
+        expect(hint(host)).toBeNull();
+    });
+
+    it('is disabled outright by an absent manifest', async () => {
+        workspace.slashCommands = undefined;
+
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, 'gif');
+
+        expect(hint(host)).toBeNull();
+    });
+
+    it('takes the standing hint’s place below the breakpoint', async () => {
+        isMobile.value = true;
+
+        const { host } = mountSwitcher(CommandPalette);
+
+        expect(find(host, 'quick-switcher-ranking-hint')).not.toBeNull();
+
+        await type(host, 'gif');
+
+        // One line in that slot, always.
+        expect(hint(host)).not.toBeNull();
+        expect(find(host, 'quick-switcher-ranking-hint')).toBeNull();
+    });
+
+    it('renders below the list rather than in it, as nothing selectable', async () => {
+        const { host } = mountSwitcher(CommandPalette);
+
+        await type(host, 'gif');
+
+        const line = find(host, 'quick-switcher-slash-command-hint');
+
+        // In no group, in no sort, and unhighlightable — so it can never move
+        // what Enter runs under the hands of whoever asked for it.
+        expect(line?.closest('[data-slot="command-list"]')).toBeNull();
+        expect(line?.tagName).toBe('P');
+    });
+});

--- a/resources/js/components/CommandPalette.stubs.ts
+++ b/resources/js/components/CommandPalette.stubs.ts
@@ -120,12 +120,29 @@ const commandGroup = defineComponent({
             ),
 });
 
+/**
+ * The list, marked the way the real one marks its listbox — which is how a suite
+ * tells a row inside it from a line the palette renders below it.
+ */
+const commandList = defineComponent({
+    name: 'CommandListStub',
+    inheritAttrs: false,
+    setup:
+        (_props, { attrs, slots }) =>
+        () =>
+            h(
+                'div',
+                { ...attrs, 'data-slot': 'command-list' },
+                slots.default?.(),
+            ),
+});
+
 export function commandDouble(): Record<string, Component> {
     return {
         Command: passthrough('div'),
         CommandGroup: commandGroup,
         CommandItem: commandItem,
-        CommandList: passthrough('div'),
+        CommandList: commandList,
     };
 }
 

--- a/resources/js/components/CommandPalette.vue
+++ b/resources/js/components/CommandPalette.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { router } from '@inertiajs/vue3';
+import { router, usePage } from '@inertiajs/vue3';
 import { computed, watch } from 'vue';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import SwitcherChannels from '@/components/switcher/SwitcherChannels.vue';
@@ -80,6 +80,26 @@ const peopleResults = computed(() =>
  * disappears with the state it is gated on.
  */
 const commandResults = computed(() => rankCommands(trimmedQuery.value));
+
+const page = usePage();
+
+/**
+ * The slash command the query plainly names, or null. Slash commands are never
+ * rows here — their context requires a channel and every one of their results is
+ * a message — so a query naming one is answered by a line saying where it lives.
+ *
+ * Exact equality only, on the trimmed query with at most one leading `/` gone.
+ * Prefix matching would pop the line on `g`; matching outright means it is
+ * silent for everyone who was not already asking for a slash command.
+ */
+const namedSlashCommand = computed<string | null>(
+    () =>
+        page.props.slashCommands?.find(
+            (command) =>
+                command.name.toLowerCase() ===
+                trimmedQuery.value.replace(/^\//, '').toLowerCase(),
+        )?.name ?? null,
+);
 
 /** The groups whose place in the list the query decides. */
 type RankedGroup = 'channels' | 'people' | 'commands';
@@ -224,11 +244,30 @@ function runCommand(command: PaletteCommand): void {
                         @see-all="seeAllResults"
                     />
                 </CommandList>
+                <!-- Where a query that names a slash command actually leads. A
+                     plain paragraph rather than a row, so it sits in no group,
+                     in no sort, and cannot move what Enter runs — the same
+                     construction the "No messages match" line has always used.
+                     Below the breakpoint it takes the standing hint's place:
+                     one line in this slot, always. -->
+                <p
+                    v-if="namedSlashCommand !== null"
+                    data-test="quick-switcher-slash-command-hint"
+                    class="shrink-0 px-4 pt-2.5 pb-3 text-center text-[11.5px] text-muted-foreground"
+                >
+                    {{
+                        $t(
+                            '/:name is a message command. Type it in a channel to use it.',
+                            { name: namedSlashCommand },
+                        )
+                    }}
+                </p>
                 <!-- The design's standing explanation of the empty-query list:
                      it doubles as the overlay's ranking hint, so it stays put
                      rather than living inside the scrolling results. -->
                 <p
-                    v-if="isMobile"
+                    v-else-if="isMobile"
+                    data-test="quick-switcher-ranking-hint"
                     class="shrink-0 px-4 pt-2.5 pb-3 text-center text-[11.5px] text-muted-foreground"
                 >
                     {{


### PR DESCRIPTION
Closes #1222. Part of the [command palette epic](https://github.com/deskhq/the-desk/issues/1217); the list-shape child (#1229) it was blocked on has landed.

## What

The palette's placeholder invites you to *run a command*, but slash commands are never rows here: their context requires a channel and every one of their results is a message, while the palette opens from anywhere. So someone typing `gif` got no channels, no people, no commands, and a Messages group answering a question they did not ask.

A query that plainly names a slash command now gets **one non-selectable line below the list**:

> `/gif is a message command. Type it in a channel to use it.`

## How

- **Exact match only**, against `page.props.slashCommands[].name` — the manifest is already shared unscoped on every workspace page, so nothing is added server-side and `app/SlashCommands/` is untouched. The trimmed query has at most one leading `/` stripped and is compared case-insensitively. Prefix matching was rejected: it would pop the line on `g`.
- **An absent or empty manifest disables it outright**, mirroring how it already disables the composer's `/` menu.
- **It cannot become an `Enter` hazard.** It is a plain `<p>` outside `CommandList`, so it is in no group, in no sort and unhighlightable — the same construction the *"No messages match"* line has always used. Nothing is registered in the command registry; a paragraph naming a command is not the command appearing.
- **Placement** is the slot below the list, where the mobile standing hint lives; below the breakpoint it takes that hint's place, so the slot holds one line either way.
- Messages is untouched: `gif` shows the hint *and* *"No messages match"*, which is established behaviour rather than a new state.

## Testing

Vitest only, per the issue — this is not a new seam: it renders no `CommandItem`, crosses no boundary, and its predicate reads the same `page.props` path shape the four `isAvailable`s already read, which `CommandPaletteTest.php` proves. Nine assertions in a new `CommandPalette.slashCommands.test.ts` (its own file because the destinations suite is at the 400-line `max-lines` cap): the exact match, the leading-slash strip, case-insensitivity, prefix and no-match silence, the empty and absent manifest disables, the mobile replacement, and that the line renders outside the list as a `<p>`.

Mutation-checked: swapping the predicate for prefix matching turns three of them red.

Also verified live in the worktree (headless): the line renders below the list with the manifest the registry actually serves, and its muted copy clears AA in both themes (5.68:1 light, 5.70:1 dark).

## i18n / docs

One new key with its `lang/fr.json` counterpart. No operator-facing change, so no `docs/` update.

## Gates

`sail composer test` green with `Total: 100.0 %`; `lint:check`, `format:check`, `types:check`, `test:js` (2686 passing) and `build` all green. Local CodeRabbit against `develop`: 0 findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788438895&installation_model_id=428379&pr_number=1231&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1231&signature=ac1cb28307bd802e0d644478b40d339053b9e56654652d5463b0d1b6e2c37192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->