### PR TITLE
perf: split the shell's rosters from unread state behind one unread digest

### DIFF
--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -10,7 +10,6 @@ use App\Models\Membership;
 use App\Models\Team;
 use App\Models\UserGroup;
 use App\Policies\TeamPolicy;
-use App\Support\WorkspaceUnread;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -156,24 +155,17 @@ trait HasTeams
      */
     public function toUserTeams(bool $includeCurrent = false): Collection
     {
-        // One grouped query answers every membership's unread standing, so the
-        // workspace list stays a fixed query cost however many workspaces the
-        // user belongs to ({@see WorkspaceUnread}).
-        $unread = WorkspaceUnread::forUser($this);
-
         return $this->teams()
             ->get()
             ->reject(fn (Team $team): bool => ! $includeCurrent && $this->isCurrentTeam($team))
-            ->map(fn (Team $team): UserTeam => $this->toUserTeam($team, $unread[$team->id] ?? null))
+            ->map(fn (Team $team): UserTeam => $this->toUserTeam($team))
             ->values();
     }
 
     /**
      * Get the user's team as a UserTeam object.
-     *
-     * @param  array{unread: int, mention: int}|null  $unread  This workspace's unread standing, when the caller has already resolved it.
      */
-    public function toUserTeam(Team $team, ?array $unread = null): UserTeam
+    public function toUserTeam(Team $team): UserTeam
     {
         $role = $this->teamRole($team);
 
@@ -186,8 +178,6 @@ trait HasTeams
             roleLabel: $role?->label(),
             membersCount: $team->members()->count(),
             isCurrent: $this->isCurrentTeam($team),
-            unreadCount: $unread['unread'] ?? 0,
-            mentionCount: $unread['mention'] ?? 0,
         );
     }
 

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -27,8 +27,6 @@ class ChannelData extends Data
         public bool $isArchived,
         public bool $muted = false,
         public NotificationLevel $notificationLevel = NotificationLevel::All,
-        public int $unreadCount = 0,
-        public int $mentionCount = 0,
         public bool $hasDraft = false,
         public ?string $draft = null,
         public bool $starred = false,
@@ -56,13 +54,15 @@ class ChannelData extends Data
      * The sidebar is the one caller that passes none and still carries state: its
      * single query selects every pivot column onto each channel, so those
      * attributes stand in for the row rather than costing one query per row.
-     * `unread_count` and `mention_count` are only ever attributes — they are
-     * correlated sub-queries, not columns of the pivot — and fall back to zero.
      *
-     * The badge counts are suppressed here so the sidebar prop is authoritative:
-     * a muted channel or the "nothing" level shows no badge at all, and the
-     * "mentions" level keeps only the mention badge (a direct @mention still
-     * alerts while ordinary unread traffic is silenced).
+     * What this DTO deliberately does *not* carry is what is unread in the
+     * channel. A roster changes when someone renames or joins something; unread
+     * state changes on every message anyone sends, and welding the two together
+     * is why the whole list used to be rebuilt on every navigation to move four
+     * integers. The badges now ride {@see UnreadDigestData}, which
+     * still applies mute and the notification level server-side. `muted` and
+     * `notificationLevel` stay here because they are the viewer's own standing
+     * preference — what the row is *set to*, not what is waiting in it.
      *
      * The draft is the viewer's own pending composer text. The open channel
      * (`Show`) carries the full `draft` so the composer restores it; the sidebar
@@ -96,9 +96,6 @@ class ChannelData extends Data
         $level = $stated
             ? $membership->notification_level
             : NotificationLevel::tryFrom((string) ($channel->getAttribute('notification_level') ?? NotificationLevel::All->value)) ?? NotificationLevel::All;
-
-        $unreadCount = (int) ($channel->getAttribute('unread_count') ?? 0);
-        $mentionCount = (int) ($channel->getAttribute('mention_count') ?? 0);
 
         $draftText = $stated ? $membership->draft : $channel->getAttribute('draft');
         $draft = is_string($draftText) && trim($draftText) !== '' ? $draftText : null;
@@ -157,8 +154,6 @@ class ChannelData extends Data
             isArchived: $channel->isArchived(),
             muted: $muted,
             notificationLevel: $level,
-            unreadCount: $level->alertsOnUnread($muted) ? $unreadCount : 0,
-            mentionCount: $level->alertsOnMention($muted) ? $mentionCount : 0,
             hasDraft: $hasDraft,
             draft: $draft,
             starred: $starred,

--- a/app/Data/UnreadCountsData.php
+++ b/app/Data/UnreadCountsData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+/**
+ * One reading of "what is waiting here": ordinary unread traffic and unread
+ * mentions, for a single channel or for a whole workspace.
+ *
+ * Both numbers arrive already suppressed — a muted conversation, or one the
+ * viewer set to "nothing", reports nothing at all — so the client renders the
+ * badge it is given rather than re-deciding whether it is allowed to.
+ */
+#[TypeScript]
+class UnreadCountsData extends Data
+{
+    public function __construct(
+        /** Ordinary unread messages, thread-only replies excluded. */
+        public int $unread,
+        /** Unread messages that named the viewer, wherever they landed. */
+        public int $mention,
+    ) {}
+}

--- a/app/Data/UnreadDigestData.php
+++ b/app/Data/UnreadDigestData.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use App\Support\WorkspaceUnread;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+/**
+ * Everything unread the shell draws, in one prop.
+ *
+ * The shell's rosters say what a workspace *is* — which channels, which people,
+ * in what order — and change when someone renames or joins something. What is
+ * unread changes on every message anyone sends. Welding the second onto the
+ * first is why the whole channel roster used to be recomputed on every
+ * navigation to keep four integers current, so the two are separated here and
+ * this is the volatile half: the one shared prop that rides every visit.
+ *
+ * Both maps are sparse — a channel or workspace with nothing waiting is simply
+ * absent, and the client reads a missing key as zero — so the ordinary case,
+ * where almost everything is read, costs almost nothing on the wire.
+ *
+ * Both readings come out of a single grouped query ({@see WorkspaceUnread}), so
+ * the per-workspace dot and the per-channel badges inside it cannot disagree.
+ */
+#[TypeScript]
+class UnreadDigestData extends Data
+{
+    public function __construct(
+        /**
+         * What is waiting in each channel of the workspace being viewed, keyed
+         * by channel id. Empty off a workspace route, where no sidebar renders.
+         *
+         * @var array<string, UnreadCountsData>
+         */
+        public array $channels,
+        /**
+         * What is waiting in each of the viewer's workspaces, keyed by team id,
+         * driving the rail's dots and the workspace sheet's rows. Present on
+         * every page the dock renders on, workspace route or not.
+         *
+         * @var array<string, UnreadCountsData>
+         */
+        public array $teams,
+        /** Whether any followed thread in the current workspace is unread. */
+        public bool $threads,
+    ) {}
+
+    /**
+     * The digest for someone with nothing to report — a guest, or a viewer off
+     * any workspace at all.
+     *
+     * Named `none` rather than `empty`, which {@see Data} already declares with
+     * an incompatible signature.
+     */
+    public static function none(): self
+    {
+        return new self(channels: [], teams: [], threads: false);
+    }
+}

--- a/app/Data/UserTeam.php
+++ b/app/Data/UserTeam.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace App\Data;
 
