### PR TITLE
perf: collapse the six workspace permission props into one derivation

### DIFF
--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -22,9 +22,9 @@ trait HasTeams
 {
     /**
      * The role this user holds on a team, memoised for the length of a single
-     * {@see toTeamPermissions()} projection and no longer.
+     * {@see holdingTeamRole()} window and no longer.
      *
-     * The projection asks the gate about one membership fifteen times over, and
+     * A projection asks the gate about one membership fifteen times over, and
      * each ability would otherwise resolve the row again. It is deliberately
      * not kept for the request: a role rewritten between two projections must
      * be answered from the database, not from a copy taken before the write.
@@ -195,28 +195,56 @@ trait HasTeams
         $gate = Gate::forUser($this);
 
         // One lookup answers all fifteen abilities below, which each resolve the
-        // same membership. Released again straight after, so the next caller
-        // sees any role written in between.
+        // same membership.
+        return $this->holdingTeamRole($team, fn (): TeamPermissions => new TeamPermissions(
+            canUpdateTeam: $gate->allows('update', $team),
+            canDeleteTeam: $gate->allows('delete', $team),
+            canAddMember: $gate->allows('addMember', $team),
+            canUpdateMember: $gate->allows('updateMember', $team),
+            canRemoveMember: $gate->allows('removeMember', $team),
+            canCreateInvitation: $gate->allows('inviteMember', $team),
+            canCancelInvitation: $gate->allows('cancelInvitation', $team),
+            canTransferOwnership: $gate->allows('transferOwnership', $team),
+            canViewAudit: $gate->allows('viewAudit', $team),
+            canViewSecurityLog: $gate->allows('viewSecurityLog', $team),
+            canViewAnalytics: $gate->allows('viewAnalytics', $team),
+            canViewDeletedChannels: $gate->allows('viewDeletedChannels', $team),
+            canManageEmojis: $gate->allows('manageEmojis', $team),
+            canManageIntegrations: $gate->allows('manageIntegrations', $team),
+            canManageUserGroups: $gate->allows('viewAny', [UserGroup::class, $team]),
+        ));
+    }
+
+    /**
+     * Run the callback with this user's role on the team held, so every ability
+     * it asks about resolves the one membership once instead of per question.
+     *
+     * Re-entrant, and that is the point of it being reachable at all: a caller
+     * that asks two projections of the same membership — the fifteen team
+     * abilities in {@see toTeamPermissions()} and the channel-creation ones
+     * beside them — pays one lookup for both, because the inner call reuses the
+     * role the outer one holds and leaves releasing it to that outer call.
+     *
+     * The role is released as soon as the outermost call returns. It is
+     * deliberately not kept for the request: a role rewritten between two
+     * derivations must be answered from the database, not from a copy taken
+     * before the write.
+     *
+     * @template TReturn
+     *
+     * @param  callable(): TReturn  $callback
+     * @return TReturn
+     */
+    public function holdingTeamRole(Team $team, callable $callback): mixed
+    {
+        if (array_key_exists($team->id, $this->projectedTeamRoles)) {
+            return $callback();
+        }
+
         $this->projectedTeamRoles[$team->id] = $this->teamRole($team);
 
         try {
-            return new TeamPermissions(
-                canUpdateTeam: $gate->allows('update', $team),
-                canDeleteTeam: $gate->allows('delete', $team),
-                canAddMember: $gate->allows('addMember', $team),
-                canUpdateMember: $gate->allows('updateMember', $team),
-                canRemoveMember: $gate->allows('removeMember', $team),
-                canCreateInvitation: $gate->allows('inviteMember', $team),
-                canCancelInvitation: $gate->allows('cancelInvitation', $team),
-                canTransferOwnership: $gate->allows('transferOwnership', $team),
-                canViewAudit: $gate->allows('viewAudit', $team),
-                canViewSecurityLog: $gate->allows('viewSecurityLog', $team),
-                canViewAnalytics: $gate->allows('viewAnalytics', $team),
-                canViewDeletedChannels: $gate->allows('viewDeletedChannels', $team),
-                canManageEmojis: $gate->allows('manageEmojis', $team),
-                canManageIntegrations: $gate->allows('manageIntegrations', $team),
-                canManageUserGroups: $gate->allows('viewAny', [UserGroup::class, $team]),
-            );
+            return $callback();
         } finally {
             unset($this->projectedTeamRoles[$team->id]);
         }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -20,6 +20,7 @@ use App\Support\TranslationCatalog;
 use App\Support\UpdateChecker;
 use App\Support\UserAgentParser;
 use App\Support\WebPushConfig;
+use App\Support\WorkspacePermissions;
 use App\Support\WorkspaceShell;
 use App\Support\WorkspaceUnread;
 use Illuminate\Http\Request;
@@ -62,6 +63,9 @@ class HandleInertiaRequests extends Middleware
      * (signed in, on a workspace route, with a bound team) precondition once.
      * A null shell means there is no workspace to describe, and each of its props
      * falls back to the empty value the frontend already renders for "not here".
+     * The affordance flags are the one thing that outlives the shell — the
+     * settings pages draw them too — so they come off
+     * {@see WorkspacePermissions}, which answers all six from one derivation.
      *
      * @see https://inertiajs.com/shared-data
      *
@@ -72,6 +76,7 @@ class HandleInertiaRequests extends Middleware
     {
         $user = $request->user();
         $shell = WorkspaceShell::forRequest($request);
+        $permissions = WorkspacePermissions::forRequest($request);
         $pinned = NavDestination::fromQuery($request->query(NavDestination::QUERY_PARAM));
         $boundChannel = $request->route('channel');
         $activeChannel = $boundChannel instanceof Channel ? $boundChannel : null;
@@ -198,38 +203,29 @@ class HandleInertiaRequests extends Middleware
             // The dock header's "invite" affordance reuses the member-invite modal,
             // so the current team's invite permission and the assignable roles ride
             // along with every workspace request.
-            'canInviteToCurrentTeam' => fn () => $user?->currentTeam
-                ? $user->toTeamPermissions($user->currentTeam)->canCreateInvitation
-                : false,
+            'canInviteToCurrentTeam' => fn (): bool => $permissions->forCurrentTeam()->canCreateInvitation ?? false,
             // Which kinds of channel the viewer may open here, per the
             // workspace's channel-creation policy. The create modal is raised
             // from the sidebar and the New menu rather than from a page of its
-            // own, so this rides along instead of being threaded through them.
-            'creatableChannelVisibilities' => fn (): array => $shell?->creatableChannelVisibilities() ?? [],
+            // own, so this rides along instead of being threaded through them —
+            // but only inside the workspace, which is what the shell answers.
+            'creatableChannelVisibilities' => fn (): array => $shell instanceof WorkspaceShell ? $permissions->creatableChannelVisibilities() : [],
             // The workspace sheet offers "Workspace settings" only to someone who
             // can actually change the workspace. The page-scoped permission set
             // is not in reach from the shell, so the one flag the sheet needs
             // rides along like its siblings below.
-            'canUpdateCurrentTeam' => fn (): bool => $user?->currentTeam
-                ? $user->toTeamPermissions($user->currentTeam)->canUpdateTeam
-                : false,
+            'canUpdateCurrentTeam' => fn (): bool => $permissions->forCurrentTeam()->canUpdateTeam ?? false,
             // The settings sidebar surfaces a team-admin "evidence" group (Audit
             // log, Security log, Exports) gated by the same permissions as the
             // Team-settings cards, so an admin can jump straight to those surfaces
             // from any settings page. Both default to false off a team / for guests.
-            'canViewCurrentTeamAudit' => fn (): bool => $user?->currentTeam
-                ? $user->toTeamPermissions($user->currentTeam)->canViewAudit
-                : false,
-            'canViewCurrentTeamSecurityLog' => fn (): bool => $user?->currentTeam
-                ? $user->toTeamPermissions($user->currentTeam)->canViewSecurityLog
-                : false,
+            'canViewCurrentTeamAudit' => fn (): bool => $permissions->forCurrentTeam()->canViewAudit ?? false,
+            'canViewCurrentTeamSecurityLog' => fn (): bool => $permissions->forCurrentTeam()->canViewSecurityLog ?? false,
             // The integrations settings surface (bots, tokens, webhooks) hides
             // entirely unless the viewer can manage it and the platform is on, so
             // the permission and the master toggle ride along with every request
             // to gate the nav entry and the Team-settings card.
-            'canManageCurrentTeamIntegrations' => fn (): bool => $user?->currentTeam
-                ? $user->toTeamPermissions($user->currentTeam)->canManageIntegrations
-                : false,
+            'canManageCurrentTeamIntegrations' => fn (): bool => $permissions->forCurrentTeam()->canManageIntegrations ?? false,
             'integrationsEnabled' => (bool) config('integrations.enabled'),
             // How long a deleted channel stays restorable. A fixed instance-wide
             // constant, and the delete dialog is raised from the channel shell

--- a/app/Support/WorkspacePermissions.php
+++ b/app/Support/WorkspacePermissions.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\TeamPermissions;
+use App\Enums\ChannelVisibility;
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+/**
+ * What the viewer may do in the workspace they are currently in, derived once
+ * per request and read by every shared prop that gates an affordance on it.
+ *
+ * The six props exist because six surfaces are raised from the shell rather
+ * than from a page of their own — the invite modal, the workspace sheet, the
+ * settings sidebar's evidence group, the integrations entry and the create-
+ * channel modal — so each needs its answer everywhere rather than on one page.
+ * What they do not need is six answers: they all describe the same viewer in
+ * the same workspace, and asking six times ran the membership lookup five times
+ * over and evaluated eighty-odd abilities to read six of them.
+ *
+ * So this collapses rather than caches. It is derived fresh on every request —
+ * these flags gate affordances only, every one has server-side enforcement
+ * behind it, and at this size cheap freshness beats a staleness debt (#1250).
+ * What it does not do is derive twice: the whole derivation runs inside one
+ * {@see User::holdingTeamRole()} window, so the fifteen team abilities and the
+ * channel-creation ones share the single role lookup they all depend on.
+ *
+ * The props themselves stay named in {@see HandleInertiaRequests::share()},
+ * which is glue; whether there is a channel-creation affordance to describe at
+ * all is still {@see WorkspaceShell}'s question, since that one is drawn only
+ * inside the workspace.
+ */
+final class WorkspacePermissions
+{
+    private bool $derived = false;
+
+    private ?TeamPermissions $teamPermissions = null;
+
+    /** @var array<int, string> */
+    private array $creatableChannelVisibilities = [];
+
+    public function __construct(private readonly ?User $viewer) {}
+
+    /**
+     * The permissions of whoever made this request, in whichever workspace they
+     * are currently in. Both may be absent — a guest, or an account with no
+     * current team — and the derivation then answers for nobody.
+     */
+    public static function forRequest(Request $request): self
+    {
+        $user = $request->user();
+
+        return new self($user instanceof User ? $user : null);
+    }
+
+    /**
+     * The viewer's abilities in their current workspace, or null when there is
+     * no viewer or no workspace to describe.
+     */
+    public function forCurrentTeam(): ?TeamPermissions
+    {
+        $this->derive();
+
+        return $this->teamPermissions;
+    }
+
+    /**
+     * The channel visibilities the viewer may create in their current workspace.
+     *
+     * Asked of the policy rather than derived from the role, so the affordance
+     * and the create endpoint answer the same question the same way. An empty
+     * list withdraws the affordance entirely, matching the 403 the create
+     * endpoint would answer with.
+     *
+     * @return array<int, string>
+     */
+    public function creatableChannelVisibilities(): array
+    {
+        $this->derive();
+
+        return $this->creatableChannelVisibilities;
+    }
+
+    /**
+     * Answer every question this holds, once, off one role lookup.
+     *
+     * Lazy rather than eager because `share()` runs on requests that read none
+     * of it — a partial reload naming other props, an error page — and the
+     * viewer's current team is a relation this would otherwise load for nothing.
+     */
+    private function derive(): void
+    {
+        if ($this->derived) {
+            return;
+        }
+
+        $this->derived = true;
+
+        $viewer = $this->viewer;
+        $team = $viewer?->currentTeam;
+
+        if (! $viewer instanceof User || ! $team instanceof Team) {
+            return;
+        }
+
+        $viewer->holdingTeamRole($team, function () use ($viewer, $team): void {
+            $this->teamPermissions = $viewer->toTeamPermissions($team);
+            $this->creatableChannelVisibilities = array_values(array_map(
+                fn (ChannelVisibility $visibility): string => $visibility->value,
+                array_filter(
+                    ChannelVisibility::cases(),
+                    fn (ChannelVisibility $visibility): bool => $viewer->can('create', [Channel::class, $team, $visibility]),
+                ),
+            ));
+        });
+    }
+}

--- a/app/Support/WorkspaceShell.php
+++ b/app/Support/WorkspaceShell.php
@@ -13,7 +13,6 @@ use App\Data\SlashCommandData;
 use App\Data\UnreadDigestData;
 use App\Data\UserData;
 use App\Data\UserGroupData;
-use App\Enums\ChannelVisibility;
 use App\Enums\MessageReminderStatus;
 use App\Enums\NavDestination;
 use App\Enums\ThreadInboxFilter;
@@ -150,27 +149,6 @@ final readonly class WorkspaceShell
     public function userGroups(): array
     {
         return UserGroupData::mentionableForTeam($this->team);
-    }
-
-    /**
-     * The channel visibilities the viewer may create in this workspace.
-     *
-     * Asked of the policy rather than derived from the role here, so the shell's
-     * affordance and the create endpoint answer the same question the same way.
-     * An empty list withdraws the affordance entirely, matching the 403 the
-     * create endpoint would answer with.
-     *
-     * @return array<int, string>
-     */
-    public function creatableChannelVisibilities(): array
-    {
-        return array_values(array_map(
-            fn (ChannelVisibility $visibility): string => $visibility->value,
-            array_filter(
-                ChannelVisibility::cases(),
-                fn (ChannelVisibility $visibility): bool => $this->viewer->can('create', [Channel::class, $this->team, $visibility]),
-            ),
-        ));
     }
 
     /**

--- a/tests/Feature/Channels/WorkspacePermissionPropsTest.php
+++ b/tests/Feature/Channels/WorkspacePermissionPropsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Enums\ChannelCreationPolicy;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Testing\TestResponse;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/*
+|--------------------------------------------------------------------------
+| The workspace permission props (#1250)
+|--------------------------------------------------------------------------
+|
+| Six shared props gate an affordance on what the viewer may do in the
+| workspace they are in. They are answered by one derivation per request
+| rather than by six, and this file pins both halves of that: the flags each
+| role is handed — the behavioural contract, which the collapse leaves
+| untouched — and the number of times the derivation runs, which is the point
+| of it.
+|
+| The seam is the Inertia visit, like the rest of the shell-contract work:
+| what a navigation ships is an HTTP fact. `WorkspacePermissionsTest` states
+| the derivation itself, without a round-trip.
+|
+*/
+
+/**
+ * A workspace visit to the team's `#general` as the given viewer.
+ */
+function visitWorkspaceAs(User $viewer, Team $team): TestResponse
+{
+    return test()->actingAs($viewer)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => Channel::GENERAL_SLUG,
+    ]));
+}
+
+test('a workspace visit reports the six permission props for the viewer role', function (
+    string $role,
+    bool $administers,
+): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $viewer = $role === TeamRole::Owner->value
+        ? $owner
+        : teamMemberInChannel($general, [], TeamRole::from($role));
+
+    visitWorkspaceAs($viewer, $team)
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('canInviteToCurrentTeam', $administers)
+            ->where('canUpdateCurrentTeam', $administers)
+            ->where('canViewCurrentTeamAudit', $administers)
+            ->where('canViewCurrentTeamSecurityLog', $administers)
+            ->where('canManageCurrentTeamIntegrations', $administers)
+            // Both visibilities are self-service by default, whatever the role.
+            ->where('creatableChannelVisibilities', [
+                ChannelVisibility::Public->value,
+                ChannelVisibility::Private->value,
+            ])
+        );
+})->with([
+    'owner' => [TeamRole::Owner->value, true],
+    'admin' => [TeamRole::Admin->value, true],
+    'member' => [TeamRole::Member->value, false],
+]);
+
+test('the creatable visibilities still follow the workspace creation policy', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    $team->update(['private_channel_creation_policy' => ChannelCreationPolicy::Admins]);
+
+    $member = teamMemberInChannel($general, [], TeamRole::Member);
+
+    visitWorkspaceAs($member, $team)
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('creatableChannelVisibilities', [ChannelVisibility::Public->value])
+        );
+
+    visitWorkspaceAs($owner, $team)
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('creatableChannelVisibilities', [
+                ChannelVisibility::Public->value,
+                ChannelVisibility::Private->value,
+            ])
+        );
+});
+
+test('off a workspace route the six props fall back to what a page without a shell shows', function (): void {
+    $user = User::factory()->create();
+
+    // A personal workspace is the viewer's current team on every settings page,
+    // so the five flags describe *it*: its owner may rename and invite to it,
+    // while the evidence logs and the integrations surface are withheld from a
+    // personal workspace outright. With no shell there is no channel-creation
+    // affordance to describe either.
+    $this->actingAs($user)
+        ->get(route('profile.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('canInviteToCurrentTeam', true)
+            ->where('canUpdateCurrentTeam', true)
+            ->where('canViewCurrentTeamAudit', false)
+            ->where('canViewCurrentTeamSecurityLog', false)
+            ->where('canManageCurrentTeamIntegrations', false)
+            ->where('creatableChannelVisibilities', [])
+        );
+});
+
+test('a guest page reports no workspace permissions at all', function (): void {
+    $this->get(route('login'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('canInviteToCurrentTeam', false)
+            ->where('canUpdateCurrentTeam', false)
+            ->where('canViewCurrentTeamAudit', false)
+            ->where('canViewCurrentTeamSecurityLog', false)
+            ->where('canManageCurrentTeamIntegrations', false)
+            ->where('creatableChannelVisibilities', [])
+        );
+});
+
+test('a workspace visit derives the viewer permissions once for all six props', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    /** @var array<int, string> $abilities */
+    $abilities = [];
+
+    Gate::after(function (?User $user, string $ability) use (&$abilities): null {
+        $abilities[] = $ability;
+
+        return null;
+    });
+
+    visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // `viewAudit` stands in for the fifteen abilities one TeamPermissions
+    // projection answers: before the collapse each of the five flag props asked
+    // for a projection of its own, so this counted five.
+    expect(array_count_values($abilities)['viewAudit'] ?? 0)->toBe(1);
+});

--- a/tests/Integration/Data/TeamPermissionsTest.php
+++ b/tests/Integration/Data/TeamPermissionsTest.php
@@ -125,6 +125,22 @@ test('the projection resolves the role once, not once per ability', function ():
     expect($queries)->toHaveCount(1);
 });
 
