### PR TITLE
feat: add Create a channel as a palette command

### DIFF
--- a/resources/js/components/ChannelEmptyState.test.ts
+++ b/resources/js/components/ChannelEmptyState.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import { useDialog } from '@/composables/useDialog';
+import type { Channel } from '@/types';
+
+/**
+ * The first-run welcome's "Create your first channel" card, which used to be a
+ * trigger wrapped in the create modal and is now a plain button onto the shell's
+ * singleton (#1223). The gate came with it: the modal declining to render is
+ * what hid the card from a viewer the workspace policy shuts out, and unpicked
+ * from that wrapper the welcome owes the reading itself.
+ */
+const page = vi.hoisted(() => ({ props: {} as Record<string, unknown> }));
+
+vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
+
+vi.mock('@lucide/vue', () => ({
+    Send: { render: () => h('svg') },
+    UserPlus: { render: () => h('svg') },
+}));
+
+vi.mock('@/components/InviteMemberModal.vue', () => ({
+    default: defineComponent({ setup: () => () => h('div') }),
+}));
+
+vi.mock('@/composables/useOnboardingTour', () => ({
+    useOnboardingTour: () => ({ open: vi.fn() }),
+}));
+
+import ChannelEmptyState from './ChannelEmptyState.vue';
+
+let app: App | null = null;
+
+/** A fresh #general for a viewer who has not finished onboarding: the welcome. */
+function seed(overrides: Record<string, unknown> = {}): void {
+    page.props = {
+        auth: { user: { onboarding_completed_at: null } },
+        currentTeam: { id: 't1', slug: 'acme' },
+        canInviteToCurrentTeam: false,
+        invitableRoles: [],
+        creatableChannelVisibilities: ['public', 'private'],
+        ...overrides,
+    };
+}
+
+function mountState(): HTMLElement {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    app = createApp({
+        render: () =>
+            h(ChannelEmptyState, {
+                channel: { slug: 'general', name: 'general' } as Channel,
+                isSelfDm: false,
+                teamName: 'Acme',
+            }),
+    });
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(host);
+
+    return host;
+}
+
+beforeEach(() => {
+    seed();
+    useDialog('createChannel').close();
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+it('opens the create form the shell mounts', () => {
+    const host = mountState();
+
+    host.querySelector<HTMLElement>(
+        '[data-test="welcome-create-channel"]',
+    )!.click();
+
+    expect(useDialog('createChannel').isOpen.value).toBe(true);
+});
+
+it('withdraws the card from a viewer the workspace policy shuts out', () => {
+    seed({ creatableChannelVisibilities: [] });
+
+    const host = mountState();
+
+    expect(
+        host.querySelector('[data-test="welcome-create-channel"]'),
+    ).toBeNull();
+    // The rest of the welcome stands: it is one card that goes, not the moment.
+    expect(
+        host.querySelector('[data-test="workspace-welcome"]'),
+    ).not.toBeNull();
+    expect(
+        host.querySelector('[data-test="welcome-post-message"]'),
+    ).not.toBeNull();
+});
+
+it('stands the plain empty state in once the viewer has been onboarded', () => {
+    seed({
+        auth: { user: { onboarding_completed_at: '2026-01-01T00:00:00Z' } },
+    });
+
+    const host = mountState();
+
+    expect(host.querySelector('[data-test="workspace-welcome"]')).toBeNull();
+    expect(
+        host.querySelector('[data-test="welcome-create-channel"]'),
+    ).toBeNull();
+});

--- a/resources/js/components/ChannelEmptyState.vue
+++ b/resources/js/components/ChannelEmptyState.vue
@@ -2,11 +2,12 @@
 import { usePage } from '@inertiajs/vue3';
 import { Send, UserPlus } from '@lucide/vue';
 import { computed, ref } from 'vue';
-import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import { Button } from '@/components/ui/button';
+import { useDialog } from '@/composables/useDialog';
 import { useOnboardingTour } from '@/composables/useOnboardingTour';
 import { useTranslations } from '@/composables/useTranslations';
+import { canCreateChannel } from '@/lib/channelCreation';
 import { groupDmMastheadName } from '@/lib/groupDm';
 import type { Channel } from '@/types';
 
@@ -15,7 +16,6 @@ const props = defineProps<{
     /** Whether the open DM is the viewer's own space, tuning the empty-state copy. */
     isSelfDm: boolean;
     teamName: string;
-    teamSlug: string;
 }>();
 
 const emit = defineEmits<{
@@ -36,6 +36,15 @@ const showWelcome = computed(
     () =>
         props.channel.slug === 'general' &&
         page.props.auth.user.onboarding_completed_at == null,
+);
+
+/**
+ * The welcome's "Create your first channel" action opens the shell's create
+ * dialog, on the same policy reading that gates the sidebar's "+".
+ */
+const createChannelDialog = useDialog('createChannel');
+const canCreate = computed(() =>
+    canCreateChannel(page.props.creatableChannelVisibilities),
 );
 
 /**
@@ -100,33 +109,33 @@ const conversationName = computed(() =>
             </p>
 
             <div class="mt-7 flex w-full flex-col gap-2.5">
-                <CreateChannelModal :team-slug="props.teamSlug">
-                    <Button
-                        variant="unstyled"
-                        size="none"
-                        type="button"
-                        data-test="welcome-create-channel"
-                        class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
+                <Button
+                    v-if="canCreate"
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="welcome-create-channel"
+                    class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
+                    @click="createChannelDialog.open()"
+                >
+                    <span
+                        class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-[16px] font-semibold text-brass-fill-foreground"
+                        >#</span
                     >
+                    <span class="flex flex-1 flex-col">
                         <span
-                            class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-[16px] font-semibold text-brass-fill-foreground"
-                            >#</span
+                            class="text-[14.5px] font-semibold text-foreground"
+                            >{{ $t('Create your first channel') }}</span
                         >
-                        <span class="flex flex-1 flex-col">
-                            <span
-                                class="text-[14.5px] font-semibold text-foreground"
-                                >{{ $t('Create your first channel') }}</span
-                            >
-                            <span class="text-[12.5px] text-muted-foreground">{{
-                                $t('Group conversations by topic or project')
-                            }}</span>
-                        </span>
-                        <span
-                            class="inline-flex h-9 items-center rounded-full bg-primary px-4 text-[13px] font-semibold text-primary-foreground"
-                            >{{ $t('Create') }}</span
-                        >
-                    </Button>
-                </CreateChannelModal>
+                        <span class="text-[12.5px] text-muted-foreground">{{
+                            $t('Group conversations by topic or project')
+                        }}</span>
+                    </span>
+                    <span
+                        class="inline-flex h-9 items-center rounded-full bg-primary px-4 text-[13px] font-semibold text-primary-foreground"
+                        >{{ $t('Create') }}</span
+                    >
+                </Button>
 
                 <Button
                     v-if="canInviteToCurrentTeam"

--- a/resources/js/components/CommandPalette.stubs.ts
+++ b/resources/js/components/CommandPalette.stubs.ts
@@ -46,6 +46,7 @@ export function lucideDouble(): Record<string, Component> {
             'Keyboard',
             'Monitor',
             'Moon',
+            'Plus',
             'Search',
             'SmilePlus',
             'SquarePen',

--- a/resources/js/components/CreateChannelModal.test.ts
+++ b/resources/js/components/CreateChannelModal.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { App } from 'vue';
-import { createApp, defineComponent, h, nextTick } from 'vue';
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
 import { translate } from '@/lib/i18n';
 
 /**
@@ -10,6 +10,9 @@ import { translate } from '@/lib/i18n';
  * member the policy shuts out of public channels must not be shown the option —
  * and a member shut out of both is not shown the affordance at all, matching the
  * 403 the create endpoint would answer with.
+ *
+ * It is a shell singleton rather than a wrapper around its own triggers (#1223),
+ * so the way in is `v-model:open` and there is no slot to click.
  */
 const pageProps = vi.hoisted(
     (): { creatableChannelVisibilities: string[] } => ({
@@ -81,27 +84,33 @@ import CreateChannelModal from './CreateChannelModal.vue';
 
 let app: App | null = null;
 
-function mount(visibilities: string[]): HTMLElement {
+/** The host's `v-model:open`, which is the only way in now. */
+const isOpen = ref(false);
+
+function mount(visibilities: string[]): void {
     pageProps.creatableChannelVisibilities = visibilities;
+    isOpen.value = false;
 
     const host = document.createElement('div');
     document.body.append(host);
 
     app = createApp({
         render: () =>
-            h(CreateChannelModal, { teamSlug: 'acme' }, () =>
-                h('button', { 'data-test': 'trigger' }, 'New channel'),
-            ),
+            h(CreateChannelModal, {
+                teamSlug: 'acme',
+                open: isOpen.value,
+                'onUpdate:open': (value: boolean) => {
+                    isOpen.value = value;
+                },
+            }),
     });
     app.config.globalProperties.$t = translate;
     app.mount(host);
-
-    return host;
 }
 
-/** Opens the dialog through its trigger, which is how the form is ever seen. */
-async function open(host: HTMLElement): Promise<void> {
-    host.querySelector<HTMLElement>('[data-test="trigger"]')?.click();
+/** Opens the dialog the way the shell does, and lets the form render. */
+async function open(): Promise<void> {
+    isOpen.value = true;
     await nextTick();
     await nextTick();
 }
@@ -123,19 +132,22 @@ afterEach(() => {
 
 describe('the create-channel modal', () => {
     it('offers both visibilities while the workspace leaves both open', async () => {
-        await open(mount(['public', 'private']));
+        mount(['public', 'private']);
+        await open();
 
         expect(visibilityOptions()).toEqual(['public', 'private']);
     });
 
     it('offers only the visibility the policy leaves open', async () => {
-        await open(mount(['private']));
+        mount(['private']);
+        await open();
 
         expect(visibilityOptions()).toEqual(['private']);
     });
 
     it('starts on the only visibility left rather than a refused default', async () => {
-        await open(mount(['private']));
+        mount(['private']);
+        await open();
 
         expect(
             document.querySelector<HTMLSelectElement>(
@@ -145,8 +157,8 @@ describe('the create-channel modal', () => {
     });
 
     it('forgets a half-finished choice when the modal is closed and reopened', async () => {
-        const host = mount(['public', 'private']);
-        await open(host);
+        mount(['public', 'private']);
+        await open();
 
         const control = document.querySelector<HTMLSelectElement>(
             '[data-test="create-channel-visibility"]',
@@ -155,10 +167,9 @@ describe('the create-channel modal', () => {
         control.dispatchEvent(new Event('change'));
         await nextTick();
 
-        // Close through the same path the dialog itself uses, then reopen.
-        host.querySelector<HTMLElement>('[data-test="trigger"]')?.click();
+        isOpen.value = false;
         await nextTick();
-        await open(host);
+        await open();
 
         expect(
             document.querySelector<HTMLSelectElement>(
@@ -167,10 +178,30 @@ describe('the create-channel modal', () => {
         ).toBe('public');
     });
 
-    it('withdraws the affordance entirely when neither is open', () => {
-        const host = mount([]);
+    it('writes a dismissal back to the host, so its opener sees the dialog go', async () => {
+        // `v-model:open` is now the whole contract: bound to a copy, the "+"
+        // that opened it would still believe it up and do nothing on a second
+        // press.
+        mount(['public', 'private']);
+        await open();
 
-        expect(host.querySelector('[data-test="trigger"]')).toBeNull();
+        document
+            .querySelector<HTMLElement>('[data-test="dialog-close-button"]')
+            ?.click();
+        await nextTick();
+
+        expect(isOpen.value).toBe(false);
+    });
+
+    it('mounts nothing at all when the policy leaves neither open', async () => {
+        // The affordances that open it are gated on the same reading, so this is
+        // the backstop rather than the gate: asked to open anyway, it declines.
+        mount([]);
+        await open();
+
+        expect(
+            document.querySelector('[data-test="create-channel-submit"]'),
+        ).toBeNull();
         expect(visibilityOptions()).toEqual([]);
     });
 });

--- a/resources/js/components/CreateChannelModal.test.ts
+++ b/resources/js/components/CreateChannelModal.test.ts
@@ -229,6 +229,9 @@ describe('the create-channel modal', () => {
         await open();
 
         expect(
+            document.querySelector('[data-slot="dialog-content"]'),
+        ).toBeNull();
+        expect(
             document.querySelector('[data-test="create-channel-submit"]'),
         ).toBeNull();
         expect(visibilityOptions()).toEqual([]);

--- a/resources/js/components/CreateChannelModal.test.ts
+++ b/resources/js/components/CreateChannelModal.test.ts
@@ -14,26 +14,35 @@ import { translate } from '@/lib/i18n';
  * It is a shell singleton rather than a wrapper around its own triggers (#1223),
  * so the way in is `v-model:open` and there is no slot to click.
  */
-const pageProps = vi.hoisted(
-    (): { creatableChannelVisibilities: string[] } => ({
-        creatableChannelVisibilities: ['public', 'private'],
+const page = vi.hoisted(
+    (): { props: { creatableChannelVisibilities: string[] } } => ({
+        props: { creatableChannelVisibilities: ['public', 'private'] },
     }),
 );
 
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props: pageProps }),
-    Form: defineComponent({
-        props: { action: { type: String, default: '' } },
-        setup:
-            (props, { slots }) =>
-            () =>
-                h(
-                    'form',
-                    { action: props.action },
-                    slots.default?.({ errors: {}, processing: false }),
-                ),
-    }),
-}));
+vi.mock('@inertiajs/vue3', async () => {
+    // Reactive, because the real shared props are: the singleton outlives a
+    // workspace switch, and a double that could not change under it would let a
+    // stale reading pass.
+    const { reactive } = await import('vue');
+
+    page.props = reactive(page.props);
+
+    return {
+        usePage: () => page,
+        Form: defineComponent({
+            props: { action: { type: String, default: '' } },
+            setup:
+                (props, { slots }) =>
+                () =>
+                    h(
+                        'form',
+                        { action: props.action },
+                        slots.default?.({ errors: {}, processing: false }),
+                    ),
+        }),
+    };
+});
 
 vi.mock('@/actions/App/Http/Controllers/Channels/ChannelController', () => ({
     store: { form: (slug: string) => ({ action: `/t/${slug}/channels` }) },
@@ -88,7 +97,7 @@ let app: App | null = null;
 const isOpen = ref(false);
 
 function mount(visibilities: string[]): void {
-    pageProps.creatableChannelVisibilities = visibilities;
+    page.props.creatableChannelVisibilities = visibilities;
     isOpen.value = false;
 
     const host = document.createElement('div');
@@ -176,6 +185,26 @@ describe('the create-channel modal', () => {
                 '[data-test="create-channel-visibility"]',
             )?.value,
         ).toBe('public');
+    });
+
+    it('re-reads the policy on the way in, not on the way out', async () => {
+        // The singleton outlives a workspace switch, where the last default it
+        // reset to may no longer be offered at all. Reading on close would leave
+        // the picker holding a value with no option under it.
+        mount(['public', 'private']);
+        await open();
+
+        isOpen.value = false;
+        await nextTick();
+
+        page.props.creatableChannelVisibilities = ['private'];
+        await open();
+
+        expect(
+            document.querySelector<HTMLSelectElement>(
+                '[data-test="create-channel-visibility"]',
+            )?.value,
+        ).toBe('private');
     });
 
     it('writes a dismissal back to the host, so its opener sees the dialog go', async () => {

--- a/resources/js/components/CreateChannelModal.vue
+++ b/resources/js/components/CreateChannelModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Form, usePage } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { store } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import FormField from '@/components/FormField.vue';
 import { Button } from '@/components/ui/button';
@@ -12,7 +12,6 @@ import {
     DialogFooter,
     DialogHeader,
     DialogTitle,
-    DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import {
@@ -23,64 +22,75 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { useTranslations } from '@/composables/useTranslations';
+import { canCreateChannel, creatableVisibilities } from '@/lib/channelCreation';
 
+/**
+ * The shell's create-channel form.
+ *
+ * One of {@see DialogHost}'s singletons rather than a wrapper around each of its
+ * triggers, which is what lets a zero-argument palette verb reach it (#1223).
+ * The affordances that open it gate themselves on {@see canCreateChannel}, the
+ * same reading this makes to decide whether to mount at all.
+ */
 const props = defineProps<{
     teamSlug: string;
 }>();
 
+const open = defineModel<boolean>('open', { default: false });
+
 const page = usePage();
 const { t } = useTranslations();
 
-/**
- * The visibilities this workspace's channel-creation policy leaves open to the
- * viewer, in the order the picker offers them. The create endpoint re-enforces
- * the policy, so this only keeps the form from offering a choice that would come
- * straight back as a 403.
- */
-const visibilities = computed(() =>
-    (
-        [
-            { value: 'public', label: t('Public') },
-            { value: 'private', label: t('Private') },
-        ] as const
-    ).filter((option) =>
-        (page.props.creatableChannelVisibilities ?? []).includes(option.value),
-    ),
-);
+/** The picker's options, labelled, for the visibilities the policy leaves open. */
+const visibilities = computed(() => {
+    const labels: Record<App.Enums.ChannelVisibility, string> = {
+        public: t('Public'),
+        private: t('Private'),
+    };
+
+    return creatableVisibilities(page.props.creatableChannelVisibilities).map(
+        (value) => ({ value, label: labels[value] }),
+    );
+});
 
 /** Whether there is any channel at all for the viewer to open here. */
-const canCreate = computed(() => visibilities.value.length > 0);
+const canCreate = computed(() =>
+    canCreateChannel(page.props.creatableChannelVisibilities),
+);
 
 const defaultVisibility = computed(
     () => visibilities.value[0]?.value ?? 'public',
 );
 
-const open = ref(false);
 const visibility = ref<string>(defaultVisibility.value);
 const formKey = ref(0);
 
-function handleOpenChange(value: boolean) {
-    open.value = value;
-
-    if (!value) {
-        visibility.value = defaultVisibility.value;
-        formKey.value++;
+/**
+ * A half-finished form is forgotten on the way out, so reopening starts clean.
+ *
+ * Watched off the model rather than hooked onto the dialog's own
+ * `update:open`, because as a singleton it is closed from both sides: its own
+ * chrome writes through the model, and so does whatever opened it.
+ */
+watch(open, (isOpen) => {
+    if (isOpen) {
+        return;
     }
-}
+
+    visibility.value = defaultVisibility.value;
+    formKey.value++;
+});
 </script>
 
 <template>
-    <Dialog v-if="canCreate" :open="open" @update:open="handleOpenChange">
-        <DialogTrigger as-child>
-            <slot />
-        </DialogTrigger>
+    <Dialog v-if="canCreate" v-model:open="open">
         <DialogContent>
             <Form
                 :key="formKey"
                 v-bind="store.form(props.teamSlug)"
                 class="space-y-6"
                 v-slot="{ errors, processing }"
-                @success="handleOpenChange(false)"
+                @success="open = false"
             >
                 <DialogHeader>
                     <DialogTitle>{{ $t('Create a channel') }}</DialogTitle>

--- a/resources/js/components/CreateChannelModal.vue
+++ b/resources/js/components/CreateChannelModal.vue
@@ -66,18 +66,25 @@ const visibility = ref<string>(defaultVisibility.value);
 const formKey = ref(0);
 
 /**
- * A half-finished form is forgotten on the way out, so reopening starts clean.
+ * A half-finished form is forgotten between openings, so it always starts clean.
  *
- * Watched off the model rather than hooked onto the dialog's own
- * `update:open`, because as a singleton it is closed from both sides: its own
- * chrome writes through the model, and so does whatever opened it.
+ * Watched off the model rather than hooked onto the dialog's own `update:open`,
+ * because as a singleton it is closed from both sides: its own chrome writes
+ * through the model, and so does whatever opened it.
+ *
+ * The picker is re-read on the way *in* rather than reset on the way out,
+ * because the singleton outlives a workspace switch — a default settled on
+ * leaving one workspace may not be offered at all in the next, and the picker
+ * would open holding a value with no option under it. The fields the `Form`
+ * owns are cleared by remounting it, which is the close's business.
  */
 watch(open, (isOpen) => {
     if (isOpen) {
+        visibility.value = defaultVisibility.value;
+
         return;
     }
 
-    visibility.value = defaultVisibility.value;
     formKey.value++;
 });
 </script>

--- a/resources/js/components/DialogHost.test.ts
+++ b/resources/js/components/DialogHost.test.ts
@@ -15,7 +15,10 @@ vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
  */
 function marker(name: string): Component {
     return defineComponent({
-        props: { open: { type: Boolean, default: false } },
+        props: {
+            open: { type: Boolean, default: false },
+            teamSlug: { type: String, default: undefined },
+        },
         emits: ['update:open'],
         setup:
             (props, { emit }) =>
@@ -23,6 +26,7 @@ function marker(name: string): Component {
                 h('button', {
                     'data-test': `dialog-${name}`,
                     'data-open': String(props.open),
+                    'data-team-slug': props.teamSlug,
                     // Standing in for the dialog's own chrome dismissing it, which
                     // is what `v-model:open` has to write back through.
                     onClick: () => emit('update:open', false),
@@ -35,6 +39,7 @@ for (const [path, name] of [
     ['@/components/PendingInvitationsModal.vue', 'invitations'],
     ['@/components/CommandPalette.vue', 'switcher'],
     ['@/components/NewDirectMessageModal.vue', 'newMessage'],
+    ['@/components/CreateChannelModal.vue', 'createChannel'],
     ['@/components/KeyboardShortcutsModal.vue', 'shortcuts'],
     ['@/components/UserStatusDialog.vue', 'status'],
     ['@/components/InstallAppDialog.vue', 'install'],
@@ -95,6 +100,7 @@ it.each([
     'invite',
     'switcher',
     'newMessage',
+    'createChannel',
     'shortcuts',
     'status',
     'install',
@@ -148,7 +154,7 @@ it('mounts no invite modal for a viewer who may not invite', () => {
     expect(dialog(mountHost(), 'invite')).toBeNull();
 });
 
-it.each(['switcher', 'newMessage'] as const)(
+it.each(['switcher', 'newMessage', 'createChannel'] as const)(
     'mounts no %s before a workspace is loaded',
     (name) => {
         seed({ currentTeam: null });
@@ -156,6 +162,12 @@ it.each(['switcher', 'newMessage'] as const)(
         expect(dialog(mountHost(), name)).toBeNull();
     },
 );
+
+it('points the create-channel dialog at the open workspace', () => {
+    // It used to take the slug from whichever trigger wrapped it; as a
+    // singleton there is one workspace to take it from.
+    expect(dialog(mountHost(), 'createChannel')!.dataset.teamSlug).toBe('acme');
+});
 
 it('mounts the post-registration prompt only while one is queued', () => {
     expect(dialog(mountHost(), 'passkey-prompt')).toBeNull();

--- a/resources/js/components/DialogHost.vue
+++ b/resources/js/components/DialogHost.vue
@@ -3,6 +3,7 @@ import { usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import PasskeyPromptDialog from '@/components/auth/PasskeyPromptDialog.vue';
 import CommandPalette from '@/components/CommandPalette.vue';
+import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import DndPauseDialog from '@/components/DndPauseDialog.vue';
 import InstallAppDialog from '@/components/InstallAppDialog.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
@@ -41,6 +42,7 @@ const page = usePage();
 // Destructured so each flag is a top-level ref the template unwraps, and
 // `v-model:open` binds it as the dialog's own state rather than a copy.
 const { isOpen: newMessageOpen } = useDialog('newMessage');
+const { isOpen: createChannelOpen } = useDialog('createChannel');
 const { isOpen: inviteOpen } = useDialog('invite');
 const { isOpen: invitationsOpen } = useDialog('invitations');
 const { isOpen: switcherOpen } = useDialog('switcher');
@@ -107,6 +109,12 @@ const postRegistrationPrompt = computed(
         v-model:open="newMessageOpen"
         :members="teamMembers"
         :current-user-id="currentUserId"
+        :team-slug="currentTeam.slug"
+    />
+
+    <CreateChannelModal
+        v-if="currentTeam"
+        v-model:open="createChannelOpen"
         :team-slug="currentTeam.slug"
     />
 

--- a/resources/js/components/channel/ChannelPane.vue
+++ b/resources/js/components/channel/ChannelPane.vue
@@ -287,7 +287,6 @@ defineExpose({
                     :channel="props.channel"
                     :is-self-dm="props.isSelfDm"
                     :team-name="props.team.name"
-                    :team-slug="props.team.slug"
                     @focus-composer="emit('focusComposer')"
                 />
             </ScrollableMessageList>

--- a/resources/js/components/navigation/DefaultChannelGroup.test.ts
+++ b/resources/js/components/navigation/DefaultChannelGroup.test.ts
@@ -1,10 +1,20 @@
 // @vitest-environment jsdom
-import { afterEach, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import type { App } from 'vue';
 import { createApp, defineComponent, h } from 'vue';
+import { useDialog } from '@/composables/useDialog';
 import type { Channel, ChannelSection } from '@/types/channels';
 
+/** The workspace props the create-channel "+" is gated on. */
+const page = vi.hoisted(() => ({
+    props: { creatableChannelVisibilities: ['public', 'private'] } as Record<
+        string,
+        unknown
+    >,
+}));
+
 vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => page,
     Link: defineComponent({
         props: { href: { type: String, default: '' } },
         setup:
@@ -62,15 +72,6 @@ vi.mock('@/components/ui/dropdown-menu', () => {
     };
 });
 
-vi.mock('@/components/CreateChannelModal.vue', () => ({
-    default: defineComponent({
-        setup:
-            (_, { slots }) =>
-            () =>
-                h('div', slots.default?.()),
-    }),
-}));
-
 vi.mock('@/components/ChannelListItem.vue', () => ({
     default: defineComponent({
         props: {
@@ -103,6 +104,11 @@ function channel(overrides: Partial<Channel> = {}): Channel {
 const sections = [{ id: 's-1', name: 'Projects' } as ChannelSection];
 
 let app: App | null = null;
+
+beforeEach(() => {
+    page.props = { creatableChannelVisibilities: ['public', 'private'] };
+    useDialog('createChannel').close();
+});
 
 afterEach(() => {
     app?.unmount();
@@ -155,6 +161,31 @@ it('keeps the selectors the browser suite reaches the group by', () => {
     ).not.toBeNull();
     expect(
         host.querySelector('[data-test="create-channel-trigger"]'),
+    ).not.toBeNull();
+});
+
+it('opens the create form the shell mounts', () => {
+    const { host } = mountGroup();
+
+    host.querySelector<HTMLElement>(
+        '[data-test="create-channel-trigger"]',
+    )!.click();
+
+    expect(useDialog('createChannel').isOpen.value).toBe(true);
+});
+
+it('withdraws the "+" from a viewer the workspace policy shuts out', () => {
+    // The trigger used to disappear because the modal wrapping it declined to
+    // render; unpicked from that wrapper, the group owes the gate itself.
+    page.props = { creatableChannelVisibilities: [] };
+
+    const { host } = mountGroup();
+
+    expect(
+        host.querySelector('[data-test="create-channel-trigger"]'),
+    ).toBeNull();
+    expect(
+        host.querySelector('[data-test="channels-section-menu"]'),
     ).not.toBeNull();
 });
 

--- a/resources/js/components/navigation/DefaultChannelGroup.vue
+++ b/resources/js/components/navigation/DefaultChannelGroup.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { Link } from '@inertiajs/vue3';
+import { Link, usePage } from '@inertiajs/vue3';
 import { MoreHorizontal, Plus, Search } from '@lucide/vue';
+import { computed } from 'vue';
 import draggable from 'vuedraggable';
 import { browse } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import ChannelListItem from '@/components/ChannelListItem.vue';
-import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import SidebarSectionHeader from '@/components/navigation/SidebarSectionHeader.vue';
 import {
     DropdownMenu,
@@ -18,6 +18,8 @@ import {
     SidebarGroupContent,
 } from '@/components/ui/sidebar';
 import type { ChannelDragChange } from '@/composables/useChannelPlacement';
+import { useDialog } from '@/composables/useDialog';
+import { canCreateChannel } from '@/lib/channelCreation';
 import type { Channel, ChannelSection } from '@/types/channels';
 
 defineProps<{
@@ -44,6 +46,14 @@ defineEmits<{
     /** vuedraggable reordered the group, or a channel was dragged into it. */
     change: [change: ChannelDragChange];
 }>();
+
+const page = usePage();
+
+/** The "+" opens the shell's create-channel dialog, on the policy's say-so. */
+const createChannelDialog = useDialog('createChannel');
+const canCreate = computed(() =>
+    canCreateChannel(page.props.creatableChannelVisibilities),
+);
 </script>
 
 <template>
@@ -83,17 +93,17 @@ defineEmits<{
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>
-        <CreateChannelModal v-if="teamSlug !== ''" :team-slug="teamSlug">
-            <SidebarGroupAction
-                :title="$t('Create channel')"
-                data-test="create-channel-trigger"
-                data-tour="create-channel"
-                class="top-2 size-5 rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-            >
-                <Plus class="size-3.25" />
-                <span class="sr-only">{{ $t('Create channel') }}</span>
-            </SidebarGroupAction>
-        </CreateChannelModal>
+        <SidebarGroupAction
+            v-if="teamSlug !== '' && canCreate"
+            :title="$t('Create channel')"
+            data-test="create-channel-trigger"
+            data-tour="create-channel"
+            class="top-2 size-5 rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            @click="createChannelDialog.open()"
+        >
+            <Plus class="size-3.25" />
+            <span class="sr-only">{{ $t('Create channel') }}</span>
+        </SidebarGroupAction>
         <SidebarGroupContent
             v-show="!collapsed"
             data-test="section-content-channels"

--- a/resources/js/components/navigation/NewMenu.test.ts
+++ b/resources/js/components/navigation/NewMenu.test.ts
@@ -4,6 +4,16 @@ import type { App } from 'vue';
 import { createApp, defineComponent, h } from 'vue';
 import { useDialog } from '@/composables/useDialog';
 
+/** The workspace props the "New channel" row is gated on. */
+const page = vi.hoisted(() => ({
+    props: { creatableChannelVisibilities: ['public', 'private'] } as Record<
+        string,
+        unknown
+    >,
+}));
+
+vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
+
 /** Drives the mocked breakpoint flag, which has to stay a real ref. */
 const viewport = vi.hoisted(() => ({
     setMobile: null as null | ((mobile: boolean) => void),
@@ -26,21 +36,8 @@ vi.mock('@lucide/vue', () => ({
     MessageSquare: { render: () => h('svg') },
 }));
 
-const channelModalTeamSlug = vi.hoisted(() => ({ value: '' }));
-
 /** Lets a test replay the moment the menu finishes closing. */
 const menu = vi.hoisted(() => ({ replayClose: null as null | (() => Event) }));
-
-vi.mock('@/components/CreateChannelModal.vue', () => ({
-    default: defineComponent({
-        props: { teamSlug: { type: String, default: '' } },
-        setup(modalProps, { slots }) {
-            channelModalTeamSlug.value = modalProps.teamSlug;
-
-            return () => h('div', slots.default?.());
-        },
-    }),
-}));
 
 /** Renders its slot and forwards a click as the `select` menu rows are wired to. */
 function passthrough(tag = 'div') {
@@ -101,9 +98,10 @@ let app: App | null = null;
 
 beforeEach(() => {
     viewport.setMobile?.(false);
-    channelModalTeamSlug.value = '';
+    page.props = { creatableChannelVisibilities: ['public', 'private'] };
     menu.replayClose = null;
     useDialog('newMessage').close();
+    useDialog('createChannel').close();
 });
 
 afterEach(() => {
@@ -122,7 +120,7 @@ function mountMenu() {
         render: () =>
             h(
                 NewMenu,
-                { teamSlug: 'acme', onSection: sectioned },
+                { onSection: sectioned },
                 {
                     default: () =>
                         h('button', { 'data-test': 'new-menu-trigger' }),
@@ -165,10 +163,23 @@ it('keeps the trigger the caller supplied', () => {
     expect(row(host, 'new-menu-trigger')).not.toBeNull();
 });
 
-it('points the channel modal at the open workspace', () => {
-    mountMenu();
+it('opens the create form the shell mounts, closing the menu behind it', () => {
+    const { host } = mountMenu();
 
-    expect(channelModalTeamSlug.value).toBe('acme');
+    row(host, 'new-menu-channel')!.click();
+
+    expect(useDialog('createChannel').isOpen.value).toBe(true);
+});
+
+it('drops the channel row for a viewer the workspace policy shuts out', () => {
+    // The row used to disappear because the modal wrapping it declined to
+    // render; unpicked from that wrapper, the menu owes the gate itself.
+    page.props = { creatableChannelVisibilities: [] };
+
+    const { host } = mountMenu();
+
+    expect(row(host, 'new-menu-channel')).toBeNull();
+    expect(row(host, 'new-menu-message')).not.toBeNull();
 });
 
 it('opens the people picker the shell mounts', () => {

--- a/resources/js/components/navigation/NewMenu.vue
+++ b/resources/js/components/navigation/NewMenu.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
 import { FolderPlus, Hash, MessageSquare } from '@lucide/vue';
-import { ref, watch } from 'vue';
-import CreateChannelModal from '@/components/CreateChannelModal.vue';
+import { computed, ref, watch } from 'vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useDialog } from '@/composables/useDialog';
 import { useIsMobile } from '@/composables/useIsMobile';
+import { canCreateChannel } from '@/lib/channelCreation';
 
 /**
  * The dock header's "+ New" menu: exactly three ways to start something —
@@ -30,20 +31,23 @@ import { useIsMobile } from '@/composables/useIsMobile';
  * Like the workspace sheet, the trigger is the default slot and the surface
  * presents as a bottom sheet below `md`.
  */
-defineProps<{
-    /** The workspace the new channel would belong to. */
-    teamSlug: string;
-}>();
-
 const emit = defineEmits<{
     /** Start a section; the host owns the inline name field. */
     section: [];
 }>();
 
+const page = usePage();
+
 const isSheetViewport = useIsMobile();
 
 /** "Message" opens the people picker the shell mounts. */
 const newMessageDialog = useDialog('newMessage');
+
+/** "Channel" opens the create form the shell mounts, on the policy's say-so. */
+const createChannelDialog = useDialog('createChannel');
+const canCreate = computed(() =>
+    canCreateChannel(page.props.creatableChannelVisibilities),
+);
 
 const open = ref(false);
 
@@ -54,6 +58,11 @@ watch(isSheetViewport, () => {
 function requestMessage(): void {
     open.value = false;
     newMessageDialog.open();
+}
+
+function requestChannel(): void {
+    open.value = false;
+    createChannelDialog.open();
 }
 
 /** The bottom sheet has no focus scope to outlive, so it announces at once. */
@@ -108,20 +117,20 @@ const sheetRowClass =
                 {{ $t('Start a channel, a message, or a section.') }}
             </DialogDescription>
 
-            <CreateChannelModal :team-slug="teamSlug">
-                <Button
-                    variant="unstyled"
-                    size="none"
-                    type="button"
-                    data-test="new-menu-channel"
-                    :class="sheetRowClass"
-                >
-                    <Hash class="size-5 text-muted-foreground" />
-                    <span class="min-w-0 flex-1 truncate">{{
-                        $t('New channel')
-                    }}</span>
-                </Button>
-            </CreateChannelModal>
+            <Button
+                v-if="canCreate"
+                variant="unstyled"
+                size="none"
+                type="button"
+                data-test="new-menu-channel"
+                :class="sheetRowClass"
+                @click="requestChannel"
+            >
+                <Hash class="size-5 text-muted-foreground" />
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('New channel')
+                }}</span>
+            </Button>
             <Button
                 variant="unstyled"
                 size="none"
@@ -161,16 +170,15 @@ const sheetRowClass =
             class="w-53.5 rounded-[14px] p-1.5"
             @close-auto-focus="onCloseAutoFocus"
         >
-            <CreateChannelModal :team-slug="teamSlug">
-                <DropdownMenuItem
-                    data-test="new-menu-channel"
-                    class="h-8.5 cursor-pointer gap-2.25"
-                    @select.prevent
-                >
-                    <Hash class="size-3.75 text-muted-foreground" />
-                    {{ $t('New channel') }}
-                </DropdownMenuItem>
-            </CreateChannelModal>
+            <DropdownMenuItem
+                v-if="canCreate"
+                data-test="new-menu-channel"
+                class="h-8.5 cursor-pointer gap-2.25"
+                @select="requestChannel"
+            >
+                <Hash class="size-3.75 text-muted-foreground" />
+                {{ $t('New channel') }}
+            </DropdownMenuItem>
             <DropdownMenuItem
                 data-test="new-menu-message"
                 class="h-8.5 cursor-pointer gap-2.25"

--- a/resources/js/composables/commands.test.ts
+++ b/resources/js/composables/commands.test.ts
@@ -37,6 +37,7 @@ function seed(props: Record<string, unknown> = {}): void {
     page.props = {
         currentTeam: { id: 't1', slug: 'acme' },
         canInviteToCurrentTeam: true,
+        creatableChannelVisibilities: ['public', 'private'],
         auth: { user: { dnd: null, timezone: 'UTC' } },
         ...props,
     };
@@ -122,6 +123,7 @@ const DIALOG_COMMANDS: Record<string, ShellDialog> = {
     'command-palette': 'switcher',
     'show-shortcuts': 'shortcuts',
     'new-message': 'newMessage',
+    'create-channel': 'createChannel',
     'set-status': 'status',
     'pause-notifications': 'dnd',
     'invite-people': 'invite',
@@ -211,6 +213,26 @@ describe('resume-notifications', () => {
         });
 
         expect(command?.isAvailable?.()).toBe(true);
+    });
+});
+
+/**
+ * Read in both polarities, because the failure this guards against is the whole
+ * gate reading `undefined`: a predicate pointed at the wrong prop path hides the
+ * row from everyone, and a one-sided assertion cannot tell that apart from the
+ * policy doing its job.
+ */
+describe('create-channel', () => {
+    it('is offered only where the workspace policy leaves a visibility open', () => {
+        const command = COMMANDS.find(
+            (candidate) => candidate.id === 'create-channel',
+        );
+
+        expect(command?.isAvailable?.()).toBe(true);
+
+        seed({ creatableChannelVisibilities: [] });
+
+        expect(command?.isAvailable?.()).toBe(false);
     });
 });
 

--- a/resources/js/composables/commands.ts
+++ b/resources/js/composables/commands.ts
@@ -10,6 +10,7 @@ import {
     Keyboard,
     Monitor,
     Moon,
+    Plus,
     Search,
     SmilePlus,
     SquarePen,
@@ -29,6 +30,7 @@ import { useDialog } from '@/composables/useDialog';
 import { urlForDestination } from '@/composables/useNavPanel';
 import { useShellFocus } from '@/composables/useShellFocus';
 import { useUserMenu } from '@/composables/useUserMenu';
+import { canCreateChannel } from '@/lib/channelCreation';
 import { isDndActiveNow } from '@/lib/dnd';
 import { translate } from '@/lib/i18n';
 import { pinUrl } from '@/lib/pinUrl';
@@ -149,6 +151,20 @@ export const COMMANDS: readonly CommandDefinition[] = [
         icon: SquarePen,
         isAvailable: () => Boolean(page.props.currentTeam),
         run: () => useDialog('newMessage').open(),
+    },
+    {
+        /**
+         * Gated on the workspace's channel-creation policy, the same reading
+         * every other affordance that opens this dialog makes — and the reason
+         * the verb waited for the dialog to become a shell singleton (#1223):
+         * as a wrapper around its own triggers there was no ref to flip.
+         */
+        id: 'create-channel',
+        title: 'Create a channel',
+        icon: Plus,
+        isAvailable: () =>
+            canCreateChannel(page.props.creatableChannelVisibilities),
+        run: () => useDialog('createChannel').open(),
     },
     {
         id: 'browse-channels',

--- a/resources/js/composables/useDialog.ts
+++ b/resources/js/composables/useDialog.ts
@@ -17,6 +17,11 @@ import type { Ref } from 'vue';
 const SHELL_DIALOGS = {
     /** The people picker behind "New message". */
     newMessage: false,
+    /**
+     * The create-channel form, reached from the sidebar's "+", the "New" menu,
+     * the first-run welcome and the palette (#1223).
+     */
+    createChannel: false,
     /** The member-invite modal. */
     invite: false,
     /** The prompt listing workspaces the viewer has been invited to. */

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -297,7 +297,6 @@ const { isSettingsSection, startTourIfEligible } = useShellStartup();
                             <div class="flex shrink-0 items-center gap-1">
                                 <NewMenu
                                     v-if="currentTeam"
-                                    :team-slug="currentTeam.slug"
                                     @section="openSectionForm"
                                 >
                                     <Button

--- a/resources/js/lib/channelCreation.test.ts
+++ b/resources/js/lib/channelCreation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { canCreateChannel, creatableVisibilities } from '@/lib/channelCreation';
+
+describe('the visibilities the picker offers', () => {
+    it('offers them in the picker’s order, whatever order the policy answered in', () => {
+        expect(creatableVisibilities(['private', 'public'])).toEqual([
+            'public',
+            'private',
+        ]);
+    });
+
+    it('drops the visibility the policy withheld', () => {
+        expect(creatableVisibilities(['private'])).toEqual(['private']);
+    });
+
+    it('offers nothing before the workspace props have landed', () => {
+        expect(creatableVisibilities(undefined)).toEqual([]);
+    });
+});
+
+describe('whether the viewer may create a channel at all', () => {
+    it('says yes while the policy leaves any visibility open', () => {
+        expect(canCreateChannel(['private'])).toBe(true);
+    });
+
+    it('says no when the policy shut the viewer out of both', () => {
+        expect(canCreateChannel([])).toBe(false);
+    });
+
+    it('says no on a page carrying no workspace props', () => {
+        expect(canCreateChannel(undefined)).toBe(false);
+    });
+});

--- a/resources/js/lib/channelCreation.ts
+++ b/resources/js/lib/channelCreation.ts
@@ -1,0 +1,39 @@
+/**
+ * The visibilities the picker offers, in the order it offers them. The
+ * workspace's policy answers per visibility and in its own order; this is what
+ * the form reads.
+ */
+const PICKER_ORDER: readonly App.Enums.ChannelVisibility[] = [
+    'public',
+    'private',
+];
+
+/**
+ * The visibilities the workspace's channel-creation policy leaves open to the
+ * viewer, in the order the picker offers them.
+ *
+ * The create endpoint re-enforces the policy, so this only keeps the form from
+ * offering a choice that would come straight back as a 403.
+ */
+export function creatableVisibilities(
+    creatable: readonly App.Enums.ChannelVisibility[] | undefined,
+): App.Enums.ChannelVisibility[] {
+    return PICKER_ORDER.filter((visibility) =>
+        (creatable ?? []).includes(visibility),
+    );
+}
+
+/**
+ * Whether there is any channel at all for the viewer to create here.
+ *
+ * The gate on every affordance that opens the create dialog — the sidebar's
+ * "+", the "New" menu, the first-run welcome, and the palette's *Create a
+ * channel* — now that the dialog is a shell singleton rather than a wrapper
+ * around each of those triggers. Sharing one reading is what keeps an
+ * affordance from offering a dialog the policy would refuse to mount.
+ */
+export function canCreateChannel(
+    creatable: readonly App.Enums.ChannelVisibility[] | undefined,
+): boolean {
+    return creatableVisibilities(creatable).length > 0;
+}


### PR DESCRIPTION
Closes #1223.

## What

*Create a channel* joins the ⌘K command registry. It was the obvious omission from the launch catalogue (#1210 §6) and was left out for a structural reason rather than a judgement about merit: the modal owned a local `ref(false)` behind a slot trigger, so there was no singleton for a module-scope `run` to flip.

## How

The three parts the issue names:

1. **`createChannel` joins `SHELL_DIALOGS`**, mounted by `DialogHost` under `v-if="currentTeam"` with `v-model:open` and `:team-slug="currentTeam.slug"` — the `NewDirectMessageModal` shape.
2. **`CreateChannelModal` drops its `DialogTrigger`, its default slot and its local ref** for a `defineModel<boolean>('open')`.
3. **Four trigger instances across the three call sites** (`NewMenu` has one per presentation, `DefaultChannelGroup`, `ChannelEmptyState`) become plain buttons calling `useDialog('createChannel').open()`.

Each call site now carries its own availability gate, because the modal's `v-if="canCreate"` was what hid those triggers from a viewer the workspace's channel-creation policy shuts out. That reading became one helper, `canCreateChannel()` in `resources/js/lib/channelCreation.ts`, shared by the modal, the three call sites and the command's `isAvailable` — five readings of `creatableChannelVisibilities` that can no longer disagree.

Falling out of the unpick: `NewMenu` and `ChannelEmptyState` shed a `teamSlug` prop nothing reads any more, and `MainLayout` / `ChannelPane` their bindings.

## Two things worth a reviewer's attention

**Focus restore survives, and it was checked rather than assumed.** `DialogFocusRestoreTest` uses create-channel as its subject and asserts focus comes home to `@create-channel-trigger`; reka only restores to a `DialogTrigger`, which is the thing deleted here. `useDialogFocusRestore` already records `document.activeElement` at open — precisely because most dialogs here are driven from `v-model:open` — so it lands on the button the user clicked. Verified live, not by reasoning.

**A defect the promotion introduced, caught and fixed.** As a singleton the dialog outlives a workspace switch, so resetting the visibility picker on the way *out* could leave it holding a value the next workspace does not offer. It now re-reads the policy on the way *in*; the `Form` remount that clears the text fields stays on close.

## Testing

Per the epic's per-seam rule, the command itself gets **no browser test** — opening a dialog is a seam `CommandPaletteTest` already proves. Unit covers the promotion (`DialogHost` mount and its `currentTeam` gate), the modal around `v-model:open`, the three rewired call sites and their gates, the new helper, and `create-channel` joining `DIALOG_COMMANDS` in `commands.test.ts` — which buys the dialog-key and bare-page-predicate assertions for free. Its permission gate is read in both polarities, since a predicate pointed at the wrong prop path hides the row from everyone.

`ChannelEmptyState` had no test at all; it has one now, scoped to the card this change touches.

The rewire's browser coverage is the suite that already drives those triggers, unchanged: `DialogFocusRestoreTest`, `MobileSheetsTest`, `A11yShellTest`, `WorkspaceSheetTest`.

Both gates green — backend at 100%, and the full `tests/Browser` sweep. One unrelated flake surfaced in `RemindersPanelTest`'s axe audit (an `opacity-0` hover timestamp sampled mid-fade); filed as #1241, not fixed here.

## i18n and docs

No new strings: *Create a channel* is the key the modal's own `DialogTitle` already uses, and `lang/fr.json` already carries it. Nothing operator-facing, so no `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788464629&installation_model_id=428379&pr_number=1242&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1242&signature=0584ca20ceed9039c229637ba9a7c568f26f0fa565ab3a1adc32c9ecbca39ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->