### PR TITLE
feat: set yourself away or active from the palette

### DIFF
--- a/resources/js/components/CommandPalette.destinations.test.ts
+++ b/resources/js/components/CommandPalette.destinations.test.ts
@@ -223,6 +223,9 @@ describe('the commands group', () => {
             'Reminders',
             'Search',
             'Set a status',
+            // Only the away half of the presence pair: this viewer is active,
+            // and the row naming the state they are already in is not offered.
+            'Set yourself away',
             'Pause notifications',
             'Use light theme',
             'Use dark theme',

--- a/resources/js/components/CommandPalette.stubs.ts
+++ b/resources/js/components/CommandPalette.stubs.ts
@@ -42,6 +42,8 @@ export function lucideDouble(): Record<string, Component> {
             'Bell',
             'BellOff',
             'BellRing',
+            'Circle',
+            'CircleDot',
             'Hash',
             'Keyboard',
             'Monitor',

--- a/resources/js/composables/commands.test.ts
+++ b/resources/js/composables/commands.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { visit, destroy } = vi.hoisted(() => ({
+const { visit, destroy, put } = vi.hoisted(() => ({
     visit: vi.fn(),
     destroy: vi.fn(),
+    put: vi.fn(),
 }));
 
 /**
@@ -17,7 +18,7 @@ const page = vi.hoisted(() => ({
 }));
 
 vi.mock('@inertiajs/vue3', () => ({
-    router: { visit, delete: destroy, put: vi.fn(), flushAll: vi.fn() },
+    router: { visit, delete: destroy, put, flushAll: vi.fn() },
     usePage: () => page,
 }));
 
@@ -27,6 +28,7 @@ vi.mock('@/lib/pinUrl', () => ({ pinUrl }));
 
 import { browse } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { destroy as destroyDndPause } from '@/actions/App/Http/Controllers/Settings/DndController';
+import { update as updatePresence } from '@/actions/App/Http/Controllers/Settings/PresenceController';
 import { COMMANDS } from '@/composables/commands';
 import { SHORTCUTS } from '@/composables/keyboardShortcuts';
 import { SHELL_DIALOG_NAMES, useDialog } from '@/composables/useDialog';
@@ -214,6 +216,55 @@ describe('resume-notifications', () => {
 
         expect(command?.isAvailable?.()).toBe(true);
     });
+});
+
+/**
+ * One capability as two gated rows rather than one row whose label follows the
+ * viewer's presence (#1224). The pair is observationally identical to a dynamic
+ * title — exactly one of them is ever offered — which is why the contract was
+ * left alone, so the assertion that matters is that "exactly one" holds in every
+ * state rather than that either row exists.
+ */
+describe('the presence rows', () => {
+    /** The ids of the presence rows this viewer is actually offered. */
+    function offeredPresenceRows(): string[] {
+        return COMMANDS.filter(
+            (command) =>
+                command.id.startsWith('set-presence-') &&
+                (command.isAvailable?.() ?? true),
+        ).map((command) => command.id);
+    }
+
+    it.each([
+        ['set-presence-away', 'away'],
+        ['set-presence-active', 'active'],
+    ])('%s asks the server for %s outright', (id, state) => {
+        run(id);
+
+        expect(put).toHaveBeenCalledWith(
+            updatePresence().url,
+            { state },
+            expect.anything(),
+        );
+    });
+
+    /**
+     * Including the case where the prop is missing altogether: a viewer reading
+     * the palette is plainly here, so the shell reads an absent presence as
+     * active exactly as the user menu does, and still offers them a row.
+     */
+    it.each([
+        [undefined, 'set-presence-away'],
+        ['active', 'set-presence-away'],
+        ['away', 'set-presence-active'],
+    ])(
+        'offers exactly one row while presence reads %s',
+        (presence, offered) => {
+            seed({ auth: { user: { dnd: null, timezone: 'UTC', presence } } });
+
+            expect(offeredPresenceRows()).toEqual([offered]);
+        },
+    );
 });
 
 /**

--- a/resources/js/composables/commands.ts
+++ b/resources/js/composables/commands.ts
@@ -6,6 +6,8 @@ import {
     Bell,
     BellOff,
     BellRing,
+    Circle,
+    CircleDot,
     Hash,
     Keyboard,
     Monitor,
@@ -72,7 +74,7 @@ export type CommandDefinition = {
 const page = usePage();
 const { focusNotificationRail } = useShellFocus();
 const { updateAppearance } = useAppearance();
-const { resumeNotifications } = useUserMenu();
+const { resumeNotifications, setPresence } = useUserMenu();
 
 /**
  * Jump `delta` channels along the sidebar list from the active one, wrapping at
@@ -97,6 +99,26 @@ function moveChannel(delta: number): void {
     if (slug) {
         router.visit(show({ team: team.slug, channel: slug }).url);
     }
+}
+
+/**
+ * The presence the viewer would be moving *to*, or null when the page carries
+ * nobody to move. The same derivation the user menu's own toggle makes, read
+ * straight off the shared prop rather than through its `computed`: a predicate
+ * is called inside the palette's own `computed` on every rebuild, and a cached
+ * reading would offer the row for a presence the viewer has since left.
+ *
+ * An absent presence reads as active and never as offline, because someone
+ * reading the palette is plainly here.
+ */
+function presenceTogglesTo(): App.Enums.PresenceState | null {
+    const user = page.props.auth?.user;
+
+    if (user === undefined) {
+        return null;
+    }
+
+    return (user.presence ?? 'active') === 'away' ? 'active' : 'away';
 }
 
 /**
@@ -203,6 +225,33 @@ export const COMMANDS: readonly CommandDefinition[] = [
         title: 'Set a status',
         icon: SmilePlus,
         run: () => useDialog('status').open(),
+    },
+    {
+        /**
+         * One toggle as two gated rows, and the answer to the first verb this
+         * contract could not express (#1224). A single row would have to name
+         * the state it moves to, which is a `title` that follows state, and
+         * {@link CommandDefinition} keeps that string static on purpose. The
+         * pair is what the widening would have rendered anyway — exactly one of
+         * these is ever offered — so the catalogue names the states instead,
+         * the same answer the theme trio gave.
+         *
+         * The glyphs quote {@see PresenceDot}, which draws away as a hollow
+         * ring and active as a filled disc. They are near-identical shapes,
+         * which is safe only because the two rows are mutually exclusive.
+         */
+        id: 'set-presence-away',
+        title: 'Set yourself away',
+        icon: Circle,
+        isAvailable: () => presenceTogglesTo() === 'away',
+        run: () => setPresence('away'),
+    },
+    {
+        id: 'set-presence-active',
+        title: 'Set yourself active',
+        icon: CircleDot,
+        isAvailable: () => presenceTogglesTo() === 'active',
+        run: () => setPresence('active'),
     },
     {
         id: 'pause-notifications',

--- a/resources/js/composables/useUserMenu.ts
+++ b/resources/js/composables/useUserMenu.ts
@@ -21,13 +21,14 @@ export type UseUserMenuReturn = {
     currentTeam: ComputedRef<Team | null>;
     ownStatus: ComputedRef<App.Data.UserStatusData | null>;
     ownPresence: ComputedRef<RenderedPresence>;
-    togglesTo: ComputedRef<RenderedPresence>;
+    togglesTo: ComputedRef<App.Enums.PresenceState>;
     isDnd: ComputedRef<boolean>;
     pausedUntil: ComputedRef<string | null>;
     quietHoursUntil: ComputedRef<string | null>;
     clearsAt: ComputedRef<string | null>;
     pausePresets: DndPauseKey[];
     clearStatus: (event?: Event) => void;
+    setPresence: (state: App.Enums.PresenceState, event?: Event) => void;
     togglePresence: (event?: Event) => void;
     choosePause: (key: DndPauseKey, event?: Event) => void;
     resumeNotifications: (event?: Event) => void;
@@ -63,7 +64,7 @@ export function useUserMenu(): UseUserMenuReturn {
     );
 
     /** The state the toggle would switch to, which is also the glyph it previews. */
-    const togglesTo = computed<RenderedPresence>(() =>
+    const togglesTo = computed<App.Enums.PresenceState>(() =>
         ownPresence.value === 'away' ? 'active' : 'away',
     );
 
@@ -129,18 +130,33 @@ export function useUserMenu(): UseUserMenuReturn {
         });
     }
 
-    /** Flip the manual away override, in place. */
-    function togglePresence(event?: Event): void {
+    /**
+     * Set the manual away override to `state` outright.
+     *
+     * The target state is sent rather than a flip, so two surfaces pressing at
+     * once agree instead of racing each other back and forth — the reasoning
+     * {@see UpdatePresenceRequest} already records for the endpoint. It matters
+     * for a caller whose label promised a particular state: the command palette
+     * offers *Set yourself away* or *Set yourself active* as separate rows, and
+     * a row must still do what it said if presence changed under it between the
+     * list rendering and `Enter` landing.
+     */
+    function setPresence(state: App.Enums.PresenceState, event?: Event): void {
         event?.preventDefault();
 
         router.put(
             updatePresence().url,
-            { state: togglesTo.value },
+            { state },
             {
                 preserveScroll: true,
                 onError: () => toast.error(t('Could not change your presence')),
             },
         );
+    }
+
+    /** Flip the manual away override, in place. */
+    function togglePresence(event?: Event): void {
+        setPresence(togglesTo.value, event);
     }
 
     /** The preset rows: everything but Custom…, which opens the dialog. */
@@ -216,6 +232,7 @@ export function useUserMenu(): UseUserMenuReturn {
         clearsAt,
         pausePresets,
         clearStatus,
+        setPresence,
         togglePresence,
         choosePause,
         resumeNotifications,

--- a/tests/Browser/CommandPaletteTest.php
+++ b/tests/Browser/CommandPaletteTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\PresenceState;
 use App\Models\Message;
 use App\Models\MessageReminder;
 
@@ -116,13 +117,19 @@ test('a command opening a dialog leaves focus inside it, not back on the trigger
 test('the availability predicates read prop paths a real page carries', function (): void {
     ['owner' => $alice, 'member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
 
-    // Four rows, three distinct prop paths: `currentTeam` for the first two,
-    // `auth.user.dnd` for the resume, `canInviteToCurrentTeam` for the invite.
-    // All three fail the same silent way — a path that is not there reads
-    // `undefined`, falls to false, and the row vanishes for everyone — and a
-    // unit stub written from the same wrong path agrees with it. Only a real
-    // page can say the strings are right.
-    $alice->forceFill(['dnd_until' => now()->addMinutes(30)])->save();
+    // Six rows, four distinct prop paths: `currentTeam` for the first two,
+    // `auth.user.dnd` for the resume, `canInviteToCurrentTeam` for the invite,
+    // `auth.user.presence` for the presence pair. All four fail the same silent
+    // way — a path that is not there reads `undefined`, falls to false, and the
+    // row vanishes for everyone — and a unit stub written from the same wrong
+    // path agrees with it. Only a real page can say the strings are right.
+    //
+    // The manual override is what makes Alice away here, because it wins over
+    // the connection roster outright; Bob is left alone and reads active.
+    $alice->forceFill([
+        'dnd_until' => now()->addMinutes(30),
+        'presence_state' => PresenceState::Away,
+    ])->save();
 
     signInThroughBrowser($alice)
         ->resize(1280, 900)
@@ -132,6 +139,10 @@ test('the availability predicates read prop paths a real page carries', function
         ->assertPresent('@quick-switcher-browse-channels')
         ->assertPresent('@quick-switcher-invite-people')
         ->assertPresent('@quick-switcher-resume-notifications')
+        // The presence pair is one capability split across two rows, so what is
+        // proven is that only ever one of them is on the page (#1224).
+        ->assertPresent('@quick-switcher-set-presence-active')
+        ->assertNotPresent('@quick-switcher-set-presence-away')
         // The other half of the gate: the modal is mounted only for a viewer who
         // may invite, so a row that renders has to reach something listening.
         ->click('@quick-switcher-invite-people')
@@ -148,7 +159,9 @@ test('the availability predicates read prop paths a real page carries', function
         // Absent, never disabled: the list is the set of things this viewer can
         // do rather than a list of things they cannot.
         ->assertNotPresent('@quick-switcher-invite-people')
-        ->assertNotPresent('@quick-switcher-resume-notifications');
+        ->assertNotPresent('@quick-switcher-resume-notifications')
+        ->assertPresent('@quick-switcher-set-presence-away')
+        ->assertNotPresent('@quick-switcher-set-presence-active');
 });
 
 test('a theme command repaints the document', function (): void {


### PR DESCRIPTION
Closes #1224.

## What

Adds *Set yourself away* and *Set yourself active* to the command palette, between *Set a status* and *Pause notifications*, matching the order the user menu already puts them in. Exactly one of the two is ever offered.

## Why this does not widen `CommandDefinition`

#1224 recorded the presence toggle as the first verb the contract could not express: the row's label follows the viewer's current presence, and `title` is deliberately static (#1209 §4).

It turns out no widening is needed. The two candidate mechanisms are observationally identical. A `title: () => string` renders one row named for the state it moves to; two commands under mutually exclusive `isAvailable` predicates render one row named for the state it moves to. Same row count, same copy, same thing under `Enter`. So the widening buys nothing a reader can see, and #1209 §4's discipline says not to pay for it.

The catalogue had also answered this question once already: #1210 §4 rejected a theme *toggle* for exactly this reason and shipped three plain rows instead. This is the same answer with two states rather than three.

One correction to the issue while it is being closed: its first objection says `title: () => string` breaks the discriminated union that makes "one string, one home" compiler-enforced. It does not. The union is `{ shortcutId; title?: never } | { title; shortcutId?: never }`, and widening the `title` member's type leaves the mutual exclusion intact. The objection that survives is only the second half, that a function hides a translatable source string. Recorded so nobody re-derives it.

The cost accepted: a verb with four or five states would make a row per state look expensive, and would be the case that genuinely reopens §4.

## How

- `useUserMenu` grows `setPresence(state)`, and `togglePresence` delegates to it. The rows send the state outright rather than a flip, so a row still does what its label promised if presence changed underneath between the list rendering and `Enter` landing. That is the same reasoning `UpdatePresenceRequest` already records for the endpoint, and it keeps the mutation and its error toast owned by the menu, as *Resume notifications* does.
- `togglesTo` narrows from `RenderedPresence` to `App.Enums.PresenceState`, which is all it could ever hold, so `setPresence` cannot be handed an `offline` the endpoint would reject.
- The predicates read `auth.user.presence` straight off the shared prop rather than through the menu's `computed`, matching how every other predicate in the registry reads. An absent presence reads as active and never as offline: someone reading the palette is plainly here.
- Icons quote `PresenceDot`: `Circle` for the hollow away ring, `CircleDot` for the filled active disc. Near-identical glyphs, which is safe only because the rows are mutually exclusive. `Moon` and `Clock` were both ruled out because *Use dark theme* and *Reminders* already draw them in the same list.

## Testing

- `commands.test.ts`: the `PUT` payload for each row, and that exactly one presence row is offered in each of the three states the prop can read (`away`, `active`, absent). The existing sweeping "availability on a bare page" test picks the new rows up for free.
- `CommandPaletteTest.php`: the existing availability test grows the pair rather than earning a fifth test, per #1213 §6. It is no new seam, but `auth.user.presence` is a prop path nothing in the palette read before, and only a real page can prove a predicate is not silently reading `undefined`. Both polarities: Alice with a manual away override, Bob without.
- `CommandPalette.destinations.test.ts`: the whole-catalogue order assertion grows the away row.
- Full gate green, coverage `Total: 100.0 %`, Vitest 2710 passed, `MobileQuickSwitcherTest` still green (its a11y audits now sweep the new row at no cost).

## i18n and docs

No new keys. *Set yourself away* and *Set yourself active* already exist and are already translated (`Se marquer absent`, `Se marquer actif`), reused per #1210 §5 rather than minting near-duplicates. Nothing operator-facing, so no `docs/` change.

## Review note

One CodeRabbit finding was declined: it asked for `translate()` around the two `title` values. The registry stores untranslated English source strings by design and `paletteRow()` translates at render, because calling `translate()` at module-evaluation time freezes the locale (#776). All eleven existing titles are bare strings for the same reason.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788467481&installation_model_id=428379&pr_number=1245&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1245&signature=ace9ff0e592f43ddd1f147f50b415d641e9c4cd520c72bf3ccf6b36aa3bb93a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->