+test('a projection that throws still releases the role it held', function (): void {
+    $user = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($user, ['role' => TeamRole::Member->value]);
+
+    expect(fn () => $user->holdingTeamRole($team, function () use ($team, $user): never {
+        $team->members()->updateExistingPivot($user->id, ['role' => TeamRole::Admin->value]);
+
+        throw new RuntimeException('the projection blew up');
+    }))->toThrow(RuntimeException::class);
+
+    // The window closed with the exception, so the promotion written inside it
+    // is answered from the database rather than from the role it was holding.
+    expect($user->teamRole($team))->toBe(TeamRole::Admin);
+});
+
 test('a role written after a projection is answered fresh', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();

--- a/tests/Integration/Support/WorkspacePermissionsTest.php
+++ b/tests/Integration/Support/WorkspacePermissionsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use App\Enums\ChannelCreationPolicy;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\User;
+use App\Support\WorkspacePermissions;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/*
+|--------------------------------------------------------------------------
+| The workspace permission derivation (#1250)
+|--------------------------------------------------------------------------
+|
+| One derivation answers what the viewer may do in the workspace they are in,
+| and six shared props read it. This file states the derivation: what it
+| answers, what it answers when there is nobody or no workspace to answer for,
+| and that asking it twice costs one lookup rather than two.
+|
+| `tests/Feature/Channels/WorkspacePermissionPropsTest.php` keeps the HTTP
+| half — which props a visit ships, and that the visit derives once.
+|
+*/
+
+/**
+ * The number of membership-role lookups the callback provokes.
+ *
+ * `teamRole()` reads the pivot row directly, so it is the one query in the
+ * derivation that starts `select * from "team_members"`; the policies' own
+ * `belongsToTeam()` checks join it from `teams` behind a `select exists`.
+ */
+function countTeamRoleLookups(Closure $callback): int
+{
+    $lookups = 0;
+
+    DB::listen(function ($query) use (&$lookups): void {
+        if (str_starts_with($query->sql, 'select * from "team_members" where')) {
+            $lookups++;
+        }
+    });
+
+    $callback();
+
+    return $lookups;
+}
+
+test('the derivation answers what the viewer may do in their current workspace', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+    $viewer->switchTeam($team);
+
+    $permissions = new WorkspacePermissions($viewer);
+
+    expect($permissions->forCurrentTeam()?->canViewAudit)->toBeTrue()
+        ->and($permissions->creatableChannelVisibilities())->toBe([
+            ChannelVisibility::Public->value,
+            ChannelVisibility::Private->value,
+        ]);
+});
+
+test('the derivation withholds a visibility the workspace reserves for admins', function (): void {
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $team->update(['private_channel_creation_policy' => ChannelCreationPolicy::Admins]);
+
+    $member = teamMemberInChannel($general, [], TeamRole::Member);
+    $member->switchTeam($team);
+
+    expect(new WorkspacePermissions($member)->creatableChannelVisibilities())
+        ->toBe([ChannelVisibility::Public->value]);
+});
+
+test('there is nothing to derive for a guest', function (): void {
+    $permissions = new WorkspacePermissions(null);
+
+    expect($permissions->forCurrentTeam())->toBeNull()
+        ->and($permissions->creatableChannelVisibilities())->toBe([]);
+});
+
+test('there is nothing to derive for an account with no current workspace', function (): void {
+    $user = User::factory()->create();
+    $user->forceFill(['current_team_id' => null])->save();
+
+    $permissions = new WorkspacePermissions($user->fresh());
+
+    expect($permissions->forCurrentTeam())->toBeNull()
+        ->and($permissions->creatableChannelVisibilities())->toBe([]);
+});
+
+test('the derivation is built from the request that asked for it', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+    $viewer->switchTeam($team);
+
+    $request = Request::create('/');
+    $request->setUserResolver(fn (): User => $viewer);
+
+    expect(WorkspacePermissions::forRequest($request)->forCurrentTeam()?->canUpdateTeam)->toBeTrue()
+        ->and(WorkspacePermissions::forRequest(Request::create('/'))->forCurrentTeam())->toBeNull();
+});
+
+test('both projections come off one role lookup, however often they are read', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+    $viewer->switchTeam($team);
+
+    $permissions = new WorkspacePermissions($viewer);
+
+    $lookups = countTeamRoleLookups(function () use ($permissions): void {
+        // The six props read the derivation between them; reading it six times
+        // has to cost what reading it once costs.
+        $permissions->forCurrentTeam();
+        $permissions->forCurrentTeam();
+        $permissions->creatableChannelVisibilities();
+        $permissions->creatableChannelVisibilities();
+    });
+
+    expect($lookups)->toBe(1);
+});
+
+test('a role rewritten between two derivations is answered from the database', function (): void {
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+    $member = teamMemberInChannel($general, [], TeamRole::Member);
+    $member->switchTeam($team);
+
+    expect(new WorkspacePermissions($member)->forCurrentTeam()?->canViewAudit)->toBeFalse();
+
+    $team->memberships()->where('user_id', $member->id)->update(['role' => TeamRole::Admin]);
+
+    // The held role dies with the derivation that held it, so the next one sees
+    // the promotion rather than a copy taken before it.
+    expect(new WorkspacePermissions($member)->forCurrentTeam()?->canViewAudit)->toBeTrue();
+});