+/**
+ * A workspace as the rail's tiles and the workspace sheet's rows list it:
+ * identity, the viewer's standing in it, and how large it is.
+ *
+ * What is *unread* in it deliberately lives elsewhere, in
+ * {@see UnreadDigestData}: this is a roster, and a roster changes when a
+ * workspace is renamed or someone joins it, not on every message anyone sends.
+ */
 readonly class UserTeam
 {
     public function __construct(
@@ -15,10 +23,6 @@ readonly class UserTeam
         public ?string $roleLabel,
         public int $membersCount = 0,
         public ?bool $isCurrent = null,
-        /** Ordinary unread messages waiting in this workspace, muting applied. */
-        public int $unreadCount = 0,
-        /** Unread @mentions waiting in this workspace, muting applied. */
-        public int $mentionCount = 0,
     ) {
         //
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Data\UnreadDigestData;
 use App\Data\UpdateStatusData;
 use App\Enums\MessageReminderStatus;
 use App\Enums\NavDestination;
@@ -20,6 +21,7 @@ use App\Support\UpdateChecker;
 use App\Support\UserAgentParser;
 use App\Support\WebPushConfig;
 use App\Support\WorkspaceShell;
+use App\Support\WorkspaceUnread;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Middleware;
@@ -236,6 +238,14 @@ class HandleInertiaRequests extends Middleware
             'channelRestoreWindowDays' => Channel::RESTORE_WINDOW_DAYS,
             'invitableRoles' => TeamRole::assignable(),
             'channels' => fn (): array => $shell?->channels($activeChannel) ?? [],
+            // What the viewer has not read: the sidebar's per-channel badges,
+            // every workspace's dot, and the Threads dot, in one prop. The
+            // rosters above carry none of it, so they can be cached while this
+            // one — the single genuinely volatile fact on a navigation — is
+            // recomputed every visit. Off a workspace route there is no sidebar
+            // to badge, but the rail still draws its cross-workspace dots, so
+            // the per-workspace half is answered there too.
+            'unread' => fn (): UnreadDigestData => $shell?->unreadDigest() ?? WorkspaceUnread::digest($user),
             // The current team's members feed the DM entry points (the sidebar
             // people picker and the ⌘K "People" group); empty off the workspace.
             'teamMembers' => fn (): array => $shell?->teamMembers() ?? [],
@@ -262,7 +272,6 @@ class HandleInertiaRequests extends Middleware
             // where the composer isn't rendered.
             'slashCommands' => fn (): array => $shell?->slashCommands() ?? [],
             'collapsedChannelSections' => fn () => $user->collapsed_channel_sections ?? [],
-            'hasUnreadThreads' => fn (): bool => $shell?->hasUnreadThreads() ?? false,
             // The Threads panel's inbox and its "Unread" tally, present only while
             // the dock actually has that destination pinned.
             ...$shell?->threadsPanelProps($pinned, ThreadInboxFilter::fromQuery($request->query('filter'))) ?? [],

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -36,8 +36,6 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $deleted_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read int|null $unread_count
- * @property-read int|null $mention_count
  * @property-read bool|null $muted
  * @property-read string|null $notification_level
  * @property-read Team $team

--- a/app/Support/SidebarChannels.php
+++ b/app/Support/SidebarChannels.php
@@ -10,20 +10,19 @@ use App\Models\ChannelMember;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
 
 /**
  * The read model behind the workspace sidebar's channel list: every channel the
  * viewer belongs to in one team, with the per-channel state the rows render from
- * — unread and mention counts, mute and notification level, star, section,
- * manual position, and whether a draft is waiting.
+ * — mute and notification level, star, section, manual position, and whether a
+ * draft is waiting.
  *
- * One query fills all of it. The badge counts are correlated sub-queries
- * ({@see WorkspaceUnread::forChannelsOf()}) rather than a per-channel loop,
- * because the list rides every workspace request and an N+1 here is an N+1 on
- * the whole shell.
+ * One query fills all of it. What is *unread* in each channel is deliberately
+ * not here: it is the one thing that moves on every message anyone sends, and it
+ * rides its own prop ({@see WorkspaceUnread}) so this list does not have to be
+ * rebuilt to move a badge.
  *
  * Direct messages are the one place the list is not simply "what you belong to":
  * a DM exists from the moment either side opens it, so listing every membership
@@ -96,16 +95,6 @@ final readonly class SidebarChannels
             // sidebar payload and expose a 1/0 flag instead (an integer, not a
             // driver-specific boolean, so the DTO's cast reads it reliably).
             ->selectRaw("case when channel_members.draft is not null and channel_members.draft != '' then 1 else 0 end as has_draft")
-            // Thread-only replies stay out of the plain unread badge (they live
-            // in the thread view), but a mention anywhere — including inside a
-            // thread — still badges the channel. That asymmetry is why the
-            // predicate is opt-in per call site: only the first of these two
-            // sub-queries asks for it.
-            ->selectSub(WorkspaceUnread::forChannelsOf($this->viewer)->channelTraffic(), 'unread_count')
-            ->selectSub(
-                WorkspaceUnread::forChannelsOf($this->viewer)->whereHas('mentionedUsers', fn (Builder $query) => $query->whereKey($this->viewer->id)),
-                'mention_count'
-            )
             // Manual order within each sidebar group first, then alphabetical as a
             // stable tiebreak for channels the user has never reordered.
             ->orderBy('channel_members.position')

--- a/app/Support/WorkspaceShell.php
+++ b/app/Support/WorkspaceShell.php
@@ -10,6 +10,7 @@ use App\Data\CustomEmojiData;
 use App\Data\MessageReminderData;
 use App\Data\MessageSearchCriteria;
 use App\Data\SlashCommandData;
+use App\Data\UnreadDigestData;
 use App\Data\UserData;
 use App\Data\UserGroupData;
 use App\Enums\ChannelVisibility;
@@ -185,12 +186,16 @@ final readonly class WorkspaceShell
     }
 
     /**
-     * Whether the viewer has any unread followed thread here, driving the rail's
-     * and the tab bar's "Threads" dot.
+     * What the viewer has not read, detailed for this workspace: its channels'
+     * badges, every workspace's dot, and whether a followed thread is waiting.
+     *
+     * The one shared prop that is not a roster, and the only one that has to be
+     * recomputed on an ordinary navigation — which is why it is derived from an
+     * indexed aggregate rather than from the channel list this shell also feeds.
      */
-    public function hasUnreadThreads(): bool
+    public function unreadDigest(): UnreadDigestData
     {
-        return $this->threadInbox()->hasUnread();
+        return WorkspaceUnread::digest($this->viewer, $this->team);
     }
 
     /**

--- a/app/Support/WorkspaceUnread.php
+++ b/app/Support/WorkspaceUnread.php
@@ -4,101 +4,113 @@ declare(strict_types=1);
 
 namespace App\Support;
 
-use App\Data\ChannelData;
+use App\Data\UnreadCountsData;
+use App\Data\UnreadDigestData;
 use App\Enums\MessageType;
 use App\Enums\NotificationLevel;
 use App\Models\Message;
+use App\Models\Team;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Collection;
+use stdClass;
 
 /**
  * What the viewer has not read, in the two shapes the shell asks for: per
  * workspace (the rail's dots and the workspace sheet's badges) and per channel
  * (the sidebar's badges).
  *
- * Both live here so they cannot drift. "Unread" is one rule — every non-deleted,
- * non-system message authored by someone else that lands after the viewer's
- * `last_read_message_id`, a null pointer meaning the channel was never opened —
- * and a workspace dot that disagreed with the channel rows found inside it would
- * be worse than no dot at all. Muting and the notification level are applied
- * through {@see NotificationLevel}'s own SQL forms, the same rule
- * {@see ChannelData::fromChannel()} applies per channel in PHP.
+ * Both come out of **one** grouped query here, so they cannot drift. The
+ * per-workspace reading is the per-channel readings summed, which is stronger
+ * than two queries agreeing by inspection: a workspace dot that disagreed with
+ * the channel rows found inside it would be worse than no dot at all.
+ *
+ * "Unread" is one rule — every non-deleted, non-system message authored by
+ * someone else that lands after the viewer's `last_read_message_id`, a null
+ * pointer meaning the channel was never opened. Muting and the notification
+ * level are applied here, through {@see NotificationLevel}'s own SQL forms, so
+ * suppression stays server-side and the client renders what it is handed.
+ *
+ * The query is an indexed aggregate over `messages`, not a hydrate-and-serialise
+ * of the roster: it returns one row per channel that holds something, whatever
+ * the workspace's size, and its cost is one query however many channels the
+ * viewer belongs to.
  */
 class WorkspaceUnread
 {
     /**
-     * Unread and mention counts per team id, for the teams that have any. A team
-     * with nothing new is simply absent, so callers default it to zero.
+     * The viewer's whole unread standing, ready to ship.
      *
-     * @return array<string, array{unread: int, mention: int}>
+     * `$workspace` is the one they are currently looking at, if any: its
+     * channels are detailed and its threads consulted. Every workspace they
+     * belong to is counted either way, because the rail draws its dots from
+     * pages that have no workspace of their own (settings, team admin).
      */
-    public static function forUser(User $user): array
+    public static function digest(?User $viewer, ?Team $workspace = null): UnreadDigestData
     {
-        return self::query($user)
-            ->get()
-            ->mapWithKeys(fn (object $row): array => [
-                (string) $row->team_id => [
-                    'unread' => (int) $row->unread_count,
-                    'mention' => (int) $row->mention_count,
-                ],
-            ])
-            ->all();
+        if (! $viewer instanceof User) {
+            return UnreadDigestData::none();
+        }
+
+        $teams = [];
+        $channels = [];
+
+        foreach (self::countsByChannel($viewer) as $row) {
+            $unread = (int) $row->unread_count;
+            $mention = (int) $row->mention_count;
+
+            // A channel can match the aggregate and still report nothing — every
+            // message in it a thread-only reply, say. Sparse means sparse.
+            if ($unread === 0 && $mention === 0) {
+                continue;
+            }
+
+            $teamId = (string) $row->team_id;
+            $running = $teams[$teamId] ?? new UnreadCountsData(unread: 0, mention: 0);
+
+            $teams[$teamId] = new UnreadCountsData(
+                unread: $running->unread + $unread,
+                mention: $running->mention + $mention,
+            );
+
+            if ($workspace instanceof Team && $teamId === $workspace->id) {
+                $channels[(string) $row->channel_id] = new UnreadCountsData($unread, $mention);
+            }
+        }
+
+        return new UnreadDigestData(
+            channels: $channels,
+            teams: $teams,
+            threads: $workspace instanceof Team && new ThreadInbox($viewer, $workspace)->hasUnread(),
+        );
     }
 
     /**
-     * A correlated sub-query counting one channel's messages the viewer has not
-     * yet read, for the sidebar's per-channel badges.
-     *
-     * Correlated against the outer sidebar query's `channels` and
-     * `channel_members` rows, so a single query fills every channel's badge
-     * without an N+1. Unlike {@see self::forUser()} it applies no muting: the
-     * sidebar ships the raw counts and {@see ChannelData::fromChannel()}
-     * suppresses the badge, because a muted channel still has to know it holds
-     * something new.
-     *
-     * @return EloquentBuilder<Message>
-     */
-    public static function forChannelsOf(User $user): EloquentBuilder
-    {
-        return Message::query()
-            ->selectRaw('count(*)')
-            ->whereColumn('messages.channel_id', 'channels.id')
-            ->where('messages.user_id', '!=', $user->id)
-            // System notices (member joined / left) are ambient: they never
-            // advance the unread badge or raise a mention, so they are excluded
-            // from both the unread and mention counts. Every other type counts —
-            // a poll is user-authored and badges the channel like a message.
-            ->whereNotIn('messages.type', MessageType::systemValues())
-            ->where(fn (EloquentBuilder $query) => $query
-                ->whereNull('channel_members.last_read_message_id')
-                ->orWhereColumn('messages.id', '>', 'channel_members.last_read_message_id'));
-    }
-
-    /**
-     * The grouped query behind {@see self::forUser()}.
+     * One row per channel the viewer has anything waiting in, across every
+     * workspace they belong to.
      *
      * Rides `Message::query()` rather than the query builder so the model's
      * soft-delete scope applies — a deleted message must stop counting — then
      * drops to the base builder because the rows are aggregates, not messages.
+     *
+     * @return Collection<int, stdClass>
      */
-    protected static function query(User $user): QueryBuilder
+    protected static function countsByChannel(User $viewer): Collection
     {
         return Message::query()
             ->join('channels', 'channels.id', '=', 'messages.channel_id')
-            ->join('channel_members', function (JoinClause $join) use ($user): void {
+            ->join('channel_members', function (JoinClause $join) use ($viewer): void {
                 $join->on('channel_members.channel_id', '=', 'channels.id')
-                    ->where('channel_members.user_id', '=', $user->id);
+                    ->where('channel_members.user_id', '=', $viewer->id);
             })
             // A mention is a row in the pivot for *this* viewer; the left join
             // keeps ordinary messages in the aggregate with a null side.
-            ->leftJoin('mentions', function (JoinClause $join) use ($user): void {
+            ->leftJoin('mentions', function (JoinClause $join) use ($viewer): void {
                 $join->on('mentions.message_id', '=', 'messages.id')
-                    ->where('mentions.mentioned_user_id', '=', $user->id);
+                    ->where('mentions.mentioned_user_id', '=', $viewer->id);
             })
             ->whereNull('channels.archived_at')
-            ->where('messages.user_id', '!=', $user->id)
+            ->where('messages.user_id', '!=', $viewer->id)
             // System notices (member joined / left) are ambient: they never
             // badge a channel, so they never badge a workspace either.
             ->whereNotIn('messages.type', MessageType::systemValues())
@@ -110,8 +122,8 @@ class WorkspaceUnread
             // reading is the wider of the two, so it is the one that bounds the
             // whole aggregate.
             ->whereRaw(NotificationLevel::alertsOnMentionSql('channel_members'))
-            ->groupBy('channels.team_id')
-            ->select('channels.team_id')
+            ->groupBy('channels.id', 'channels.team_id')
+            ->select('channels.id as channel_id', 'channels.team_id')
             // Thread-only replies live in the thread view and stay out of the
             // plain unread count, and the "mentions" level silences it entirely.
             // Both halves are the owning module's own SQL fragment rather than a
@@ -123,6 +135,7 @@ class WorkspaceUnread
                 .' and '.Message::channelTrafficSql().' then 1 else 0 end) as unread_count',
             )
             ->selectRaw('sum(case when mentions.message_id is not null then 1 else 0 end) as mention_count')
-            ->toBase();
+            ->toBase()
+            ->get();
     }
 }

--- a/resources/js/components/ChannelListItem.test.ts
+++ b/resources/js/components/ChannelListItem.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import type { Channel } from '@/types/channels';
+import type { UnreadCounts } from '@/types/unread';
+
+/**
+ * Inertia + Wayfinder + UI stubs, so the row's own markup — the mention badge,
+ * the draft cue, the unread dot — renders in isolation. `stub(tag)` builds a
+ * passthrough component; hoisted so the vi.mock factories can reach it.
+ */
+const { stub } = await vi.hoisted(async () => {
+    const { defineComponent, h: hyper } = await import('vue');
+
+    return {
+        stub: (tag: string) =>
+            defineComponent({
+                setup:
+                    (_: unknown, ctx: { slots: { default?: () => unknown } }) =>
+                    () =>
+                        hyper(tag, ctx.slots.default?.() as never),
+            }),
+    };
+});
+
+/**
+ * The shared props the row reads its badge from. The `channel` prop carries no
+ * counts at all — the digest is the only thing that says what is waiting.
+ */
+const page = await vi.hoisted(async () => ({
+    props: {
+        unread: { channels: {}, teams: {}, threads: false },
+    } as Record<string, unknown>,
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    Link: stub('a'),
+    router: { patch: vi.fn() },
+    usePage: () => page,
+}));
+vi.mock('@lucide/vue', () => ({
+    GripVertical: stub('svg'),
+    MoreVertical: stub('svg'),
+    Pencil: stub('svg'),
+    Star: stub('svg'),
+}));
+vi.mock('@/composables/useToast', () => ({
+    useToast: () => ({
+        error: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    }),
+}));
+vi.mock('@/actions/App/Http/Controllers/Channels/ChannelController', () => ({
+    show: () => ({ url: '/acme/design' }),
+}));
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/ChannelStarController',
+    () => ({
+        update: () => ({ url: '/acme/design/star' }),
+    }),
+);
+vi.mock('@/components/ui/button', () => ({ Button: stub('button') }));
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: stub('div'),
+    DropdownMenuContent: stub('div'),
+    DropdownMenuItem: stub('div'),
+    DropdownMenuLabel: stub('div'),
+    DropdownMenuSeparator: stub('div'),
+    DropdownMenuTrigger: stub('div'),
+}));
+vi.mock('@/components/ui/sidebar', () => ({
+    SidebarMenuItem: stub('div'),
+    SidebarMenuButton: stub('div'),
+}));
+vi.mock('@/components/ui/tooltip', () => ({
+    Tooltip: stub('div'),
+    TooltipTrigger: stub('div'),
+    TooltipContent: stub('div'),
+}));
+
+import ChannelListItem from './ChannelListItem.vue';
+
+function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        id: 'ch-1',
+        name: 'design',
+        slug: 'design',
+        visibility: 'public',
+        topic: null,
+        description: null,
+        isGeneral: false,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        sectionId: null,
+        position: 0,
+        isDirect: false,
+        isGroupDirect: false,
+        dmUserId: null,
+        dmParticipants: null,
+        lastActivityAt: null,
+        ...overrides,
+    };
+}
+
+async function render(
+    unread?: UnreadCounts,
+    overrides: Partial<Channel> = {},
+): Promise<string> {
+    const row = channel(overrides);
+
+    page.props.unread = {
+        channels: unread ? { [row.id]: unread } : {},
+        teams: {},
+        threads: false,
+    };
+
+    const app = createSSRApp({
+        render: () =>
+            h(ChannelListItem, {
+                channel: row,
+                teamSlug: 'acme',
+                activeChannelSlug: null,
+            }),
+    });
+
+    app.config.globalProperties.$t = (
+        key: string,
+        replacements?: Record<string, unknown>,
+    ) =>
+        replacements
+            ? Object.entries(replacements).reduce(
+                  (line, [token, value]) =>
+                      line.replaceAll(`:${token}`, String(value)),
+                  key,
+              )
+            : key;
+
+    return renderToString(app);
+}
+
+describe('ChannelListItem badges', () => {
+    it('spells out the mention count from the digest, not from the channel row', async () => {
+        const html = await render({ unread: 9, mention: 2 });
+
+        expect(html).toContain('data-test="mention-badge"');
+        expect(html).toContain('>2</span>');
+        expect(html).toContain('2 unread mentions');
+    });
+
+    it('falls back to a plain dot when the unread traffic named nobody', async () => {
+        const html = await render({ unread: 3, mention: 0 });
+
+        expect(html).not.toContain('data-test="mention-badge"');
+        expect(html).toContain('data-test="unread-dot"');
+        expect(html).toContain('data-test="channel-unread-design"');
+    });
+
+    /**
+     * The draft cue outranks the dot and is outranked by the mention badge, and
+     * it lives on the roster rather than the digest — the two halves have to
+     * compose in one row for that ordering to survive the split.
+     */
+    it('prefers the draft cue over the unread dot, and the mention badge over both', async () => {
+        const drafted = await render(
+            { unread: 3, mention: 0 },
+            { hasDraft: true },
+        );
+
+        expect(drafted).toContain('data-test="draft-indicator"');
+        expect(drafted).not.toContain('data-test="unread-dot"');
+
+        const mentioned = await render(
+            { unread: 3, mention: 1 },
+            { hasDraft: true },
+        );
+
+        expect(mentioned).toContain('data-test="mention-badge"');
+        expect(mentioned).not.toContain('data-test="draft-indicator"');
+    });
+
+    it('renders no badge at all for a channel the digest does not name', async () => {
+        const html = await render();
+
+        expect(html).not.toContain('data-test="mention-badge"');
+        expect(html).not.toContain('data-test="unread-dot"');
+    });
+});

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -21,8 +21,10 @@ import {
 } from '@/components/ui/tooltip';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
+import { useUnreadDigest } from '@/composables/useUnreadDigest';
 import { notificationIndicator } from '@/lib/notificationIndicator';
 import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