--- a/tests/Integration/Support/WorkspaceShellTest.php
+++ b/tests/Integration/Support/WorkspaceShellTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Data\MessageSearchCriteria;
-use App\Enums\ChannelVisibility;
 use App\Enums\MessageReminderStatus;
 use App\Enums\NavDestination;
 use App\Enums\SearchScope;
@@ -87,8 +86,7 @@ test('the shell is constructible from a viewer and a team alone', function (): v
         ->and($shell->userGroups())->toBe([])
         ->and($shell->reminders(MessageReminderStatus::Pending))->toBe([])
         ->and($shell->unreadDigest()->threads)->toBeFalse()
-        ->and($shell->slashCommands())->not->toBeEmpty()
-        ->and($shell->creatableChannelVisibilities())->toContain(ChannelVisibility::Public->value);
+        ->and($shell->slashCommands())->not->toBeEmpty();
 });
 
 test('the team roster is ordered by name and lists the viewer among the others', function (): void {


### PR DESCRIPTION
Closes #1250. Second of the shell-contract children on [perf: navigation feels instant](https://github.com/deskhq/the-desk/issues/1248), after #1249.

## What changed

**Six props, one derivation.** `canInviteToCurrentTeam`, `canUpdateCurrentTeam`, `canViewCurrentTeamAudit`, `canViewCurrentTeamSecurityLog` and `canManageCurrentTeamIntegrations` each rebuilt a whole `TeamPermissions` projection to read one field off it and discard the other fourteen; `creatableChannelVisibilities` asked the channel policy separately alongside them. A new `App\Support\WorkspacePermissions` answers all six.

- It **collapses rather than caches**: derived fresh on every request, not `once`'d and not keyed. 466 bytes is not worth a staleness debt, and keying on the role would cost the `teamRole()` query the caching was meant to save.
- The whole derivation runs inside **one held-role window**. `HasTeams`'s existing `projectedTeamRoles` memo is now reachable as `holdingTeamRole()`, which is re-entrant — the inner `toTeamPermissions()` call reuses the role the outer window holds and leaves releasing it to that outer call, so the fifteen team abilities and the two channel-creation ones share a single membership lookup. It is still released as soon as the outermost call returns, so a role rewritten between two derivations is answered from the database.
- It is **lazy**: `share()` runs on requests that read none of it (a partial reload naming other props, an error page), and the viewer's current team is a relation that would otherwise be loaded for nothing.
- `creatableChannelVisibilities` moves off `WorkspaceShell` onto the same derivation. The shell still decides *whether* there is a creation affordance to describe — that one is drawn only inside the workspace — while the derivation decides what it says.

**Out of scope, deliberately:** `TeamPolicy` and `toTeamPermissions`'s own restatement of policy abilities are untouched. That is #1198's territory in a different epic, and folding it in would turn a payload change into a security change.

## Number

Gate-call and query counts on a workspace visit (`channels.show` on a one-member workspace), not a time number — this child is the budget's worked example of something that does not clear the ~50 ms floor.

| | before | after |
|---|---|---|
| `Gate::allows` invocations | 85 | **25** |
| `teamRole()` queries | 10 | **4** |
| queries in total | 51 | **45** |

The permission work itself went from 7 role lookups to 1; the remaining 4 belong to `currentTeam` / `teams`, which are #1252 and #1253's territory. Bytes are unchanged by design — the six props still ride every visit.

## Testing

- `tests/Feature/Channels/WorkspacePermissionPropsTest.php` — the HTTP contract: what each role (owner, admin, member) is handed on a workspace visit, that the creatable visibilities still follow the workspace's creation policy, what a settings page and a guest page report, and that the visit derives **once** (a `Gate::after` counter: `viewAudit` was checked 5 times, now 1).
- `tests/Integration/Support/WorkspacePermissionsTest.php` — the derivation itself: what it answers, what it answers for a guest and for an account with no current workspace, that reading it four times costs one role lookup, and that a role rewritten between two derivations is answered fresh.
- `tests/Integration/Data/TeamPermissionsTest.php` — one added case: a projection that throws still releases the role it held.

Full gate green, `Total: 100.0 %`. Frontend gate green and untouched — the prop names and shapes are byte-identical, so no client change was needed.

No i18n or docs changes: nothing user-facing and nothing an operator acts on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788476965&installation_model_id=428379&pr_number=1267&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1267&signature=482efda9eb13c41d8b80745923f2f0ee06f9798038c6129e4d4074bc1585dfe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->