+import { channelUnread } from '@/lib/unreadDigest';
 import type { Channel, ChannelSection } from '@/types/channels';
 
 const props = defineProps<{
@@ -50,6 +52,12 @@ const menuOpen = ref(false);
 
 const { t } = useTranslations();
 const toast = useToast();
+const digest = useUnreadDigest();
+
+// What this row has waiting. Read from the shared digest rather than from the
+// `channel` prop beside it: the roster says what the channel *is*, and only the
+// digest is refreshed often enough to be trusted for a badge.
+const unread = computed(() => channelUnread(digest.value, props.channel.id));
 
 // The mute / notification-level cue for this row, matching the conversation
 // masthead; null (and so no icon) for an unmuted channel at the default level.
@@ -104,7 +112,7 @@ function toggleStar(): void {
                     :class="
                         channel.slug === activeChannelSlug
                             ? 'text-brass'
-                            : channel.unreadCount > 0
+                            : unread.unread > 0
                               ? 'text-muted-foreground'
                               : 'text-muted-foreground'
                     "
@@ -113,8 +121,7 @@ function toggleStar(): void {
                 <span
                     class="truncate"
                     :class="
-                        channel.unreadCount > 0 &&
-                        channel.slug !== activeChannelSlug
+                        unread.unread > 0 && channel.slug !== activeChannelSlug
                             ? 'font-semibold text-sidebar-foreground'
                             : ''
                     "
@@ -140,15 +147,15 @@ function toggleStar(): void {
                 <!-- then a "draft" cue for a pending unsent message on -->
                 <!-- another channel; otherwise a plain unread dot. -->
                 <span
-                    v-if="channel.mentionCount > 0"
+                    v-if="unread.mention > 0"
                     data-test="mention-badge"
                     class="ml-auto flex h-4.25 min-w-4.5 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
                     :aria-label="
                         $t(':count unread mentions', {
-                            count: channel.mentionCount,
+                            count: unread.mention,
                         })
                     "
-                    >{{ channel.mentionCount }}</span
+                    >{{ unread.mention }}</span
                 >
                 <span
                     v-else-if="
@@ -161,7 +168,7 @@ function toggleStar(): void {
                     <Pencil class="size-3" />
                     {{ $t('Draft') }}
                 </span>
-                <template v-else-if="channel.unreadCount > 0">
+                <template v-else-if="unread.unread > 0">
                     <span
                         data-test="unread-dot"
                         aria-hidden="true"

--- a/resources/js/components/ChannelMasthead.connectionPill.test.ts
+++ b/resources/js/components/ChannelMasthead.connectionPill.test.ts
@@ -107,8 +107,6 @@ function channel(): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,

--- a/resources/js/components/ChannelMasthead.doubles.ts
+++ b/resources/js/components/ChannelMasthead.doubles.ts
@@ -119,8 +119,6 @@ export function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,

--- a/resources/js/components/CommandPalette.doubles.ts
+++ b/resources/js/components/CommandPalette.doubles.ts
@@ -214,8 +214,6 @@ export function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,

--- a/resources/js/components/DirectMessageListItem.test.ts
+++ b/resources/js/components/DirectMessageListItem.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import type { Channel } from '@/types/channels';
+import type { UnreadCounts } from '@/types/unread';
 
 /**
  * Inertia + Wayfinder + UI stubs so the row's own markup (unread badge, close
@@ -23,10 +24,21 @@ const { stub } = await vi.hoisted(async () => {
     };
 });
 
+/**
+ * The row reads its badge off the shared unread digest, so the stubbed page
+ * carries one — the `channel` prop beside it holds no counts at all.
+ */
+const page = await vi.hoisted(async () => ({
+    props: {
+        auth: { user: { avatar: null } },
+        unread: { channels: {}, teams: {}, threads: false },
+    } as Record<string, unknown>,
+}));
+
 vi.mock('@inertiajs/vue3', () => ({
     Link: stub('a'),
     router: { post: vi.fn() },
-    usePage: () => ({ props: { auth: { user: { avatar: null } } } }),
+    usePage: () => page,
 }));
 vi.mock('@/composables/useToast', () => {
     const toast = {
@@ -78,8 +90,6 @@ function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,
@@ -94,7 +104,16 @@ function channel(overrides: Partial<Channel> = {}): Channel {
     };
 }
 
-async function render(overrides: Partial<Channel> = {}): Promise<string> {
+async function render(
+    unread: UnreadCounts = { unread: 0, mention: 0 },
+    overrides: Partial<Channel> = {},
+): Promise<string> {
+    page.props.unread = {
+        channels: { [channel(overrides).id]: unread },
+        teams: {},
+        threads: false,
+    };
+
     const app = createSSRApp({
         render: () =>
             h(DirectMessageListItem, {
@@ -113,7 +132,7 @@ async function render(overrides: Partial<Channel> = {}): Promise<string> {
 
 describe('DirectMessageListItem unread badge', () => {
     it('fades the unread pill out on hover and close-button focus so the ✕ replaces it', async () => {
-        const html = await render({ unreadCount: 3 });
+        const html = await render({ unread: 3, mention: 0 });
 
         expect(html).toContain('data-test="dm-unread-badge"');
         // The pill hides whenever the close button is revealed: on row hover...
@@ -125,14 +144,14 @@ describe('DirectMessageListItem unread badge', () => {
     });
 
     it('hides the multi-digit pill the same way, so a wider count never peeks past the mask', async () => {
-        const html = await render({ unreadCount: 42 });
+        const html = await render({ unread: 42, mention: 0 });
 
         expect(html).toContain('>42</span>');
         expect(html).toContain('group-hover/row:opacity-0');
     });
 
     it('anchors the close button to the same right edge as the pill so the ✕ replaces it in place', async () => {
-        const html = await render({ unreadCount: 3 });
+        const html = await render({ unread: 3, mention: 0 });
 
         // Row content sits at `pr-2.5`, so the right-aligned pill rests on that
         // inset; the overlay close button matches it (`right-2.5`) instead of the
@@ -143,7 +162,7 @@ describe('DirectMessageListItem unread badge', () => {
     });
 
     it('renders no pill when there is nothing unread', async () => {
-        const html = await render({ unreadCount: 0 });
+        const html = await render();
 
         expect(html).not.toContain('data-test="dm-unread-badge"');
     });

--- a/resources/js/components/DirectMessageListItem.vue
+++ b/resources/js/components/DirectMessageListItem.vue
@@ -18,11 +18,13 @@ import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
 import { useInitials } from '@/composables/useInitials';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
+import { useUnreadDigest } from '@/composables/useUnreadDigest';
 import { groupDmSidebarName } from '@/lib/groupDm';
 import { notificationIndicator } from '@/lib/notificationIndicator';
 import { presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
 import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
+import { channelUnread } from '@/lib/unreadDigest';
 import type { Channel } from '@/types/channels';
 
 const props = defineProps<{
@@ -47,6 +49,11 @@ const MAX_ROW_AVATARS = 3;
 const isGroup = computed(() => props.channel.isGroupDirect);
 
 const page = usePage();
+const digest = useUnreadDigest();
+
+// What this conversation has waiting, read from the shared digest rather than
+// from the `channel` prop: the roster is allowed to be stale, a badge is not.
+const unread = computed(() => channelUnread(digest.value, props.channel.id));
 
 // The other participant of a 1:1 DM, whose avatar the row shows.
 const soloParticipant = computed(
@@ -178,7 +185,7 @@ function hide(): void {
                 <span
                     class="truncate"
                     :class="
-                        channel.unreadCount > 0 && !isActive
+                        unread.unread > 0 && !isActive
                             ? 'font-semibold text-sidebar-foreground'
                             : ''
                     "
@@ -215,15 +222,15 @@ function hide(): void {
                      (the pill can be wider than the button's mask on multi-digit
                      counts, so masking alone would leave it peeking out). -->
                 <span
-                    v-if="channel.unreadCount > 0"
+                    v-if="unread.unread > 0"
                     data-test="dm-unread-badge"
                     class="ml-auto flex h-4.25 min-w-4.5 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums transition-opacity group-hover/row:opacity-0 group-has-[button:focus-visible]/row:opacity-0"
                     :aria-label="
                         $t(':count unread messages', {
-                            count: channel.unreadCount,
+                            count: unread.unread,
                         })
                     "
-                    >{{ channel.unreadCount }}</span
+                    >{{ unread.unread }}</span
                 >
             </Link>
         </SidebarMenuButton>

--- a/resources/js/components/channel/ChannelDetailsDialog.test.ts
+++ b/resources/js/components/channel/ChannelDetailsDialog.test.ts
@@ -89,8 +89,6 @@ function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,

--- a/resources/js/components/navigation/NavigationRail.test.ts
+++ b/resources/js/components/navigation/NavigationRail.test.ts
@@ -4,6 +4,15 @@ import type { App } from 'vue';
 import { createApp, defineComponent, h } from 'vue';
 import type { NavDestination } from '@/composables/useNavPanel';
 import type { Team, User } from '@/types';
+import type { UnreadCounts } from '@/types/unread';
+
+/**
+ * The shared props the rail reads through {@see useUnreadDigest}: the workspace
+ * dots come off the digest, not off the workspace roster beside them.
+ */
+const page = vi.hoisted(() => ({ props: {} as Record<string, unknown> }));
+
+vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
 
 vi.mock('@lucide/vue', () => ({
     AlarmClock: { render: () => h('svg') },
@@ -90,8 +99,6 @@ function makeTeam(overrides: Partial<Team> = {}): Team {
         isPersonal: false,
         membersCount: 7,
         isCurrent: true,
-        unreadCount: 0,
-        mentionCount: 0,
         ...overrides,
     };
 }
@@ -103,6 +110,7 @@ afterEach(() => {
     app = null;
     document.body.innerHTML = '';
     switchTeam.mockClear();
+    page.props = {};
 });
 
 function mountRail(
@@ -112,10 +120,16 @@ function mountRail(
         hasPendingReminders?: boolean;
         teams?: Team[];
         avatar?: string;
+        /** What the digest says is waiting in each workspace, keyed by team id. */
+        unread?: Record<string, UnreadCounts>;
     } = {},
 ) {
     const host = document.createElement('div');
     document.body.append(host);
+
+    page.props = {
+        unread: { channels: {}, teams: overrides.unread ?? {}, threads: false },
+    };
 
     const select = vi.fn();
 
@@ -320,14 +334,10 @@ it('dots a workspace holding anything unread, and only that one', () => {
     const { host } = mountRail({
         teams: [
             makeTeam(),
-            makeTeam({
-                id: 't-2',
-                name: 'Nord',
-                isCurrent: false,
-                unreadCount: 4,
-            }),
+            makeTeam({ id: 't-2', name: 'Nord', isCurrent: false }),
             makeTeam({ id: 't-3', name: 'Sud', isCurrent: false }),
         ],
+        unread: { 't-2': { unread: 4, mention: 0 } },
     });
 
     expect(
@@ -337,14 +347,8 @@ it('dots a workspace holding anything unread, and only that one', () => {
 
 it('dots a workspace whose only news is a mention', () => {
     const { host } = mountRail({
-        teams: [
-            makeTeam({
-                id: 't-2',
-                name: 'Nord',
-                isCurrent: false,
-                mentionCount: 2,
-            }),
-        ],
+        teams: [makeTeam({ id: 't-2', name: 'Nord', isCurrent: false })],
+        unread: { 't-2': { unread: 0, mention: 2 } },
     });
 
     expect(

--- a/resources/js/components/navigation/NavigationRail.vue
+++ b/resources/js/components/navigation/NavigationRail.vue
@@ -11,7 +11,9 @@ import UserMenuPopover from '@/components/UserMenuPopover.vue';
 import { useInitials } from '@/composables/useInitials';
 import type { NavDestination } from '@/composables/useNavPanel';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
+import { useUnreadDigest } from '@/composables/useUnreadDigest';
 import type { RenderedPresence } from '@/lib/presence';
+import { workspaceUnread } from '@/lib/unreadDigest';
 import type { Team, User } from '@/types';
 
 /**
@@ -52,6 +54,7 @@ const emit = defineEmits<{
 
 const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
+const digest = useUnreadDigest();
 
 const hasAvatar = computed(
     () => !!props.user.avatar && props.user.avatar !== '',
@@ -72,7 +75,9 @@ const hasAvatar = computed(
  * room to read it.
  */
 function hasUnread(team: Team): boolean {
-    return team.unreadCount > 0 || team.mentionCount > 0;
+    const counts = workspaceUnread(digest.value, team.id);
+
+    return counts.unread > 0 || counts.mention > 0;
 }
 
 /**

--- a/resources/js/components/navigation/WorkspaceSheet.test.ts
+++ b/resources/js/components/navigation/WorkspaceSheet.test.ts
@@ -4,6 +4,7 @@ import type { App } from 'vue';
 import { createApp, defineComponent, h } from 'vue';
 import { useDialog } from '@/composables/useDialog';
 import type { Team } from '@/types';
+import type { UnreadDigest } from '@/types/unread';
 
 /** Mutable stand-in for the shared workspace props. */
 const props = vi.hoisted(() => ({
@@ -12,6 +13,7 @@ const props = vi.hoisted(() => ({
     canInviteToCurrentTeam: false,
     canUpdateCurrentTeam: false,
     pendingInvitations: [] as unknown[],
+    unread: null as UnreadDigest | null,
 }));
 
 const switchTeam = vi.hoisted(() => vi.fn());
@@ -116,8 +118,6 @@ function team(overrides: Partial<Team> = {}): Team {
         isPersonal: false,
         membersCount: 7,
         isCurrent: true,
-        unreadCount: 0,
-        mentionCount: 0,
         ...overrides,
     };
 }
@@ -130,6 +130,7 @@ beforeEach(() => {
     props.canInviteToCurrentTeam = true;
     props.canUpdateCurrentTeam = true;
     props.pendingInvitations = [];
+    props.unread = { channels: {}, teams: {}, threads: false };
     viewport.setMobile?.(false);
     switchTeam.mockClear();
     useDialog('invite').close();
@@ -276,9 +277,17 @@ it('switches straight to another workspace', () => {
 
 it('badges a workspace with its mention count, and dots a merely unread one', () => {
     props.teams = [
-        team({ id: 't-2', name: 'Nord', isCurrent: false, mentionCount: 3 }),
-        team({ id: 't-3', name: 'Sud', isCurrent: false, unreadCount: 5 }),
+        team({ id: 't-2', name: 'Nord', isCurrent: false }),
+        team({ id: 't-3', name: 'Sud', isCurrent: false }),
     ];
+    props.unread = {
+        channels: {},
+        teams: {
+            't-2': { unread: 0, mention: 3 },
+            't-3': { unread: 5, mention: 0 },
+        },
+        threads: false,
+    };
 
     const { host } = mountSheet();
 

--- a/resources/js/components/navigation/WorkspaceSheet.vue
+++ b/resources/js/components/navigation/WorkspaceSheet.vue
@@ -24,8 +24,11 @@ import { useInitials } from '@/composables/useInitials';
 import { useIsMobile } from '@/composables/useIsMobile';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
 import { useTranslations } from '@/composables/useTranslations';
+import { useUnreadDigest } from '@/composables/useUnreadDigest';
+import { workspaceUnread } from '@/lib/unreadDigest';
 import { edit as teamEdit } from '@/routes/teams';
 import type { Team } from '@/types';
+import type { UnreadCounts } from '@/types/unread';
 
 /**
  * The workspace sheet: one surface behind three anchors — the desktop panel
@@ -66,6 +69,16 @@ const { getInitials } = useInitials();
 const inviteDialog = useDialog('invite');
 const invitationsDialog = useDialog('invitations');
 const { switchTeam } = useTeamSwitch();
+const digest = useUnreadDigest();
+
+/**
+ * What a workspace row has waiting. Read from the shared digest, which is the
+ * one prop refreshed often enough to be trusted for a badge — the workspace
+ * roster beside it says only what the workspaces *are*.
+ */
+function unreadFor(team: Team): UnreadCounts {
+    return workspaceUnread(digest.value, team.id);
+}
 
 const currentTeam = computed<Team | null>(() => page.props.currentTeam);
 const teams = computed<Team[]>(() => page.props.teams ?? []);
@@ -249,17 +262,17 @@ const sheetRowClass =
                 />
                 <template v-else>
                     <span
-                        v-if="team.mentionCount > 0"
+                        v-if="unreadFor(team).mention > 0"
                         data-test="workspace-mention-badge"
                         class="flex h-4.5 min-w-4.5 shrink-0 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
                         :aria-label="
                             $t(':count unread mentions', {
-                                count: team.mentionCount,
+                                count: unreadFor(team).mention,
                             })
                         "
-                        >{{ team.mentionCount }}</span
+                        >{{ unreadFor(team).mention }}</span
                     >
-                    <template v-else-if="team.unreadCount > 0">
+                    <template v-else-if="unreadFor(team).unread > 0">
                         <span
                             aria-hidden="true"
                             data-test="workspace-unread-dot"
@@ -409,17 +422,17 @@ const sheetRowClass =
                 />
                 <template v-else>
                     <span
-                        v-if="team.mentionCount > 0"
+                        v-if="unreadFor(team).mention > 0"
                         data-test="workspace-mention-badge"
                         class="flex h-4.25 min-w-4.5 shrink-0 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
                         :aria-label="
                             $t(':count unread mentions', {
-                                count: team.mentionCount,
+                                count: unreadFor(team).mention,
                             })
                         "
-                        >{{ team.mentionCount }}</span
+                        >{{ unreadFor(team).mention }}</span
                     >
-                    <template v-else-if="team.unreadCount > 0">
+                    <template v-else-if="unreadFor(team).unread > 0">
                         <span
                             aria-hidden="true"
                             data-test="workspace-unread-dot"

--- a/resources/js/components/teams/ChannelCreationForm.test.ts
+++ b/resources/js/components/teams/ChannelCreationForm.test.ts
@@ -83,8 +83,6 @@ function team(): Team {
         slug: 'acme',
         isPersonal: false,
         membersCount: 1,
-        unreadCount: 0,
-        mentionCount: 0,
     };
 }
 

--- a/resources/js/components/teams/DefaultChannelsForm.test.ts
+++ b/resources/js/components/teams/DefaultChannelsForm.test.ts
@@ -54,8 +54,6 @@ function team(): Team {
         slug: 'acme',
         isPersonal: false,
         membersCount: 1,
-        unreadCount: 0,
-        mentionCount: 0,
     };
 }
 

--- a/resources/js/composables/useReadPointer.ts
+++ b/resources/js/composables/useReadPointer.ts
@@ -3,7 +3,7 @@ import { echo } from '@laravel/echo-vue';
 import { read as markChannelRead } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { backgroundVisit } from '@/lib/backgroundVisit';
-import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
+import { UNREAD_DIGEST_PROPS } from '@/lib/reloadProps';
 
 export interface ReadPointerOptions {
     teamSlug: () => string;
@@ -14,7 +14,9 @@ export interface ReadPointerOptions {
  * Advance the read pointer for the open channel so its sidebar badge clears.
  * Debounced and gated on tab focus: a channel is only "read" while the user is
  * actually looking at it, and a burst of arriving messages collapses to one
- * request. The redirect refreshes just the shared `channels` prop.
+ * request. The redirect refreshes just the unread digest — the badge is the
+ * only thing this write moves, and reloading the roster to move it was the
+ * second PHP round trip every click used to pay.
  *
  * The Echo socket id rides along so the resulting `ReadStateAdvanced` broadcast
  * skips this tab: the response above already brings it fresh counts, and its
@@ -41,7 +43,7 @@ export function useReadPointer(options: ReadPointerOptions): {
                     ...backgroundVisit,
                     preserveScroll: true,
                     preserveState: true,
-                    only: CHANNEL_LIST_PROPS,
+                    only: UNREAD_DIGEST_PROPS,
                     headers: socketId ? { 'X-Socket-ID': socketId } : {},
                 },
             );

--- a/resources/js/composables/useSidebarBadges.test.ts
+++ b/resources/js/composables/useSidebarBadges.test.ts
@@ -107,15 +107,11 @@ describe('useSidebarBadges cross-device read sync', () => {
         expect(reload).toHaveBeenCalledTimes(1);
         expect(reload).toHaveBeenCalledWith(
             expect.objectContaining({
-                // `unreadThreadCount` and `teams` ride along so the Threads
-                // panel's tally and the cross-workspace dots refresh on the same
-                // debounced reload the channel badges already use.
-                only: [
-                    'channels',
-                    'hasUnreadThreads',
-                    'unreadThreadCount',
-                    'teams',
-                ],
+                // One prop answers every badge the shell draws. `channels`
+                // rides along because an arrival also reorders the DM group and
+                // can earn a new row, and `unreadThreadCount` so the Threads
+                // panel's tally refreshes on the same debounced reload.
+                only: ['unread', 'channels', 'unreadThreadCount'],
             }),
         );
     });

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -5,6 +5,7 @@ import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscr
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { backgroundVisit } from '@/lib/backgroundVisit';
 import { isChannelTraffic } from '@/lib/channelTraffic';
+import { CHANNEL_LIST_PROPS, UNREAD_DIGEST_PROPS } from '@/lib/reloadProps';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
 
 /** Coalesce a burst of arrivals into a single sidebar reload. */
@@ -13,13 +14,13 @@ const REFRESH_DEBOUNCE_MS = 500;
 /**
  * Keep the sidebar's unread and mention badges live.
  *
- * The shared `channels` prop is recomputed server-side (see HandleInertiaRequests)
+ * The shared `unread` digest is recomputed server-side (see HandleInertiaRequests)
  * but only refreshes on navigation and when the open channel is marked read, so a
  * message posted in a channel the user belongs to but is not viewing would not move
  * its badge until the next visit. Mounted once in the persistent channel layout,
  * this rides {@see useChannelFleetSubscription} — the shared subscribe/reconcile/
  * teardown engine — and, on a qualifying MessageSent, debounces a partial reload of
- * `channels` so the badge updates without a manual navigation. A single reload
+ * the digest so the badge updates without a manual navigation. A single reload
  * recomputes every channel's count, so bursts across channels collapse to one
  * request.
  *
@@ -38,19 +39,19 @@ export function useSidebarBadges(): void {
         () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
     );
 
-    // reload defaults to preserving scroll and page state; it re-evaluates the
-    // shared `channels` prop to recompute every badge count, the aggregate
-    // `hasUnreadThreads` flag behind the rail's Threads dot, the
-    // `unreadThreadCount` behind the Threads panel's "Unread" pill, and `teams` —
-    // whose per-workspace counts are the cross-workspace dots on the rail. The
-    // last one rides along rather than getting its own signal: no per-member
-    // fanout of MessageSent exists, so a workspace the viewer is not in
-    // refreshes on the next trigger any of their own channels raises. A
-    // teammate's
-    // message — or another of the viewer's own devices — decides when it fires,
-    // so it runs as a background visit ({@see backgroundVisit}); otherwise an
-    // arrival landing mid-navigation cancels the visit the user actually asked
-    // for.
+    // reload defaults to preserving scroll and page state. One prop answers
+    // every badge the shell draws — the sidebar's per-channel counts, the
+    // rail's cross-workspace dots and its Threads dot were three readings of
+    // the same fact before the digest consolidated them — so a burst across
+    // channels still collapses to a single request for a single prop.
+    //
+    // `channels` rides along because an arrival also moves what the *roster*
+    // says: the direct-message group orders on last activity, and a DM nobody
+    // had messaged in yet earns its row on the first message. Neither is unread
+    // state, so neither belongs in the digest. A teammate's message — or
+    // another of the viewer's own devices — decides when this fires, so it runs
+    // as a background visit ({@see backgroundVisit}); otherwise an arrival
+    // landing mid-navigation cancels the visit the user actually asked for.
     //
     // `unreadThreadCount` is shared only while that panel is open, so asking for
     // it off the destination costs nothing: the server simply has no such prop to
@@ -61,10 +62,9 @@ export function useSidebarBadges(): void {
             router.reload({
                 ...backgroundVisit,
                 only: [
-                    'channels',
-                    'hasUnreadThreads',
+                    ...UNREAD_DIGEST_PROPS,
+                    ...CHANNEL_LIST_PROPS,
                     'unreadThreadCount',
-                    'teams',
                 ],
             }),
         { delay: REFRESH_DEBOUNCE_MS },

--- a/resources/js/composables/useUnreadDigest.ts
+++ b/resources/js/composables/useUnreadDigest.ts
@@ -1,0 +1,23 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import type { ComputedRef } from 'vue';
+import { EMPTY_DIGEST } from '@/lib/unreadDigest';
+import type { UnreadDigest } from '@/types/unread';
+
+/**
+ * The shared unread digest, as every badge in the shell reads it.
+ *
+ * It rides every visit rather than being cached, because it is the one shared
+ * prop with no honest invalidation trigger — it *is* the thing that changes. So
+ * a surface that wants a badge reads it here rather than off the roster it is
+ * rendering: the roster is allowed to be stale, this is not.
+ *
+ * Defaults to nothing waiting so a surface outside a workspace — an auth page,
+ * a settings page reached before the shell has any workspace to describe —
+ * renders no badges rather than failing on a missing prop.
+ */
+export function useUnreadDigest(): ComputedRef<UnreadDigest> {
+    const page = usePage();
+
+    return computed(() => page.props.unread ?? EMPTY_DIGEST);
+}

--- a/resources/js/composables/useUnreadElsewhere.test.ts
+++ b/resources/js/composables/useUnreadElsewhere.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { reactive } from 'vue';
 import type { Channel } from '@/types/channels';
+import type { UnreadCounts, UnreadDigest } from '@/types/unread';
 
 const page = reactive<{ props: Record<string, unknown> }>({ props: {} });
 
@@ -20,8 +21,6 @@ function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,
@@ -36,6 +35,11 @@ function channel(overrides: Partial<Channel> = {}): Channel {
     };
 }
 
+/** The shared digest, naming only the conversations that hold something. */
+function digest(channels: Record<string, UnreadCounts>): UnreadDigest {
+    return { channels, teams: {}, threads: false };
+}
+
 describe('useUnreadElsewhere', () => {
     it('reports nothing on a page that carries no sidebar channels', () => {
         page.props = {};
@@ -46,12 +50,16 @@ describe('useUnreadElsewhere', () => {
         });
     });
 
-    it('derives the rollup from the shared channels prop', () => {
+    it('derives the rollup from the channels roster and the unread digest', () => {
         page.props = {
             channels: [
-                channel({ id: 'ch-design', unreadCount: 3 }),
-                channel({ id: 'dm-ep', isDirect: true, unreadCount: 1 }),
+                channel({ id: 'ch-design' }),
+                channel({ id: 'dm-ep', isDirect: true }),
             ],
+            unread: digest({
+                'ch-design': { unread: 3, mention: 0 },
+                'dm-ep': { unread: 1, mention: 0 },
+            }),
         };
 
         expect(useUnreadElsewhere().value).toEqual({
@@ -63,9 +71,8 @@ describe('useUnreadElsewhere', () => {
     it('excludes the open conversation named by the page', () => {
         page.props = {
             channel: { id: 'dm-ep' },
-            channels: [
-                channel({ id: 'dm-ep', isDirect: true, unreadCount: 1 }),
-            ],
+            channels: [channel({ id: 'dm-ep', isDirect: true })],
+            unread: digest({ 'dm-ep': { unread: 1, mention: 0 } }),
         };
 
         expect(useUnreadElsewhere().value).toEqual({
@@ -74,17 +81,21 @@ describe('useUnreadElsewhere', () => {
         });
     });
 
-    it('tracks the channels prop, so the partial reload behind the sidebar badges moves it too', () => {
-        page.props = { channels: [channel({ id: 'ch-design' })] };
+    it('tracks the digest, so the partial reload behind the sidebar badges moves it too', () => {
+        page.props = {
+            channels: [channel({ id: 'dm-ep', isDirect: true })],
+            unread: digest({}),
+        };
 
         const summary = useUnreadElsewhere();
 
         expect(summary.value.hasUnread).toBe(false);
 
+        // The badge reload asks for the digest alone; the roster beside it is
+        // unchanged, and the rollup still moves.
         page.props = {
-            channels: [
-                channel({ id: 'dm-ep', isDirect: true, unreadCount: 2 }),
-            ],
+            ...page.props,
+            unread: digest({ 'dm-ep': { unread: 2, mention: 0 } }),
         };
 
         expect(summary.value).toEqual({ count: 2, hasUnread: true });

--- a/resources/js/composables/useUnreadElsewhere.ts
+++ b/resources/js/composables/useUnreadElsewhere.ts
@@ -1,27 +1,30 @@
 import { usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import type { ComputedRef } from 'vue';
+import { useUnreadDigest } from '@/composables/useUnreadDigest';
 import { summarizeUnreadElsewhere } from '@/lib/unreadElsewhere';
 import type { UnreadElsewhereSummary } from '@/lib/unreadElsewhere';
 
 /**
  * The unread rollup behind the mobile sidebar toggle's badge.
  *
- * Purely derived: the shared `channels` prop already carries every
- * conversation's counts on each channel route, and {@see useSidebarBadges}
- * already keeps it fresh — an arrival, or a read on another device via
- * `ReadStateAdvanced`, debounces a partial reload of that prop. So the badge
- * tracks both without subscribing to anything of its own.
+ * Purely derived: the shared `channels` prop names the conversations, the
+ * `unread` digest says what is waiting in each, and {@see useSidebarBadges}
+ * already keeps the digest fresh — an arrival, or a read on another device via
+ * `ReadStateAdvanced`, debounces a partial reload of it. So the badge tracks
+ * both without subscribing to anything of its own.
  *
  * Pages that carry no sidebar (auth, settings) simply have no `channels` prop
  * and roll up to nothing.
  */
 export function useUnreadElsewhere(): ComputedRef<UnreadElsewhereSummary> {
     const page = usePage();
+    const digest = useUnreadDigest();
 
     return computed(() =>
         summarizeUnreadElsewhere(
             page.props.channels ?? [],
+            digest.value,
             (page.props.channel as { id?: string } | undefined)?.id ?? null,
         ),
     );

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -51,6 +51,7 @@ import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresenceSubscription } from '@/composables/useTeamPresence';
 import { useToastZoneHeight } from '@/composables/useToastZoneHeight';
+import { useUnreadDigest } from '@/composables/useUnreadDigest';
 import type { MessageReminder } from '@/types/messages';
 
 const page = usePage();
@@ -104,7 +105,11 @@ useTeamPresenceSubscription(() => currentTeam.value?.id);
 // mounts, so someone reading a settings page still counts as here.
 usePresenceReporter();
 
-const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
+// The Threads dot, read off the shared unread digest along with every other
+// badge in the shell rather than from a flag of its own — the two were three
+// readings of the same fact before the digest consolidated them.
+const digest = useUnreadDigest();
+const hasUnreadThreads = computed(() => digest.value.threads);
 
 /**
  * Whether the reminders glyph wears its dot. The pending rows already ride

--- a/resources/js/lib/channelSections.test.ts
+++ b/resources/js/lib/channelSections.test.ts
@@ -21,8 +21,6 @@ function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,

--- a/resources/js/lib/groupDm.test.ts
+++ b/resources/js/lib/groupDm.test.ts
@@ -33,8 +33,6 @@ function dmChannel(id: string, participants: DmParticipant[]): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,

--- a/resources/js/lib/reloadProps.test.ts
+++ b/resources/js/lib/reloadProps.test.ts
@@ -8,6 +8,7 @@ import {
     SCHEDULED_MESSAGE_PROPS,
     THREAD_PROPS,
     THREAD_RESET_PROPS,
+    UNREAD_DIGEST_PROPS,
 } from '@/lib/reloadProps';
 import { filesSpelling } from '@/lib/sourceScan.harness';
 
@@ -30,6 +31,12 @@ describe('reloadProps', () => {
 
     it('names the sidebar channel read-model', () => {
         expect(CHANNEL_LIST_PROPS).toEqual(['channels']);
+    });
+
+    it('keeps the unread digest apart from the roster it badges', () => {
+        // Marking a channel read used to reload the whole roster to move four
+        // integers; the badges are their own prop, so the write asks for that.
+        expect(UNREAD_DIGEST_PROPS).toEqual(['unread']);
     });
 
     it('names the sidebar section read-model', () => {
@@ -74,6 +81,7 @@ describe('reloadProps', () => {
         ['SCHEDULED_MESSAGE_PROPS', arrayLiteralOf(/'scheduledMessages'/)],
         ['THREAD_PROPS', arrayLiteralOf(/'thread',\s*'threadReplies'/)],
         ['THREAD_RESET_PROPS', arrayLiteralOf(/'threadReplies'/)],
+        ['UNREAD_DIGEST_PROPS', arrayLiteralOf(/'unread'/)],
     ])('is the only place %s is spelled out', (_name, pattern) => {
         // Sixteen copies of `only: ['channels']` across twelve files is what
         // this replaces: a surface refreshing one prop of a pair goes stale, and

--- a/resources/js/lib/reloadProps.ts
+++ b/resources/js/lib/reloadProps.ts
@@ -9,9 +9,9 @@
  * `pinCount` are two readings of one fact, and so are `thread` and
  * `threadReplies`.
  *
- * Seven invalidation sets live here; the eighth, {@see REMINDER_PROPS}, is next
+ * Eight invalidation sets live here; the ninth, {@see REMINDER_PROPS}, is next
  * door in {@see reminderReload} with the visit options a reminder mutation
- * carries. All eight are enforced the same way, by a test that fails on a second
+ * carries. All nine are enforced the same way, by a test that fails on a second
  * copy. {@link THREAD_RESET_PROPS} is not one of them — it names what a thread
  * load *resets* rather than what a write invalidates.
  *
@@ -36,13 +36,25 @@ export const AUTH_PROPS: string[] = ['auth'];
 /**
  * The sidebar's channel list.
  *
- * Nearly every workspace write touches it, because the prop carries far more
- * than the roster: unread counts, the member's star/mute/notification state,
- * placement, and the last-activity order the direct-message group sorts on. A
- * reaction, a vote, a read pointer and a drag all move something the sidebar
- * draws.
+ * Nearly every workspace write touches it, because the prop carries more than
+ * the names: the member's star/mute/notification state, placement, and the
+ * last-activity order the direct-message group sorts on. A reaction, a vote and
+ * a drag all move something the sidebar draws. What it no longer carries is the
+ * badges — see {@link UNREAD_DIGEST_PROPS}, which is why marking a channel read
+ * is no longer one of the writes that reaches for this set.
  */
 export const CHANNEL_LIST_PROPS: string[] = ['channels'];
+
+/**
+ * What the viewer has not read, everywhere at once.
+ *
+ * The counterpart to {@link CHANNEL_LIST_PROPS} and deliberately separate from
+ * it: marking a channel read used to reload the whole roster — every channel's
+ * name, placement and participants — to move four integers. The badges now live
+ * in one prop of their own, so the write that clears them asks for that and
+ * nothing else.
+ */
+export const UNREAD_DIGEST_PROPS: string[] = ['unread'];
 
 /** The viewer's custom sidebar sections, in their persisted order. */
 export const CHANNEL_SECTION_PROPS: string[] = ['channelSections'];

--- a/resources/js/lib/unreadDigest.test.ts
+++ b/resources/js/lib/unreadDigest.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+    EMPTY_DIGEST,
+    NOTHING_UNREAD,
+    channelUnread,
+    workspaceUnread,
+} from '@/lib/unreadDigest';
+import type { UnreadDigest } from '@/types/unread';
+
+function digest(overrides: Partial<UnreadDigest> = {}): UnreadDigest {
+    return { ...EMPTY_DIGEST, ...overrides };
+}
+
+describe('unread digest lookups', () => {
+    it('reports what the digest names for a channel', () => {
+        const counts = channelUnread(
+            digest({ channels: { 'ch-1': { unread: 4, mention: 2 } } }),
+            'ch-1',
+        );
+
+        expect(counts).toEqual({ unread: 4, mention: 2 });
+    });
+
+    it('reads a channel the digest does not name as nothing waiting', () => {
+        expect(channelUnread(digest(), 'ch-absent')).toBe(NOTHING_UNREAD);
+    });
+
+    it('reports what the digest names for a workspace', () => {
+        const counts = workspaceUnread(
+            digest({ teams: { 't-1': { unread: 9, mention: 0 } } }),
+            't-1',
+        );
+
+        expect(counts).toEqual({ unread: 9, mention: 0 });
+    });
+
+    it('reads a workspace the digest does not name as nothing waiting', () => {
+        expect(workspaceUnread(digest(), 't-absent')).toBe(NOTHING_UNREAD);
+    });
+});

--- a/resources/js/lib/unreadDigest.ts
+++ b/resources/js/lib/unreadDigest.ts
@@ -1,0 +1,46 @@
+import type { UnreadCounts, UnreadDigest } from '@/types/unread';
+
+/**
+ * What an absent key means. Shared rather than built per lookup so a row that
+ * has nothing waiting compares identically on every render.
+ */
+export const NOTHING_UNREAD: UnreadCounts = Object.freeze({
+    unread: 0,
+    mention: 0,
+});
+
+/**
+ * The digest a page carries when it carries none — a guest, or a surface
+ * rendered outside any workspace.
+ */
+export const EMPTY_DIGEST: UnreadDigest = Object.freeze({
+    channels: {},
+    teams: {},
+    threads: false,
+});
+
+/**
+ * What is waiting in one conversation.
+ *
+ * The digest names only the channels that hold something, so almost every
+ * lookup on an ordinary workspace misses — which is the point: a read
+ * conversation costs nothing on the wire and nothing here.
+ */
+export function channelUnread(
+    digest: UnreadDigest,
+    channelId: string,
+): UnreadCounts {
+    return digest.channels[channelId] ?? NOTHING_UNREAD;
+}
+
+/**
+ * What is waiting in one workspace: the sum of its channels' readings, taken
+ * server-side from the same query, so the rail's dot can never disagree with
+ * the rows the sidebar shows inside it.
+ */
+export function workspaceUnread(
+    digest: UnreadDigest,
+    teamId: string,
+): UnreadCounts {
+    return digest.teams[teamId] ?? NOTHING_UNREAD;
+}

--- a/resources/js/lib/unreadElsewhere.test.ts
+++ b/resources/js/lib/unreadElsewhere.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { EMPTY_DIGEST } from '@/lib/unreadDigest';
 import {
     formatUnreadCount,
     summarizeUnreadElsewhere,
 } from '@/lib/unreadElsewhere';
+import type { UnreadElsewhereSummary } from '@/lib/unreadElsewhere';
 import type { Channel } from '@/types/channels';
+import type { UnreadCounts } from '@/types/unread';
 
+/** A conversation as the sidebar lists it, carrying no badge of its own. */
 function channel(overrides: Partial<Channel> = {}): Channel {
     return {
         id: 'ch-1',
@@ -17,8 +21,6 @@ function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,
@@ -33,74 +35,93 @@ function channel(overrides: Partial<Channel> = {}): Channel {
     };
 }
 
+/**
+ * Roll up the given conversations, each paired with what the digest says is
+ * waiting in it. A conversation given no counts is absent from the digest, which
+ * is how a read — or a suppressed — one arrives.
+ */
+function summarize(
+    rows: Array<[Channel, UnreadCounts?]>,
+    activeChannelId: string | null = null,
+): UnreadElsewhereSummary {
+    return summarizeUnreadElsewhere(
+        rows.map(([conversation]) => conversation),
+        {
+            ...EMPTY_DIGEST,
+            channels: Object.fromEntries(
+                rows
+                    .filter(([, counts]) => counts !== undefined)
+                    .map(([conversation, counts]) => [
+                        conversation.id,
+                        counts as UnreadCounts,
+                    ]),
+            ),
+        },
+        activeChannelId,
+    );
+}
+
 describe('summarizeUnreadElsewhere', () => {
     it('reports nothing for an empty conversation list', () => {
-        expect(summarizeUnreadElsewhere([], null)).toEqual({
-            count: 0,
-            hasUnread: false,
-        });
+        expect(summarize([])).toEqual({ count: 0, hasUnread: false });
     });
 
     it('leaves plain channel unread out of the numeral but still inks the rail', () => {
-        const summary = summarizeUnreadElsewhere(
-            [channel({ unreadCount: 3 })],
-            null,
-        );
-
-        expect(summary).toEqual({ count: 0, hasUnread: true });
+        expect(summarize([[channel(), { unread: 3, mention: 0 }]])).toEqual({
+            count: 0,
+            hasUnread: true,
+        });
     });
 
     it('counts channel @mentions', () => {
-        const summary = summarizeUnreadElsewhere(
-            [channel({ unreadCount: 5, mentionCount: 2 })],
-            null,
-        );
-
-        expect(summary).toEqual({ count: 2, hasUnread: true });
+        expect(summarize([[channel(), { unread: 5, mention: 2 }]])).toEqual({
+            count: 2,
+            hasUnread: true,
+        });
     });
 
     it('counts every unread message in a DM, mention or not', () => {
-        const summary = summarizeUnreadElsewhere(
-            [channel({ id: 'dm-1', isDirect: true, unreadCount: 1 })],
-            null,
-        );
+        const summary = summarize([
+            [
+                channel({ id: 'dm-1', isDirect: true }),
+                { unread: 1, mention: 0 },
+            ],
+        ]);
 
         expect(summary).toEqual({ count: 1, hasUnread: true });
     });
 
     it('does not count an @mention inside a DM twice', () => {
-        const summary = summarizeUnreadElsewhere(
+        const summary = summarize([
             [
-                channel({
-                    id: 'dm-1',
-                    isDirect: true,
-                    unreadCount: 2,
-                    mentionCount: 1,
-                }),
+                channel({ id: 'dm-1', isDirect: true }),
+                { unread: 2, mention: 1 },
             ],
-            null,
-        );
+        ]);
 
         expect(summary.count).toBe(2);
     });
 
     it('adds the design brief up to one DM, with the three plain unread only inking the rail', () => {
-        const summary = summarizeUnreadElsewhere(
+        const summary = summarize([
+            [channel({ id: 'ch-design' }), { unread: 3, mention: 0 }],
             [
-                channel({ id: 'ch-design', unreadCount: 3 }),
-                channel({ id: 'dm-ep', isDirect: true, unreadCount: 1 }),
+                channel({ id: 'dm-ep', isDirect: true }),
+                { unread: 1, mention: 0 },
             ],
-            null,
-        );
+        ]);
 
         expect(summary).toEqual({ count: 1, hasUnread: true });
     });
 
     it('excludes the conversation the viewer already has open', () => {
-        const summary = summarizeUnreadElsewhere(
+        const summary = summarize(
             [
-                channel({ id: 'dm-open', isDirect: true, unreadCount: 4 }),
-                channel({ id: 'ch-other', unreadCount: 2 }),
+                [
+                    channel({ id: 'dm-open', isDirect: true }),
+                    { unread: 4, mention: 0 },
+                ],
+                [channel({ id: 'ch-other' }), { unread: 2, mention: 0 }],
             ],
             'dm-open',
         );
@@ -109,70 +130,49 @@ describe('summarizeUnreadElsewhere', () => {
     });
 
     it('reports nothing when the only unread sits in the open conversation', () => {
-        const summary = summarizeUnreadElsewhere(
-            [channel({ id: 'ch-open', unreadCount: 9, mentionCount: 2 })],
+        const summary = summarize(
+            [[channel({ id: 'ch-open' }), { unread: 9, mention: 2 }]],
             'ch-open',
         );
 
         expect(summary).toEqual({ count: 0, hasUnread: false });
     });
 
-    it('silences a muted conversation entirely', () => {
-        const summary = summarizeUnreadElsewhere(
-            [
-                channel({
-                    id: 'dm-muted',
-                    isDirect: true,
-                    muted: true,
-                    unreadCount: 6,
-                    mentionCount: 3,
-                }),
-            ],
-            null,
-        );
-
-        expect(summary).toEqual({ count: 0, hasUnread: false });
-    });
-
-    it('silences a conversation set to the "nothing" notification level', () => {
-        const summary = summarizeUnreadElsewhere(
-            [
-                channel({
-                    notificationLevel: 'nothing',
-                    unreadCount: 6,
-                    mentionCount: 3,
-                }),
-            ],
-            null,
-        );
+    /**
+     * Muting and the "nothing" level are applied server-side, so a silenced
+     * conversation is simply absent from the digest — the rollup never has to
+     * re-decide whether it is allowed to shout. The row is still listed, and
+     * still dimmed, which is the distinction a single aggregate cannot draw.
+     */
+    it('reports nothing for a conversation the digest does not name', () => {
+        const summary = summarize([
+            [channel({ id: 'dm-muted', isDirect: true, muted: true })],
+            [channel({ id: 'ch-silent', notificationLevel: 'nothing' })],
+        ]);
 
         expect(summary).toEqual({ count: 0, hasUnread: false });
     });
 
     it('keeps a "mentions only" conversation, whose ordinary unread the server has already zeroed', () => {
-        const summary = summarizeUnreadElsewhere(
+        const summary = summarize([
             [
-                channel({
-                    notificationLevel: 'mentions',
-                    unreadCount: 0,
-                    mentionCount: 2,
-                }),
+                channel({ notificationLevel: 'mentions' }),
+                { unread: 0, mention: 2 },
             ],
-            null,
-        );
+        ]);
 
         expect(summary).toEqual({ count: 2, hasUnread: true });
     });
 
     it('sums the numeral across every remaining conversation', () => {
-        const summary = summarizeUnreadElsewhere(
+        const summary = summarize([
+            [channel({ id: 'ch-a' }), { unread: 4, mention: 2 }],
             [
-                channel({ id: 'ch-a', mentionCount: 2, unreadCount: 4 }),
-                channel({ id: 'dm-b', isDirect: true, unreadCount: 3 }),
-                channel({ id: 'ch-c', unreadCount: 1 }),
+                channel({ id: 'dm-b', isDirect: true }),
+                { unread: 3, mention: 0 },
             ],
-            null,
-        );
+            [channel({ id: 'ch-c' }), { unread: 1, mention: 0 }],
+        ]);
 
         expect(summary).toEqual({ count: 5, hasUnread: true });
     });

--- a/resources/js/lib/unreadElsewhere.ts
+++ b/resources/js/lib/unreadElsewhere.ts
@@ -1,5 +1,6 @@
-import { alertsOnMention } from '@/lib/alerts';
+import { channelUnread } from '@/lib/unreadDigest';
 import type { Channel } from '@/types/channels';
+import type { UnreadDigest } from '@/types/unread';
 
 /** Highest numeral the badge spells out; anything past it renders as `99+`. */
 const UNREAD_BADGE_CAP = 99;
@@ -26,19 +27,22 @@ export type UnreadElsewhereSummary = {
  * mobile toggle carries, since below `md` the sidebar itself is a sheet and
  * every badge it holds is off screen while a conversation is open.
  *
- * Three rules shape the rollup, all of them narrowing what the sidebar shows:
+ * Two rules shape the rollup, both of them narrowing what the sidebar shows:
  *
  * - The open conversation is excluded — the badge means "unread *elsewhere*",
  *   and its own unread is already in front of the viewer.
- * - Conversations that would not alert even on a mention are excluded outright,
- *   read through `lib/alerts.ts`. The sidebar dims a muted row rather than
- *   silencing it, but a single aggregate cannot be dimmed per row, so a muted
- *   room would shout exactly as loudly as a live one.
  * - Only mentions and DM unread reach the numeral. Everything else contributes
  *   the `hasUnread` flag alone, which the glyph carries as a brass rail.
+ *
+ * A conversation the viewer muted, or set to "nothing", never reaches here at
+ * all: the digest suppresses it server-side, so it is simply absent. That
+ * matters because the sidebar dims a muted row rather than silencing it, and a
+ * single aggregate cannot be dimmed per row — a muted room would otherwise
+ * shout exactly as loudly as a live one.
  */
 export function summarizeUnreadElsewhere(
     channels: Channel[],
+    digest: UnreadDigest,
     activeChannelId: string | null,
 ): UnreadElsewhereSummary {
     let count = 0;
@@ -49,18 +53,16 @@ export function summarizeUnreadElsewhere(
             continue;
         }
 
-        if (!alertsOnMention(channel)) {
-            continue;
-        }
+        const unread = channelUnread(digest, channel.id);
 
         // A DM's whole unread run is addressed to the viewer, so all of it
         // counts; a channel contributes only its @mentions. Taking the larger of
         // the two on a DM keeps an @mention inside one from counting twice.
         count += channel.isDirect
-            ? Math.max(channel.unreadCount, channel.mentionCount)
-            : channel.mentionCount;
+            ? Math.max(unread.unread, unread.mention)
+            : unread.mention;
 
-        if (channel.unreadCount > 0 || channel.mentionCount > 0) {
+        if (unread.unread > 0 || unread.mention > 0) {
             hasUnread = true;
         }
     }

--- a/resources/js/pages/channels/Show.actions.test.ts
+++ b/resources/js/pages/channels/Show.actions.test.ts
@@ -294,7 +294,7 @@ describe('the typing beat', () => {
 });
 
 describe('the read pointer', () => {
-    it('advances the pointer for the open channel, refreshing only the sidebar', async () => {
+    it('advances the pointer for the open channel, refreshing only the unread digest', async () => {
         vi.useFakeTimers();
         vi.spyOn(document, 'hasFocus').mockReturnValue(true);
 
@@ -307,7 +307,9 @@ describe('the read pointer', () => {
 
         expect(url).toContain('/t/acme/c/general/read');
         expect(payload).toEqual({});
-        expect(options.only).toEqual(['channels']);
+        // The badge is the only thing this write moves, so the roster stays out
+        // of the response entirely.
+        expect(options.only).toEqual(['unread']);
         expect(options.preserveScroll).toBe(true);
         expect(options.preserveState).toBe(true);
         expect(options.headers).toEqual({ 'X-Socket-ID': 'socket-1' });

--- a/resources/js/pages/channels/Show.doubles.ts
+++ b/resources/js/pages/channels/Show.doubles.ts
@@ -151,8 +151,6 @@ export function channel(overrides: Partial<Channel> = {}): Channel {
         isArchived: false,
         muted: false,
         notificationLevel: 'all',
-        unreadCount: 0,
-        mentionCount: 0,
         hasDraft: false,
         draft: null,
         starred: false,

--- a/resources/js/pages/teams/Analytics.charts.test.ts
+++ b/resources/js/pages/teams/Analytics.charts.test.ts
@@ -116,8 +116,6 @@ const team: Team = {
     isPersonal: false,
     role: 'owner',
     membersCount: 12,
-    unreadCount: 0,
-    mentionCount: 0,
 };
 
 const rangeOptions: AnalyticsRangeOption[] = [

--- a/resources/js/pages/teams/Analytics.tiles.test.ts
+++ b/resources/js/pages/teams/Analytics.tiles.test.ts
@@ -108,8 +108,6 @@ const team: Team = {
     isPersonal: false,
     role: 'owner',
     membersCount: 12,
-    unreadCount: 0,
-    mentionCount: 0,
 };
 
 const rangeOptions: AnalyticsRangeOption[] = [

--- a/resources/js/pages/teams/AuditExports.doubles.ts
+++ b/resources/js/pages/teams/AuditExports.doubles.ts
@@ -12,8 +12,6 @@ export const team: Team = {
     isPersonal: false,
     role: 'owner',
     membersCount: 12,
-    unreadCount: 0,
-    mentionCount: 0,
 };
 
 export const logTypeOptions: AuditExportOption[] = [

--- a/resources/js/pages/teams/DeletedChannels.test.ts
+++ b/resources/js/pages/teams/DeletedChannels.test.ts
@@ -85,8 +85,6 @@ function mount(channels: DeletedChannel[]): HTMLElement {
                             isPersonal: false,
                             role: 'owner',
                             membersCount: 1,
-                            unreadCount: 0,
-                            mentionCount: 0,
                         },
                         channels,
                     });

--- a/resources/js/pages/teams/Edit.invitations.test.ts
+++ b/resources/js/pages/teams/Edit.invitations.test.ts
@@ -171,8 +171,6 @@ function team(overrides: Partial<Team> = {}): Team {
         isPersonal: false,
         role: 'owner',
         membersCount: 1,
-        unreadCount: 0,
-        mentionCount: 0,
         ...overrides,
     };
 }

--- a/resources/js/pages/teams/Edit.members.test.ts
+++ b/resources/js/pages/teams/Edit.members.test.ts
@@ -175,8 +175,6 @@ function team(overrides: Partial<Team> = {}): Team {
         isPersonal: false,
         role: 'owner',
         membersCount: 2,
-        unreadCount: 0,
-        mentionCount: 0,
         ...overrides,
     };
 }

--- a/resources/js/pages/teams/Edit.sections.test.ts
+++ b/resources/js/pages/teams/Edit.sections.test.ts
@@ -187,8 +187,6 @@ function team(overrides: Partial<Team> = {}): Team {
         isPersonal: false,
         role: 'owner',
         membersCount: 1,
-        unreadCount: 0,
-        mentionCount: 0,
         ...overrides,
     };
 }

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -16,6 +16,7 @@ import type {
     Team,
     TeamInvitationContext,
 } from '@/types/teams';
+import type { UnreadDigest } from '@/types/unread';
 
 // Extend ImportMeta interface for Vite...
 declare module 'vite/client' {
@@ -88,7 +89,13 @@ declare module '@inertiajs/core' {
             userGroups?: App.Data.UserGroupData[];
             slashCommands?: App.Data.SlashCommandData[];
             collapsedChannelSections?: string[];
-            hasUnreadThreads?: boolean;
+            /**
+             * What the viewer has not read, per channel and per workspace, plus
+             * the Threads dot. The one shared prop that is never cached: the
+             * rosters above say what the workspace is, this says what has
+             * happened in it.
+             */
+            unread?: UnreadDigest;
             /**
              * The Threads panel's own props, present only while the dock has that
              * destination pinned (`?nav=threads`) — absent everywhere else, which is

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -12,14 +12,6 @@ export type Team = {
     roleLabel?: string;
     membersCount: number;
     isCurrent?: boolean;
-    /**
-     * Ordinary unread messages waiting in this workspace, muting and the
-     * per-channel notification level already applied server-side. Drives the
-     * rail tile's dot and the workspace sheet's row cue.
-     */
-    unreadCount: number;
-    /** Unread @mentions waiting in this workspace, drawn as a numeric badge. */
-    mentionCount: number;
 };
 
 export type TeamMember = {

--- a/resources/js/types/unread.ts
+++ b/resources/js/types/unread.ts
@@ -1,0 +1,16 @@
+/**
+ * What is waiting in one conversation or one workspace: ordinary unread traffic
+ * and unread mentions, already suppressed server-side for muting and the
+ * notification level.
+ */
+export type UnreadCounts = App.Data.UnreadCountsData;
+
+/**
+ * Everything unread the shell draws, in one shared prop.
+ *
+ * The rosters — `channels`, `teams`, `teamMembers` — say what a workspace *is*;
+ * this says what has happened in it since the viewer last looked, which is the
+ * one thing that changes on every message anyone sends. Both maps are sparse: a
+ * conversation or workspace with nothing waiting is simply absent.
+ */
+export type UnreadDigest = App.Data.UnreadDigestData;

--- a/tests/Feature/Channels/ChannelPreferenceTest.php
+++ b/tests/Feature/Channels/ChannelPreferenceTest.php
@@ -27,16 +27,6 @@ function prefPost(Channel $channel, User $author, ?User $mention = null): Messag
 }
 
 /**
- * The sidebar `channels` row for the channel, as the acting user.
- *
- * @return array<string, mixed>
- */
-function prefSidebarEntry(User $user, Team $team, Channel $channel): array
-{
-    return sidebarRow($user, $team, $channel)->toArray();
-}
-
-/**
  * Update the preferences endpoint as the given user.
  */
 function updatePreferences(User $user, Team $team, Channel $channel, bool $muted, string $level): TestResponse
@@ -177,8 +167,11 @@ test('the notification level and mute suppress the sidebar badges', function (bo
         'notification_level' => $level,
     ]);
 
-    expect(prefSidebarEntry($member, $team, $general))
-        ->toMatchArray(['unreadCount' => $expectedUnread, 'mentionCount' => $expectedMention]);
+    // The suppression is applied server-side, in the digest's own query, so a
+    // silenced channel arrives with nothing rather than with a count the client
+    // has to know to hide.
+    expect(unreadBadge($member, $team, $general))
+        ->toBe(['unread' => $expectedUnread, 'mention' => $expectedMention]);
 })->with([
     '"all" shows the unread dot and the mention badge' => [false, 'all', 2, 1],
     '"mentions" keeps the mention badge but silences the unread dot' => [false, 'mentions', 0, 1],

--- a/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
+++ b/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Data\UserTeam;
 use App\Enums\MessageType;
 use App\Enums\NotificationLevel;
 use App\Enums\TeamRole;
@@ -8,26 +7,21 @@ use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
-use Illuminate\Support\Collection;
 use Inertia\Testing\AssertableInertia as Assert;
 
 /**
- * The workspace-switcher entry for the given team, as the viewer sees it.
+ * The rail's badge for the given workspace, as the viewer sees it.
  *
- * Read off `User::toUserTeams()`, which is what `share()` hands the `teams`
+ * Read off the shared unread digest, which is what `share()` hands the `unread`
  * prop, rather than by rendering a page to pluck that prop back out (#1117).
  * The HTTP half — that a workspace render still ships it — is stated once, in
  * the last test in this file.
  *
- * @return array{unreadCount: int, mentionCount: int}
+ * @return array{unread: int, mention: int}
  */
 function workspaceBadge(User $user, Team $team): array
 {
-    $entry = collect($user->toUserTeams(includeCurrent: true))->firstWhere('id', $team->id);
-
-    expect($entry)->toBeInstanceOf(UserTeam::class);
-
-    return ['unreadCount' => $entry->unreadCount, 'mentionCount' => $entry->mentionCount];
+    return workspaceUnreadBadge($user, $team);
 }
 
 /**
@@ -66,7 +60,7 @@ test('a workspace the viewer is not reading carries its unread and mention count
     crossWorkspacePost($general, $author, $viewer);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 3, 'mentionCount' => 1]);
+        ->toMatchArray(['unread' => 3, 'mention' => 1]);
 });
 
 test('a workspace with nothing new reports zero', function (): void {
@@ -74,7 +68,7 @@ test('a workspace with nothing new reports zero', function (): void {
     [$team] = otherWorkspace($viewer);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 0, 'mention' => 0]);
 });
 
 test('messages already read do not count', function (): void {
@@ -87,7 +81,7 @@ test('messages already read do not count', function (): void {
 
     $viewer->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $last->id]);
 
-    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(1);
+    expect(workspaceBadge($viewer, $team)['unread'])->toBe(1);
 });
 
 test('the viewer own messages and system notices never count', function (): void {
@@ -98,7 +92,7 @@ test('the viewer own messages and system notices never count', function (): void
     crossWorkspacePost($general, $author, attributes: ['type' => MessageType::MemberJoined]);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 0, 'mention' => 0]);
 });
 
 test('a muted channel contributes neither unread nor mentions', function (): void {
@@ -111,7 +105,7 @@ test('a muted channel contributes neither unread nor mentions', function (): voi
     $viewer->channels()->updateExistingPivot($general->id, ['muted' => true]);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 0, 'mention' => 0]);
 });
 
 test('the mentions-only level keeps the mention count and silences ordinary unread', function (): void {
@@ -126,7 +120,7 @@ test('the mentions-only level keeps the mention count and silences ordinary unre
     ]);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 1]);
+        ->toMatchArray(['unread' => 0, 'mention' => 1]);
 });
 
 test('the nothing level silences the workspace entirely', function (): void {
@@ -141,7 +135,7 @@ test('the nothing level silences the workspace entirely', function (): void {
     ]);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 0, 'mention' => 0]);
 });
 
 test('a thread-only reply stays out of the unread count but its mention still counts', function (): void {
@@ -155,7 +149,7 @@ test('a thread-only reply stays out of the unread count but its mention still co
     ]);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 1]);
+        ->toMatchArray(['unread' => 1, 'mention' => 1]);
 });
 
 test('a thread reply also sent to the channel counts like any other message', function (): void {
@@ -168,7 +162,7 @@ test('a thread reply also sent to the channel counts like any other message', fu
         'sent_to_channel' => true,
     ]);
 
-    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(2);
+    expect(workspaceBadge($viewer, $team)['unread'])->toBe(2);
 });
 
 test('an archived channel drops out of the workspace counts', function (): void {
@@ -178,7 +172,7 @@ test('an archived channel drops out of the workspace counts', function (): void 
     crossWorkspacePost($general, $author);
     $general->update(['archived_at' => now()]);
 
-    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(0);
+    expect(workspaceBadge($viewer, $team)['unread'])->toBe(0);
 });
 
 test('a deleted message stops counting', function (): void {
@@ -187,7 +181,7 @@ test('a deleted message stops counting', function (): void {
 
     crossWorkspacePost($general, $author)->delete();
 
-    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(0);
+    expect(workspaceBadge($viewer, $team)['unread'])->toBe(0);
 });
 
 test('counts are grouped per workspace rather than pooled', function (): void {
@@ -199,8 +193,8 @@ test('counts are grouped per workspace rather than pooled', function (): void {
     crossWorkspacePost($secondGeneral, $secondAuthor);
     crossWorkspacePost($secondGeneral, $secondAuthor, $viewer);
 
-    expect(workspaceBadge($viewer, $first))->toMatchArray(['unreadCount' => 1, 'mentionCount' => 0]);
-    expect(workspaceBadge($viewer, $second))->toMatchArray(['unreadCount' => 2, 'mentionCount' => 1]);
+    expect(workspaceBadge($viewer, $first))->toMatchArray(['unread' => 1, 'mention' => 0]);
+    expect(workspaceBadge($viewer, $second))->toMatchArray(['unread' => 2, 'mention' => 1]);
 });
 
 test('another member unread traffic never leaks into the viewer counts', function (): void {
@@ -214,7 +208,7 @@ test('another member unread traffic never leaks into the viewer counts', functio
     crossWorkspacePost($general, $author, $bystander);
 
     expect(workspaceBadge($viewer, $team))
-        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 1, 'mention' => 0]);
 });
 
 test('a workspace render ships the switcher its badge counts', function (): void {
@@ -224,16 +218,13 @@ test('a workspace render ships the switcher its badge counts', function (): void
     crossWorkspacePost($general, $author, $viewer);
 
     $badge = workspaceBadge($viewer, $team);
-    expect($badge)->toMatchArray(['unreadCount' => 1, 'mentionCount' => 1]);
+    expect($badge)->toMatchArray(['unread' => 1, 'mention' => 1]);
 
-    // The one HTTP claim the `teams` prop needs: a render still carries the
-    // switcher, with the counts the read-model above is asserted on.
+    // The one HTTP claim the digest needs here: a render still carries the
+    // other workspace's counts, exactly as the read-model above states them.
     $this->actingAs($viewer)
         ->get(route('channels.show', ['team' => $home->slug, 'channel' => $homeGeneral->slug]))
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->where('teams', fn (Collection $teams): bool => $teams->contains(
-                fn (array $entry): bool => $entry['id'] === $team->id
-                    && $entry['unreadCount'] === $badge['unreadCount']
-                    && $entry['mentionCount'] === $badge['mentionCount']))
+            ->where("unread.teams.{$team->id}", $badge)
             ->etc());
 });

--- a/tests/Feature/Channels/GroupMentionTest.php
+++ b/tests/Feature/Channels/GroupMentionTest.php
@@ -177,9 +177,9 @@ test('a group mention counts toward the sidebar mention badge like a direct one'
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk();
 
-    $entry = collect($response->viewData('page')['props']['channels'])->firstWhere('slug', $general->slug);
+    $digest = $response->viewData('page')['props']['unread'];
 
-    expect($entry['mentionCount'])->toBe(1);
+    expect($digest['channels'][$general->id]['mention'])->toBe(1);
 });
 
 test('a group mention makes the thread show up in the mentioned member inbox', function (): void {

--- a/tests/Feature/Channels/MarkAllThreadsReadTest.php
+++ b/tests/Feature/Channels/MarkAllThreadsReadTest.php
@@ -95,7 +95,7 @@ test('marking all read advances the pointer on every unread followed thread', fu
 
     $props = markAllPanelProps($owner, $team);
 
-    expect($props['hasUnreadThreads'])->toBeFalse()
+    expect($props['unread']['threads'])->toBeFalse()
         ->and($props['unreadThreadCount'])->toBe(0)
         ->and($props['threads']['data'])->toHaveCount(2)
         ->and(collect($props['threads']['data'])->pluck('root.threadUnread')->all())->toBe([false, false])
@@ -120,7 +120,7 @@ test('marking all read points past a deleted tail', function (): void {
 
     expect(ThreadRead::where('user_id', $owner->id)->where('thread_root_id', $root->id)->value('last_read_reply_id'))
         ->toBe($deleted->id)
-        ->and(markAllPanelProps($owner, $team)['hasUnreadThreads'])->toBeFalse();
+        ->and(markAllPanelProps($owner, $team)['unread']['threads'])->toBeFalse();
 });
 
 test('marking all read leaves a thread in a channel the viewer cannot see alone', function (): void {
@@ -152,7 +152,7 @@ test('marking all read leaves other members read state untouched', function (): 
     markAllRead($owner, $team);
 
     expect(ThreadRead::where('user_id', $alice->id)->exists())->toBeFalse()
-        ->and(markAllPanelProps($alice, $team)['hasUnreadThreads'])->toBeTrue()
+        ->and(markAllPanelProps($alice, $team)['unread']['threads'])->toBeTrue()
         ->and(ThreadRead::where('user_id', $owner->id)->where('thread_root_id', $root->id)->exists())
         ->toBeTrue();
 });

--- a/tests/Feature/Channels/ThreadTest.php
+++ b/tests/Feature/Channels/ThreadTest.php
@@ -277,7 +277,7 @@ test('a thread-only reply does not raise the channel unread badge', function ():
     $entry = threadSidebarEntry($member, $team, $general);
 
     // The root + the plain message count; the thread-only reply does not.
-    expect($entry['unreadCount'])->toBe(2);
+    expect($entry['unread'])->toBe(2);
 });
 
 test('a sent-to-channel reply raises the channel unread badge', function (): void {
@@ -287,7 +287,7 @@ test('a sent-to-channel reply raises the channel unread badge', function (): voi
     Message::factory()->for($owner)->inThread($root)->sentToChannel()->create();
 
     // The root + the sent-to-channel reply both count.
-    expect(threadSidebarEntry($member, $team, $general)['unreadCount'])->toBe(2);
+    expect(threadSidebarEntry($member, $team, $general)['unread'])->toBe(2);
 });
 
 test('a mention inside a thread still badges the channel', function (): void {
@@ -303,18 +303,16 @@ test('a mention inside a thread still badges the channel', function (): void {
     $entry = threadSidebarEntry($member, $team, $general);
 
     // The thread reply is not in the plain unread count, but its mention badges.
-    expect($entry['unreadCount'])->toBe(1)
-        ->and($entry['mentionCount'])->toBe(1);
+    expect($entry['unread'])->toBe(1)
+        ->and($entry['mention'])->toBe(1);
 });
 
 /**
- * The sidebar `channels` row's badge counts for the channel, as the acting user.
+ * The badge the sidebar draws on the channel, as the acting user.
  *
- * @return array{unreadCount: int, mentionCount: int}
+ * @return array{unread: int, mention: int}
  */
 function threadSidebarEntry(User $user, Team $team, Channel $channel): array
 {
-    $row = sidebarRow($user, $team, $channel);
-
-    return ['unreadCount' => $row->unreadCount, 'mentionCount' => $row->mentionCount];
+    return unreadBadge($user, $team, $channel);
 }

--- a/tests/Feature/Channels/ThreadsInboxTest.php
+++ b/tests/Feature/Channels/ThreadsInboxTest.php
@@ -240,7 +240,7 @@ test('a mention inside a thread dots its card on a mentions-level channel', func
         ->and($props['threads']['data'][0]['root']['threadUnread'])->toBeTrue()
         ->and($props['threads']['data'][0]['root']['threadUnreadReplyCount'])->toBe(1)
         ->and($props['unreadThreadCount'])->toBe(1)
-        ->and($props['hasUnreadThreads'])->toBeTrue();
+        ->and($props['unread']['threads'])->toBeTrue();
 });
 
 test('opening and reading a thread clears its unread dot in the inbox', function (): void {
@@ -458,21 +458,21 @@ test('the legacy threads inbox route redirects onto the pinned destination', fun
         ->assertRedirect(route('channels.index', ['team' => $team->slug, 'nav' => 'threads']));
 });
 
-test('hasUnreadThreads flags an unread followed thread and clears when read', function (): void {
+test('the digest flags an unread followed thread and clears when read', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
     $root = inboxRoot($general, $owner);
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    expect(inboxProps($owner, $team)['hasUnreadThreads'])->toBeTrue();
+    expect(inboxProps($owner, $team)['unread']['threads'])->toBeTrue();
 
     app(MarkThreadRead::class)->handle($root, $owner);
 
-    expect(inboxProps($owner, $team)['hasUnreadThreads'])->toBeFalse();
+    expect(inboxProps($owner, $team)['unread']['threads'])->toBeFalse();
 });
 
-test('hasUnreadThreads ignores threads the user does not follow', function (): void {
+test('the digest ignores threads the user does not follow', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
     $bob = inboxMember($team, $general);
@@ -480,10 +480,10 @@ test('hasUnreadThreads ignores threads the user does not follow', function (): v
     $root = inboxRoot($general, $owner);
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    expect(inboxProps($bob, $team)['hasUnreadThreads'])->toBeFalse();
+    expect(inboxProps($bob, $team)['unread']['threads'])->toBeFalse();
 });
 
-test('hasUnreadThreads respects channel mute', function (): void {
+test('the digest respects channel mute', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -493,5 +493,5 @@ test('hasUnreadThreads respects channel mute', function (): void {
     $root = inboxRoot($general, $owner);
     Message::factory()->for($general)->for($alice)->inThread($root)->create();
 
-    expect(inboxProps($owner, $team)['hasUnreadThreads'])->toBeFalse();
+    expect(inboxProps($owner, $team)['unread']['threads'])->toBeFalse();
 });

--- a/tests/Feature/Channels/UnreadBadgeTest.php
+++ b/tests/Feature/Channels/UnreadBadgeTest.php
@@ -33,15 +33,16 @@ function markReadUpTo(User $user, Channel $channel, ?Message $message): void
 }
 
 /**
- * The sidebar `channels` row's badge counts for the channel, as the acting user.
+ * The badge the sidebar draws on the channel, as the acting user.
  *
- * @return array{unreadCount: int, mentionCount: int}
+ * Read off the shared unread digest: the badge left the `channels` row when the
+ * roster and the unread state were split (#1249).
+ *
+ * @return array{unread: int, mention: int}
  */
 function sidebarChannel(User $user, Team $team, Channel $channel): array
 {
-    $row = sidebarRow($user, $team, $channel);
-
-    return ['unreadCount' => $row->unreadCount, 'mentionCount' => $row->mentionCount];
+    return unreadBadge($user, $team, $channel);
 }
 
 test('unread count reflects only the messages posted after last_read', function (): void {
@@ -52,7 +53,7 @@ test('unread count reflects only the messages posted after last_read', function 
     markReadUpTo($member, $general, $messages[2]);
 
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 2, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 2, 'mention' => 0]);
 });
 
 test('a null last_read means every message in the channel is unread', function (): void {
@@ -61,7 +62,7 @@ test('a null last_read means every message in the channel is unread', function (
 
     collect(range(1, 3))->each(fn (): Message => unreadPost($general, $owner));
 
-    expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(3);
+    expect(sidebarChannel($member, $team, $general)['unread'])->toBe(3);
 });
 
 test('a member does not see their own messages as unread', function (): void {
@@ -72,7 +73,7 @@ test('a member does not see their own messages as unread', function (): void {
     unreadPost($general, $member);
     unreadPost($general, $member);
 
-    expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(1);
+    expect(sidebarChannel($member, $team, $general)['unread'])->toBe(1);
 });
 
 test('soft-deleted messages are excluded from the unread count', function (): void {
@@ -83,7 +84,7 @@ test('soft-deleted messages are excluded from the unread count', function (): vo
     $deleted = unreadPost($general, $owner);
     $deleted->delete();
 
-    expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(1);
+    expect(sidebarChannel($member, $team, $general)['unread'])->toBe(1);
 });
 
 test('system notices are ambient and never advance the unread or mention badge', function (): void {
@@ -98,7 +99,7 @@ test('system notices are ambient and never advance the unread or mention badge',
     Message::factory()->for($general)->for($owner)->memberLeft()->create();
 
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 0, 'mention' => 0]);
 });
 
 test('a poll badges the channel like any other user-authored message', function (): void {
@@ -114,7 +115,7 @@ test('a poll badges the channel like any other user-authored message', function 
     Message::factory()->for($general)->for($owner)->memberJoined()->create();
 
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 1, 'mention' => 0]);
 });
 
 test('a poll that mentions the user raises the mention badge', function (): void {
@@ -125,7 +126,7 @@ test('a poll that mentions the user raises the mention badge', function (): void
     $poll->mentionedUsers()->attach($member->id);
 
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 1]);
+        ->toMatchArray(['unread' => 1, 'mention' => 1]);
 });
 
 test('the mention count only counts unread messages that mention the user', function (): void {
@@ -140,7 +141,7 @@ test('the mention count only counts unread messages that mention the user', func
     unreadPost($general, $owner, $member);
 
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 3, 'mentionCount' => 2]);
+        ->toMatchArray(['unread' => 3, 'mention' => 2]);
 });
 
 test('a mention of another member does not inflate the users mention count', function (): void {
@@ -150,7 +151,7 @@ test('a mention of another member does not inflate the users mention count', fun
 
     unreadPost($general, $owner, $other);
 
-    expect(sidebarChannel($member, $team, $general)['mentionCount'])->toBe(0);
+    expect(sidebarChannel($member, $team, $general)['mention'])->toBe(0);
 });
 
 test('MarkChannelRead advances last_read to the latest message and clears the badge', function (): void {
@@ -169,7 +170,7 @@ test('MarkChannelRead advances last_read to the latest message and clears the ba
     ]);
 
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 0, 'mention' => 0]);
 });
 
 test('MarkChannelRead leaves the pointer untouched when the channel has no messages', function (): void {
@@ -213,7 +214,7 @@ test('hitting the read endpoint advances the pointer and clears the badges', fun
 
     // The badges are showing before the channel is marked read.
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 2, 'mentionCount' => 1]);
+        ->toMatchArray(['unread' => 2, 'mention' => 1]);
 
     $this->actingAs($member)
         ->post(route('channels.read', ['team' => $team->slug, 'channel' => $general->slug]))
@@ -226,7 +227,7 @@ test('hitting the read endpoint advances the pointer and clears the badges', fun
     ]);
 
     expect(sidebarChannel($member, $team, $general))
-        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+        ->toMatchArray(['unread' => 0, 'mention' => 0]);
 });
 
 test('the read endpoint is forbidden on a private channel the user cannot view', function (): void {

--- a/tests/Feature/Channels/UnreadDigestTest.php
+++ b/tests/Feature/Channels/UnreadDigestTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\NotificationLevel;
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+use Database\Factories\ChannelMemberFactory;
+use Illuminate\Testing\TestResponse;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * The one genuinely volatile fact a navigation ships: what the viewer has not
+ * read, per channel and per workspace, plus whether any followed thread is
+ * waiting.
+ *
+ * Asserted through a real Inertia visit rather than against `share()` or the
+ * read models under it, because the digest exists to be a *prop* — its whole
+ * point is which shape reaches the client, and a unit test on the derivation
+ * would keep passing the day the prop stopped being shared at all.
+ */
+
+/**
+ * Post a message in the channel that names the given user.
+ */
+function mentionPost(Channel $channel, User $author, User $mentioned): Message
+{
+    $message = Message::factory()->for($channel)->for($author)->create([
+        'body' => "hey @[{$mentioned->name}]({$mentioned->id})",
+    ]);
+
+    $message->mentionedUsers()->attach($mentioned->id);
+
+    return $message;
+}
+
+/**
+ * Visit a channel as the given user and hand back the Inertia assertion.
+ */
+function visitChannel(User $viewer, Channel $channel): Assert
+{
+    $page = null;
+
+    test()->actingAs($viewer)
+        ->get(route('channels.show', ['team' => $channel->team->slug, 'channel' => $channel->slug]))
+        ->assertOk()
+        ->assertInertia(function (Assert $inertia) use (&$page): void {
+            $page = $inertia;
+        });
+
+    /** @var Assert $page */
+    return $page;
+}
+
+/**
+ * The partial reload the client makes after marking a channel read, asking for
+ * the named props and nothing else.
+ *
+ * A partial reload answers with JSON rather than a rendered view, so it is
+ * asserted on the page payload directly — {@see Assert} only reads a view.
+ */
+function reloadOnly(User $viewer, Channel $channel, string $only): TestResponse
+{
+    return test()->actingAs($viewer)
+        ->get(
+            route('channels.show', ['team' => $channel->team->slug, 'channel' => $channel->slug]),
+            [
+                'X-Inertia' => 'true',
+                'X-Inertia-Version' => app(HandleInertiaRequests::class)->version(request()),
+                'X-Inertia-Partial-Component' => 'channels/Show',
+                'X-Inertia-Partial-Data' => $only,
+            ],
+        )
+        ->assertOk();
+}
+
+test('a visit carries the unread digest and the rosters carry no badge fields', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    visitChannel($member, $general)
+        ->where("unread.channels.{$general->id}.unread", 1)
+        ->where("unread.channels.{$general->id}.mention", 0)
+        ->missing('channels.0.unreadCount')
+        ->missing('channels.0.mentionCount')
+        ->missing('teams.0.unreadCount')
+        ->missing('teams.0.mentionCount')
+        ->missing('currentTeam.unreadCount')
+        ->missing('hasUnreadThreads');
+});
+
+test('marking a channel read clears its badge, and the trip carries the digest without the roster', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    visitChannel($member, $general)->where("unread.channels.{$general->id}.unread", 1);
+
+    $this->actingAs($member)
+        ->post(route('channels.read', ['team' => $general->team->slug, 'channel' => $general->slug]))
+        ->assertRedirect();
+
+    // The one prop the client asks back for. The badge is gone from the digest,
+    // and the channel roster — 7.8 KB to move four integers before this — never
+    // enters the response at all.
+    reloadOnly($member, $general, 'unread')
+        ->assertJsonPath('props.unread.threads', false)
+        ->assertJsonMissingPath("props.unread.channels.{$general->id}")
+        ->assertJsonMissingPath('props.channels')
+        ->assertJsonMissingPath('props.teamMembers');
+});
+
+test('suppression stays server-side: a muted channel badges nothing, a mentions-only channel only mentions', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
+
+    $muted = Channel::factory()->for($team)->create(['name' => 'Muted', 'slug' => 'muted']);
+    channelMembership($muted, $member, fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->muted());
+    $muted->members()->attach($owner);
+
+    $mentionsOnly = Channel::factory()->for($team)->create(['name' => 'Quiet', 'slug' => 'quiet']);
+    channelMembership(
+        $mentionsOnly,
+        $member,
+        fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->notificationLevel(NotificationLevel::Mentions),
+    );
+    $mentionsOnly->members()->attach($owner);
+
+    foreach ([$muted, $mentionsOnly] as $channel) {
+        Message::factory()->for($channel)->for($owner)->create();
+        mentionPost($channel, $owner, $member);
+    }
+
+    visitChannel($member, $general)
+        // Muted silences both readings, so the channel is absent from the digest
+        // entirely rather than present with two zeroes.
+        ->missing("unread.channels.{$muted->id}")
+        // "Mentions only" keeps the one message that named the viewer and
+        // silences the ordinary traffic beside it.
+        ->where("unread.channels.{$mentionsOnly->id}.unread", 0)
+        ->where("unread.channels.{$mentionsOnly->id}.mention", 1);
+});
+
+test('the workspace reading is the channel readings summed', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general);
+
+    $second = Channel::factory()->for($team)->create(['name' => 'Second', 'slug' => 'second']);
+    channelMembership($second, $member);
+    $second->members()->attach($owner);
+
+    Message::factory()->count(2)->for($general)->for($owner)->create();
+    mentionPost($general, $owner, $member);
+    Message::factory()->for($second)->for($owner)->create();
+
+    // The muted channel contributes to neither reading, which is the drift the
+    // single query exists to prevent: a workspace dot lit by traffic no row
+    // inside it is allowed to show would be worse than no dot at all.
+    $muted = Channel::factory()->for($team)->create(['name' => 'Muted', 'slug' => 'muted']);
+    channelMembership($muted, $member, fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->muted());
+    $muted->members()->attach($owner);
+    Message::factory()->count(5)->for($muted)->for($owner)->create();
+
+    visitChannel($member, $general)
+        ->where("unread.channels.{$general->id}", ['unread' => 3, 'mention' => 1])
+        ->where("unread.channels.{$second->id}", ['unread' => 1, 'mention' => 0])
+        ->where("unread.teams.{$team->id}", ['unread' => 4, 'mention' => 1]);
+});

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -191,10 +191,10 @@ test('seeded system notices stay ambient — they never badge the demo landing c
         'channel' => $announcements->slug,
     ]))->assertOk();
 
-    $entry = collect($response->viewData('page')['props']['channels'])
-        ->firstWhere('slug', 'announcements');
+    $digest = $response->viewData('page')['props']['unread'];
 
-    expect($entry['unreadCount'])->toBe(0);
+    // Nothing waiting means no entry at all — the digest is sparse.
+    expect($digest['channels'])->not->toHaveKey($announcements->id);
 });
 
 test('it varies the demo user unread state across channels', function (): void {

--- a/tests/Feature/Support/WorkspaceUnreadTest.php
+++ b/tests/Feature/Support/WorkspaceUnreadTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\Teams\CreateTeam;
+use App\Data\UnreadDigestData;
 use App\Enums\MessageType;
 use App\Enums\NotificationLevel;
 use App\Enums\TeamRole;
@@ -9,6 +10,7 @@ use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
 use App\Support\WorkspaceUnread;
+use Illuminate\Support\Facades\DB;
 
 /**
  * A viewer, a workspace mate, their team, and its #general channel — both in it.
@@ -30,40 +32,41 @@ function unreadWorkspace(): array
 }
 
 /**
- * The viewer's raw per-channel unread count for one channel, resolved through
- * the correlated sub-query exactly as the sidebar query resolves it.
+ * The viewer's digest as plain arrays, detailed for the given workspace.
+ *
+ * @return array{channels: array<string, array{unread: int, mention: int}>, teams: array<string, array{unread: int, mention: int}>, threads: bool}
  */
-function channelUnreadCount(User $viewer, Channel $channel): int
+function digestArray(User $viewer, ?Team $team = null): array
 {
-    return (int) $viewer->channels()
-        ->whereKey($channel->id)
-        ->select('channels.*')
-        ->selectSub(WorkspaceUnread::forChannelsOf($viewer), 'unread_count')
-        ->firstOrFail()
-        ->getAttribute('unread_count');
+    /** @var array{channels: array<string, array{unread: int, mention: int}>, teams: array<string, array{unread: int, mention: int}>, threads: bool} $digest */
+    $digest = WorkspaceUnread::digest($viewer, $team)->toArray();
+
+    return $digest;
 }
 
-test('the per-channel count holds other people\'s messages past the read pointer', function (): void {
-    [$viewer, $mate, , $general] = unreadWorkspace();
+test('the per-channel reading holds other people\'s messages past the read pointer', function (): void {
+    [$viewer, $mate, $team, $general] = unreadWorkspace();
 
     Message::factory()->for($general)->for($viewer)->create();
     $theirs = Message::factory()->for($general)->for($mate)->count(3)->create();
 
-    expect(channelUnreadCount($viewer, $general))->toBe(3);
+    expect(digestArray($viewer, $team)['channels'][$general->id])->toBe(['unread' => 3, 'mention' => 0]);
 
     $viewer->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $theirs->first()->id]);
 
-    expect(channelUnreadCount($viewer, $general))->toBe(2);
+    expect(digestArray($viewer, $team)['channels'][$general->id])->toBe(['unread' => 2, 'mention' => 0]);
 });
 
-test('the per-channel count ignores system notices and deleted messages', function (): void {
-    [$viewer, $mate, , $general] = unreadWorkspace();
+test('the per-channel reading ignores system notices and deleted messages', function (): void {
+    [$viewer, $mate, $team, $general] = unreadWorkspace();
 
     Message::factory()->for($general)->for($mate)->create(['type' => MessageType::systemValues()[0]]);
     $deleted = Message::factory()->for($general)->for($mate)->create();
     $deleted->delete();
 
-    expect(channelUnreadCount($viewer, $general))->toBe(0);
+    // Nothing waiting means no entry at all: the map is sparse, and the client
+    // reads a missing channel as zero.
+    expect(digestArray($viewer, $team)['channels'])->toBe([]);
 });
 
 test('the per-workspace tally sums a team\'s unread and mentions', function (): void {
@@ -72,7 +75,7 @@ test('the per-workspace tally sums a team\'s unread and mentions', function (): 
     $messages = Message::factory()->for($general)->for($mate)->count(2)->create();
     $messages->last()->mentionedUsers()->attach($viewer);
 
-    expect(WorkspaceUnread::forUser($viewer))->toBe([
+    expect(digestArray($viewer)['teams'])->toBe([
         $team->id => ['unread' => 2, 'mention' => 1],
     ]);
 });
@@ -95,7 +98,7 @@ test('the per-workspace tally counts a thread reply only when it was also sent t
     ]);
 
     // The root alone; the thread-only reply lives in the thread view.
-    expect(WorkspaceUnread::forUser($viewer))->toBe([
+    expect(digestArray($viewer)['teams'])->toBe([
         $team->id => ['unread' => 1, 'mention' => 0],
     ]);
 
@@ -104,7 +107,7 @@ test('the per-workspace tally counts a thread reply only when it was also sent t
         'sent_to_channel' => true,
     ]);
 
-    expect(WorkspaceUnread::forUser($viewer))->toBe([
+    expect(digestArray($viewer)['teams'])->toBe([
         $team->id => ['unread' => 2, 'mention' => 0],
     ]);
 });
@@ -112,7 +115,7 @@ test('the per-workspace tally counts a thread reply only when it was also sent t
 /**
  * The mention half of the same aggregate deliberately does not carry the
  * predicate — a mention anywhere, thread included, still badges — which is why
- * the rule is opt-in per call site rather than folded into the shared query.
+ * the rule is applied to one half of the conditional aggregate and not the other.
  */
 test('a mention inside a thread-only reply still tallies for the workspace', function (): void {
     [$viewer, $mate, $team, $general] = unreadWorkspace();
@@ -124,24 +127,29 @@ test('a mention inside a thread-only reply still tallies for the workspace', fun
         'sent_to_channel' => false,
     ])->mentionedUsers()->attach($viewer);
 
-    expect(WorkspaceUnread::forUser($viewer))->toBe([
+    expect(digestArray($viewer)['teams'])->toBe([
         $team->id => ['unread' => 1, 'mention' => 1],
     ]);
 });
 
-test('a muted channel is silent in the per-workspace tally but still counted per channel', function (): void {
-    [$viewer, $mate, , $general] = unreadWorkspace();
+/**
+ * The two readings used to disagree here on purpose: the workspace tally applied
+ * muting in SQL while the channel row shipped its raw count for the DTO to
+ * suppress. One query now answers both, so suppression happens once — which is
+ * what makes "the dot and the rows inside it cannot drift" a property rather
+ * than a habit.
+ */
+test('a muted channel is silent in both readings', function (): void {
+    [$viewer, $mate, $team, $general] = unreadWorkspace();
 
     Message::factory()->for($general)->for($mate)->count(2)->create();
     $viewer->channels()->updateExistingPivot($general->id, ['muted' => true]);
 
-    // The workspace dot goes quiet; the channel row still knows what it holds,
-    // and ChannelData suppresses the badge from there.
-    expect(WorkspaceUnread::forUser($viewer))->toBe([])
-        ->and(channelUnreadCount($viewer, $general))->toBe(2);
+    expect(digestArray($viewer, $team))
+        ->toMatchArray(['teams' => [], 'channels' => []]);
 });
 
-test('the "nothing" notification level silences a workspace, "mentions" keeps only mentions', function (): void {
+test('the "nothing" notification level silences a channel, "mentions" keeps only mentions', function (): void {
     [$viewer, $mate, $team, $general] = unreadWorkspace();
 
     $messages = Message::factory()->for($general)->for($mate)->count(2)->create();
@@ -149,11 +157,58 @@ test('the "nothing" notification level silences a workspace, "mentions" keeps on
 
     $viewer->channels()->updateExistingPivot($general->id, ['notification_level' => NotificationLevel::Mentions]);
 
-    expect(WorkspaceUnread::forUser($viewer))->toBe([
-        $team->id => ['unread' => 0, 'mention' => 1],
+    expect(digestArray($viewer, $team))->toMatchArray([
+        'teams' => [$team->id => ['unread' => 0, 'mention' => 1]],
+        'channels' => [$general->id => ['unread' => 0, 'mention' => 1]],
     ]);
 
     $viewer->channels()->updateExistingPivot($general->id, ['notification_level' => NotificationLevel::Nothing]);
 
-    expect(WorkspaceUnread::forUser($viewer))->toBe([]);
+    expect(digestArray($viewer, $team))->toMatchArray(['teams' => [], 'channels' => []]);
 });
+
+/**
+ * The digest is the only thing left on a navigation that still touches
+ * per-channel state, so its cost is the epic's first suspect if the budget is
+ * missed. It is an indexed aggregate plus the threads probe, and that is the
+ * whole of it: a workspace ten times the size costs the same number of round
+ * trips, which is the property a byte figure alone would not catch.
+ */
+test('the digest costs the same number of queries however many channels the viewer is in', function (): void {
+    [$viewer, $mate, $team, $general] = unreadWorkspace();
+
+    Message::factory()->for($general)->for($mate)->create();
+
+    $small = countQueries(fn (): UnreadDigestData => WorkspaceUnread::digest($viewer, $team));
+
+    foreach (range(1, 20) as $index) {
+        $channel = Channel::factory()->for($team)->create(['name' => "Room {$index}", 'slug' => "room-{$index}"]);
+        $channel->members()->attach([$viewer->id, $mate->id]);
+        Message::factory()->for($channel)->for($mate)->create();
+    }
+
+    $large = countQueries(fn (): UnreadDigestData => WorkspaceUnread::digest($viewer, $team));
+
+    expect(digestArray($viewer, $team)['channels'])->toHaveCount(21)
+        ->and($large)->toBe($small)
+        ->and($small)->toBe(3);
+});
+
+/**
+ * Run the callback with the query log on and hand back how many statements it
+ * cost.
+ */
+function countQueries(Closure $work): int
+{
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    try {
+        $work();
+
+        return count(DB::getRawQueryLog());
+    } finally {
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+    }
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 use App\Actions\Teams\CreateTeam;
 use App\Data\ChannelData;
+use App\Data\UnreadCountsData;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\Team;
 use App\Models\User;
 use App\Support\SidebarChannels;
+use App\Support\WorkspaceUnread;
 use Database\Factories\ChannelMemberFactory;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
@@ -119,6 +121,43 @@ function sidebarRow(User $viewer, Team $team, Channel $channel): ChannelData
 
     /** @var ChannelData $row */
     return $row;
+}
+
+/**
+ * What the shell's unread digest says is waiting in the channel, as the given
+ * viewer sees it — the badge the sidebar row draws.
+ *
+ * The counts left {@see sidebarRow()} when the roster and the unread state were
+ * split (#1249), so a test about a badge asks here and a test about a row's
+ * placement, mute or draft asks there. Both readings of the digest are sparse,
+ * so "nothing waiting" arrives as two zeroes rather than as a missing key.
+ *
+ * @return array{unread: int, mention: int}
+ */
+function unreadBadge(User $viewer, Team $team, Channel $channel): array
+{
+    return unreadCounts(WorkspaceUnread::digest($viewer, $team)->channels[$channel->id] ?? null);
+}
+
+/**
+ * The same reading for a whole workspace: the rail's dot and the workspace
+ * sheet's badge.
+ *
+ * @return array{unread: int, mention: int}
+ */
+function workspaceUnreadBadge(User $viewer, Team $team): array
+{
+    return unreadCounts(WorkspaceUnread::digest($viewer)->teams[$team->id] ?? null);
+}
+
+/**
+ * One entry of the digest as a plain pair, defaulting an absent one to zero.
+ *
+ * @return array{unread: int, mention: int}
+ */
+function unreadCounts(?UnreadCountsData $counts): array
+{
+    return ['unread' => $counts?->unread ?? 0, 'mention' => $counts?->mention ?? 0];
 }
 
 /**

--- a/tests/Integration/Support/SidebarChannelsTest.php
+++ b/tests/Integration/Support/SidebarChannelsTest.php
@@ -124,60 +124,24 @@ test('a deleted channel leaves the list at once', function (): void {
     expect(sidebarSlugs(new SidebarChannels($owner, $team)->forSidebar()))->not->toContain($channel->slug);
 });
 
-test('unread and mention counts ride along, ignoring the viewer\'s own messages', function (): void {
-    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
-
-    $mate = teamMemberInChannel($general);
-
-    Message::factory()->for($general)->for($user)->create();
-    $theirs = Message::factory()->for($general)->for($mate)->count(3)->create();
-    $theirs->last()->mentionedUsers()->attach($user);
-
-    $channels = new SidebarChannels($user, $team)->forSidebar();
-
-    expect($channels[0]->unreadCount)->toBe(3)
-        ->and($channels[0]->mentionCount)->toBe(1);
-});
-
 /**
- * The predicate is opt-in per sub-query, and this is the asymmetry that makes it
- * so: the unread badge asks for channel traffic, the mention badge deliberately
- * does not. Baking the rule into `WorkspaceUnread::forChannelsOf()` — the shared
- * half both counts ride — would silently take the second half with it, and a
- * mention nobody was badged for is the worst failure this module has.
+ * The badges left this read model with #1249: the list says which channels the
+ * viewer has and how they are placed, and `App\Support\WorkspaceUnread` says
+ * what is waiting in each. What the counts themselves hold — the thread-traffic
+ * asymmetry, muting, the read pointer — is stated where they now live, in
+ * `tests/Feature/Support/WorkspaceUnreadTest.php`.
  */
-test('a thread-only reply raises the mention badge without touching the unread count', function (): void {
+test('the listed row carries the viewer\'s own state and no badge of its own', function (): void {
     ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
     $mate = teamMemberInChannel($general);
+    Message::factory()->for($general)->for($mate)->create();
 
-    $root = Message::factory()->for($general)->for($mate)->create();
+    $row = new SidebarChannels($user, $team)->forSidebar()[0];
 
-    // The reply lives only in the thread, and it @mentions the viewer.
-    Message::factory()->for($general)->for($mate)->create([
-        'thread_root_id' => $root->id,
-        'sent_to_channel' => false,
-    ])->mentionedUsers()->attach($user);
-
-    $channels = new SidebarChannels($user, $team)->forSidebar();
-
-    expect($channels[0]->unreadCount)->toBe(1)
-        ->and($channels[0]->mentionCount)->toBe(1);
-});
-
-test('a thread reply also sent to the channel counts towards the unread badge', function (): void {
-    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
-
-    $mate = teamMemberInChannel($general);
-
-    $root = Message::factory()->for($general)->for($mate)->create();
-
-    Message::factory()->for($general)->for($mate)->create([
-        'thread_root_id' => $root->id,
-        'sent_to_channel' => true,
-    ]);
-
-    expect(new SidebarChannels($user, $team)->forSidebar()[0]->unreadCount)->toBe(2);
+    expect($row->slug)->toBe($general->slug)
+        ->and($row->muted)->toBeFalse()
+        ->and(array_keys($row->toArray()))->not->toContain('unreadCount', 'mentionCount');
 });
 
 test('a draft is reported as a flag without shipping its text', function (): void {
@@ -296,7 +260,7 @@ test('a message after closing re-surfaces the direct message with an unread badg
     $row = collect(new SidebarChannels($owner, $team)->forSidebar())->firstWhere('slug', $dm->slug);
 
     expect($row)->not->toBeNull()
-        ->and($row->unreadCount)->toBe(1);
+        ->and(unreadBadge($owner, $team, $dm))->toBe(['unread' => 1, 'mention' => 0]);
 });
 
 test('reopening a closed direct message un-hides it', function (): void {

--- a/tests/Integration/Support/WorkspaceShellTest.php
+++ b/tests/Integration/Support/WorkspaceShellTest.php
@@ -86,7 +86,7 @@ test('the shell is constructible from a viewer and a team alone', function (): v
         ->and($shell->customEmojis())->toBe([])
         ->and($shell->userGroups())->toBe([])
         ->and($shell->reminders(MessageReminderStatus::Pending))->toBe([])
-        ->and($shell->hasUnreadThreads())->toBeFalse()
+        ->and($shell->unreadDigest()->threads)->toBeFalse()
         ->and($shell->slashCommands())->not->toBeEmpty()
         ->and($shell->creatableChannelVisibilities())->toContain(ChannelVisibility::Public->value);
 });


### PR DESCRIPTION
Closes #1249. First of the shell-contract children on [perf: navigation feels instant](https://github.com/deskhq/the-desk/issues/1248) — the one every other one depends on.

## What changed

**One rule: a shell prop is either a roster or unread state, never both.**

- `ChannelData` loses `unreadCount` / `mentionCount`, `UserTeam` loses its per-workspace pair, and `hasUnreadThreads` is gone as a prop of its own.
- A single `unread` digest replaces all three: sparse per-channel and per-workspace maps plus the Threads flag, in one `App\Data\UnreadDigestData`.
- Both readings now come out of **one grouped aggregate** in `App\Support\WorkspaceUnread`, so the workspace dot is literally the channel rows inside it summed — the drift `WorkspaceUnread`'s docblock already said it existed to prevent, finished.
- Muting and the notification level are applied **inside that query**, through `NotificationLevel`'s own SQL fragments. Suppression stays server-side; the client renders the badge it is handed and never re-decides whether it is allowed to.
- `SidebarChannels` drops its two correlated badge sub-queries — the roster query is now purely a roster.
- The read-marking trip asks for `UNREAD_DIGEST_PROPS` (`['unread']`) instead of `CHANNEL_LIST_PROPS`. It stays a debounced background visit with `preserveState` / `preserveScroll`, so it never blocked paint and still doesn't.

Client side, the five surfaces the map enumerated read the digest through `useUnreadDigest()` / `lib/unreadDigest.ts`: `ChannelListItem`, `DirectMessageListItem`, `NavigationRail`, `WorkspaceSheet`, `lib/unreadElsewhere.ts` (plus `MainLayout`, which feeds the Threads dot down).

## Numbers

**Query count for the digest on a channel visit: 3** — one grouped aggregate over `messages`, plus the two the followed-threads probe already cost. Flat across channel count, pinned by a test that builds a 21-channel workspace and asserts the count is unchanged.

**Shared-prop bytes**, measured on the seeded demo workspace (8 channels, 4 workspaces, 4 channels and 3 workspaces holding something):

| prop | before | after |
|---|---:|---:|
| `channels` | 4,781 B | 4,514 B |
| `teams` | 829 B | 693 B |
| `currentTeam` | 204 B | 171 B |
| `hasUnreadThreads` | 5 B | — |
| `unread` | — | 495 B |
| **total** | **5,819 B** | **5,873 B** |

Two things worth stating plainly:

1. **The visit itself is byte-neutral here (+54 B).** A sparse map entry costs ~60 B where the inline pair cost 33 B, so on a workspace where half the channels are unread the digest is marginally larger. It shrinks as the workspace is read — 42 B on a fully caught-up one — and it scales with *unread* channels, not with channel count, which is the shape the epic is after. The byte win lands when #1252 `once`s the roster half: the per-visit residue then becomes the 495 B digest instead of 5,819 B, which is exactly what this child unblocks.
2. **The read-marking trip is where the win is today: 4,781 B → 495 B**, a 90% cut on a request every click makes. On the demo's 14-channel workspace the roster it used to reload was the 7,834 B the issue quotes.

No time number is quoted, per the budget: the expected delta is well under the ~50 ms noise floor.

## Scope note

The map lists `hasDraft` / `lastActivityAt` (on `ChannelData`) and presence / DND / status (on `UserData`) alongside the counts as welded volatile state. Those are **not** unread state and not badges, and moving them would exceed the blast radius this issue enumerates, so they stay on their rosters: the draft flag is the viewer's own write (already invalidated by `CHANNEL_LIST_PROPS`), last-activity is the DM group's ordering key, and presence is #1252/#1253's territory. Happy to fold them in here instead if you'd rather.

`useSidebarBadges` still pulls `channels` alongside the digest on an *arrival*, because a new message also reorders the DM group and can earn a brand-new DM its row. That is roster movement, not unread state, and it is untouched by this child.

## Testing

- New `tests/Feature/Channels/UnreadDigestTest.php` at the seam the issue names — real Inertia visits asserted with `AssertableInertia`, alongside `WorkspaceShellTest`: the digest rides a visit and the rosters carry no badge fields; reading a channel clears its badge and the trip carries the digest without the roster; muted badges nothing and mentions-only badges only mentions; the workspace reading is the channel readings summed.
- `tests/Feature/Support/WorkspaceUnreadTest.php` rewritten onto the digest, including the query-count-is-flat test.
- New `ChannelListItem.test.ts` (the one enumerated badge surface with no coverage before) and `lib/unreadDigest.test.ts`; `unreadElsewhere`, `useUnreadElsewhere`, `NavigationRail`, `WorkspaceSheet` and `DirectMessageListItem` tests moved onto the digest.
- Shared `unreadBadge()` / `workspaceUnreadBadge()` helpers in `tests/Helpers.php`, so the seven files that read a badge off `sidebarRow()` have one place to read it from now.
- Gates green: `composer test` at **Total: 100.0 %**, plus lint / format / types / vitest (2 719 tests) / build. The full Pest browser suite (355 tests) passes too, which is what proves the rail dots, the workspace sheet badges, the Threads dot and the sidebar's unread indicator still render from the real shell.

No user-facing copy changed, so no new translation keys. Nothing operator-facing, so no `docs/` change.

## CodeRabbit

One finding, declined: it read `digest.value.threads` as a numeric count needing a boolean coercion in `MainLayout`. It is a `bool` on the DTO and `boolean` in the generated types, and `vue-tsc` — the check the finding itself asked for — passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788474265&installation_model_id=428379&pr_number=1265&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1265&signature=0c5db622e63e7010e613d2eccb505b0a5b1130e53e3210584e591daffee5bc80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->