### PR TITLE
perf: once the instance-config, TTL and session-keyed shared props

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -313,9 +313,11 @@ class HandleInertiaRequests extends Middleware
             //
             // Keyed on whether anyone is signed in, because the two answers are
             // different props: without the split, a guest's null would be the
-            // cached value a sign-in from that same tab never replaced.
+            // cached value a sign-in from that same tab never replaced. It
+            // carries the instance key too, since `current` *is* the running
+            // version and an in-place upgrade is what settles the comparison.
             'update' => Inertia::once(fn (): ?UpdateStatusData => $user ? app(UpdateChecker::class)->status() : null)
-                ->as('update:'.($user ? 'viewer' : 'guest'))
+                ->as($instance.':update:'.($user ? 'viewer' : 'guest'))
                 ->until(now()->addHours(max((int) config('updates.cache_ttl_hours', 12), 1))),
             'locale' => Inertia::once(fn (): string => app()->getLocale())->as('locale:'.$locale),
             // The active locale's catalog rides the initial document as a "once"
@@ -348,8 +350,13 @@ class HandleInertiaRequests extends Middleware
             // settings visit answering `[]` would be the value a later workspace
             // visit restored. It is a global registry, so there is one honest
             // answer, and it is paid for once.
+            //
+            // Carries the instance key as well as the locale, because which
+            // commands exist is instance config too: `/poll` and `/gif` are
+            // registered only where their feature is configured, so an operator
+            // switching one off has to take it out of autocomplete with it.
             'slashCommands' => Inertia::once(fn (): array => app(SlashCommandRegistry::class)->manifest())
-                ->as("slashCommands:{$locale}:".config('app.version')),
+                ->as("{$instance}:slashCommands:{$locale}"),
             // A readable name for the device this request came from, so a surface
             // that has to name it (the post-registration passkey prompt prefills
             // its name field with it) does not re-derive the parse client-side.

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -11,8 +11,10 @@ use App\Enums\SidebarPosition;
 use App\Enums\TeamRole;
 use App\Enums\ThreadInboxFilter;
 use App\Models\Channel;
+use App\SlashCommands\SlashCommandRegistry;
 use App\Support\Branding\BrandingAssets;
 use App\Support\FrequentEmoji;
+use App\Support\InstanceFingerprint;
 use App\Support\MessageSearchPanel;
 use App\Support\PendingInvitations;
 use App\Support\ReverbConfig;
@@ -26,6 +28,7 @@ use App\Support\WorkspaceUnread;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Middleware;
+use Inertia\OnceProp;
 use Laravel\Fortify\Features;
 
 class HandleInertiaRequests extends Middleware
@@ -57,15 +60,19 @@ class HandleInertiaRequests extends Middleware
      *
      * This list *is* the Inertia contract with the frontend, so it stays spelled
      * out here — one line per prop, naming it and saying where it comes from.
-     * What it deliberately does not do is compute any of them: instance-level
-     * props read config or a `Support` helper, and everything an in-workspace
-     * page needs comes off {@see WorkspaceShell}, which resolves the
+     * What it deliberately does not do is compute any of them: everything an
+     * in-workspace page needs comes off {@see WorkspaceShell}, which resolves the
      * (signed in, on a workspace route, with a bound team) precondition once.
      * A null shell means there is no workspace to describe, and each of its props
      * falls back to the empty value the frontend already renders for "not here".
      * The affordance flags are the one thing that outlives the shell — the
      * settings pages draw them too — so they come off
      * {@see WorkspacePermissions}, which answers all six from one derivation.
+     *
+     * What is *not* here is the instance's own description — its name, branding,
+     * connection details and feature toggles — along with the session facts that
+     * settle at sign-in. Those cannot change between two clicks, so they are
+     * declared next door in {@see self::shareOnce()} and reach the client once.
      *
      * @see https://inertiajs.com/shared-data
      *
@@ -83,119 +90,8 @@ class HandleInertiaRequests extends Middleware
 
         return [
             ...parent::share($request),
-            'name' => config('app.name'),
-            // Instance branding. `logo` is the operator's mark, or null when the
-            // instance still ships ours — the shipped mark is an inline SVG whose
-            // lower planes ride on `currentColor`, which an uploaded file cannot
-            // do, so the client only swaps in an <img> once there is something to
-            // swap in. `attribution` drives the removable "Powered by" line.
-            'branding' => [
-                'logo' => $this->brandingAssets->logoPath() === null ? null : route('branding.logo'),
-                'attribution' => (bool) config('branding.attribution'),
-            ],
-            // Browser-facing Reverb connection details, resolved at runtime so a
-            // single built image works for any operator without baking VITE_*
-            // values into the bundle. Read by app.ts to configure Echo at boot.
-            'reverb' => ReverbConfig::forFrontend(),
-            // Whether this instance can send web push, plus the VAPID public key
-            // a browser needs to subscribe. Resolved at runtime for the same
-            // reason as the Reverb block above: one published image serves every
-            // operator's keypair without a rebuild. Both are withheld when no
-            // keypair is configured, which is what hides the settings toggle.
-            'webPush' => WebPushConfig::forFrontend(),
-            'locale' => app()->getLocale(),
-            // The active locale's catalog rides the initial document as a "once"
-            // prop: it reaches the SSR render and first hydration (so the first
-            // paint is already translated) but is excluded from every subsequent
-            // SPA visit, keeping navigation payloads free of the catalog.
-            //
-            // The once key carries the locale it holds, so "already loaded" means
-            // "already loaded *this* catalog". A visit that changes the effective
-            // locale without a document load — signing in as a French user from
-            // the English guest page — therefore ships the new catalog instead of
-            // leaving the client rendering the old one (#764).
-            'translations' => Inertia::once(fn () => app(TranslationCatalog::class)->messages(app()->getLocale()))
-                ->as('translations:'.app()->getLocale()),
-            // A single deploy-time flag lets self-hosters lock down public
-            // registration; when off, Fortify never registers the register
-            // routes, so the frontend hides its "sign up" affordances to match.
-            'registrationEnabled' => Features::enabled(Features::registration()),
-            // Whether new accounts must confirm their email before using the app.
-            // Off by default; the frontend reads it only to hide copy that would
-            // imply a verification step that can't happen (e.g. the profile
-            // "resend verification email" affordance).
-            'emailVerificationEnabled' => (bool) config('fortify.email_verification_enabled'),
-            // Whether this instance is the public single-shared-account demo.
-            // The frontend reads it only to disable the destructive owner-level
-            // controls (delete/rename the workspace, change email/password,
-            // enable 2FA/passkeys, remove members) with a "disabled in the demo"
-            // tooltip — the server enforces every block regardless (see
-            // PreventDestructiveDemoActions), so this is UI affordance only.
-            'demoMode' => (bool) config('demo.mode'),
-            // ISO-8601 instant of the next hourly demo wipe (top of the hour),
-            // so the banner's "Resets in X min" chip ticks against the real
-            // schedule (see routes/console.php). Null off the demo.
-            'demoResetsAt' => config('demo.mode')
-                ? now()->startOfHour()->addHour()->toIso8601String()
-                : null,
-            // Single sign-on state for the login page: whether to show the
-            // "Sign in with SSO" entry point (an OIDC provider is configured),
-            // and whether the password form still applies (off only when SSO
-            // enforcement is active — AUTH_SSO_ONLY with a configured provider —
-            // where the password login POST is blocked too).
-            'sso' => [
-                'oidcEnabled' => (bool) config('sso.oidc.enabled'),
-                'passwordLoginEnabled' => ! config('sso.enforced'),
-            ],
-            // A readable name for the device this request came from, so a surface
-            // that has to name it (the post-registration passkey prompt prefills
-            // its name field with it) does not re-derive the parse client-side.
-            // Joined into one line by the frontend through the `:browser on
-            // :platform` key the session list already uses, so it follows a live
-            // locale switch rather than freezing at render time.
-            'currentDevice' => UserAgentParser::parse($request->userAgent()),
-            // The one-time account-security prompt owed to an account created in
-            // this session, or null. Read from the session rather than the user so
-            // it dies with the session — a returning user is no longer "just
-            // registered" — and re-gated per request, so switching the feature off
-            // withdraws the prompt instead of offering something that would 404.
-            'postRegistrationPrompt' => $this->postRegistrationPrompt($request),
-            // The per-file and per-message attachment caps, so the composer can
-            // reject an oversized or over-count drop client-side for instant
-            // feedback. The upload and send endpoints re-enforce them as the
-            // source of truth (see config/attachments.php).
-            'attachments' => [
-                'maxSizeMb' => (int) config('attachments.max_size_mb'),
-                'maxPerMessage' => (int) config('attachments.max_per_message'),
-            ],
-            // Whether the Giphy `/gif` picker is available, derived from the API
-            // key being set. False fully hides the picker client-side (and the
-            // `/gif` command is absent from autocomplete), matching the 404 the
-            // search/attach endpoints return when unconfigured.
-            'gifPickerEnabled' => filled(config('services.giphy.key')),
-            // Whether the `/poll` builder is available. False fully hides the
-            // builder client-side (and the `/poll` command is absent from
-            // autocomplete), matching the 404 the poll endpoints return when off.
-            'pollsEnabled' => (bool) config('polls.enabled'),
-            // The instance's version standing, so authenticated users see a
-            // low-key "update available" indicator when the self-hosted release
-            // is behind. `current` is always present; `latest`/`notesUrl` fill in
-            // once a scheduled check has cached a result (never when disabled).
-            'update' => fn (): ?UpdateStatusData => $user ? app(UpdateChecker::class)->status() : null,
             'auth' => [
                 'user' => $user,
-            ],
-            // The selectable sidebar positions (left / right) ride every request
-            // so the user menu can offer them anywhere, not just on
-            // Settings → Appearance where the page-level prop is scoped. The enum
-            // is the single source of truth, shared the same way the settings page
-            // sources its own options.
-            'sidebarPositions' => SidebarPosition::options(),
-            // The auto-idle threshold rides every request because the detector
-            // that enforces it runs in the browser: a tab has to know how long
-            // "no activity" may last before it reports itself away.
-            'presence' => [
-                'awayAfterMinutes' => max((int) config('presence.away_after_minutes'), 1),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
@@ -226,13 +122,6 @@ class HandleInertiaRequests extends Middleware
             // the permission and the master toggle ride along with every request
             // to gate the nav entry and the Team-settings card.
             'canManageCurrentTeamIntegrations' => fn (): bool => $permissions->forCurrentTeam()->canManageIntegrations ?? false,
-            'integrationsEnabled' => (bool) config('integrations.enabled'),
-            // How long a deleted channel stays restorable. A fixed instance-wide
-            // constant, and the delete dialog is raised from the channel shell
-            // rather than from a page of its own, so it rides along here instead
-            // of being threaded through the channel view as a page prop.
-            'channelRestoreWindowDays' => Channel::RESTORE_WINDOW_DAYS,
-            'invitableRoles' => TeamRole::assignable(),
             'channels' => fn (): array => $shell?->channels($activeChannel) ?? [],
             // What the viewer has not read: the sidebar's per-channel badges,
             // every workspace's dot, and the Threads dot, in one prop. The
@@ -261,12 +150,6 @@ class HandleInertiaRequests extends Middleware
             // `group:<id>` token renders as a pill or as plain text. A deleted
             // group is simply absent, so its token falls back to text.
             'userGroups' => fn (): array => $shell?->userGroups() ?? [],
-            // The composer's slash-command autocomplete manifest, built from the
-            // registry with copy already translated under the active locale.
-            // Server-authoritative: a newly registered command appears in
-            // autocomplete with no frontend change. Empty off the workspace,
-            // where the composer isn't rendered.
-            'slashCommands' => fn (): array => $shell?->slashCommands() ?? [],
             'collapsedChannelSections' => fn () => $user->collapsed_channel_sections ?? [],
             // The Threads panel's inbox and its "Unread" tally, present only while
             // the dock actually has that destination pinned.
@@ -281,6 +164,243 @@ class HandleInertiaRequests extends Middleware
             // in-app nudges; reloaded live when a MessageReminderDue signal lands.
             'firedReminders' => fn (): array => $shell?->reminders(MessageReminderStatus::Fired) ?? [],
         ];
+    }
+
+    /**
+     * Define the props that are shared once and remembered across navigations.
+     *
+     * The counterpart to {@see self::share()}: everything there is recomputed
+     * and reserialised on every click, and everything here is not. A prop
+     * belongs in this list when it **cannot change between two clicks** and
+     * there is an honest trigger for when it can — an instance whose operator
+     * changed something, a clock reaching the top of the hour, a session whose
+     * locale or device is different. Inertia excludes a once prop *before*
+     * resolving it, so a prop moved here costs zero bytes and zero closure time
+     * on an ordinary navigation; that is why the two that read the filesystem
+     * and parse a user agent are closures rather than eager values.
+     *
+     * Three groups, distinguished only by what their key is made of:
+     *
+     * 1. **Instance config**, behind one shared {@see InstanceFingerprint}. The
+     *    key is the same digest for all of them because they change together.
+     * 2. **TTL'd** — `demoResetsAt` and `update`, where the trigger is a clock
+     *    rather than an event.
+     * 3. **Session-, locale- or version-keyed** — what the viewer's own session
+     *    settles: the language they read in, the device they arrived on, the
+     *    prompt their registration queued.
+     *
+     * Every key carries its own discriminator because the **client stores once
+     * props by key and restores them by prop path**: two props sharing one key
+     * collapse into a single entry client-side, and the other would come back
+     * absent on the second visit rather than cached. One digest, sixteen keys.
+     *
+     * The exclusion is bypassed on partial requests, so a `router.reload({ only:
+     * [...] })` naming any of these still receives it — which is what makes
+     * `resources/js/lib/reloadProps.ts` the invalidation registry for the props
+     * whose trigger is a write rather than a key.
+     *
+     * @see https://inertiajs.com/shared-data
+     *
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function shareOnce(Request $request): array
+    {
+        $instance = 'instance:'.InstanceFingerprint::current();
+        $locale = app()->getLocale();
+        $user = $request->user();
+        $prompt = $this->postRegistrationPrompt($request);
+
+        return [
+            'name' => Inertia::once(fn (): string => (string) config('app.name'))->as($instance.':name'),
+            // Instance branding. `logo` is the operator's mark, or null when the
+            // instance still ships ours — the shipped mark is an inline SVG whose
+            // lower planes ride on `currentColor`, which an uploaded file cannot
+            // do, so the client only swaps in an <img> once there is something to
+            // swap in. `attribution` drives the removable "Powered by" line.
+            //
+            // Resolving the logo is up to two filesystem stats, and it is the
+            // reason this prop is a closure: the stats now run on a first load
+            // and never again. The fingerprint deliberately does not cover them
+            // — see {@see InstanceFingerprint}.
+            'branding' => Inertia::once(fn (): array => [
+                'logo' => $this->brandingAssets->logoPath() === null ? null : route('branding.logo'),
+                'attribution' => (bool) config('branding.attribution'),
+            ])->as($instance.':branding'),
+            // Browser-facing Reverb connection details, resolved at runtime so a
+            // single built image works for any operator without baking VITE_*
+            // values into the bundle. Read by app.ts to configure Echo at boot —
+            // and by nothing afterwards, which is what makes it a once prop
+            // rather than something the shell keeps re-reading.
+            'reverb' => Inertia::once(ReverbConfig::forFrontend(...))->as($instance.':reverb'),
+            // Whether this instance can send web push, plus the VAPID public key
+            // a browser needs to subscribe. Resolved at runtime for the same
+            // reason as the Reverb block above: one published image serves every
+            // operator's keypair without a rebuild. Both are withheld when no
+            // keypair is configured, which is what hides the settings toggle.
+            'webPush' => Inertia::once(WebPushConfig::forFrontend(...))->as($instance.':webPush'),
+            // A single deploy-time flag lets self-hosters lock down public
+            // registration; when off, Fortify never registers the register
+            // routes, so the frontend hides its "sign up" affordances to match.
+            'registrationEnabled' => Inertia::once(fn (): bool => Features::enabled(Features::registration()))
+                ->as($instance.':registrationEnabled'),
+            // Whether new accounts must confirm their email before using the app.
+            // Off by default; the frontend reads it only to hide copy that would
+            // imply a verification step that can't happen (e.g. the profile
+            // "resend verification email" affordance).
+            'emailVerificationEnabled' => Inertia::once(fn (): bool => (bool) config('fortify.email_verification_enabled'))
+                ->as($instance.':emailVerificationEnabled'),
+            // Whether this instance is the public single-shared-account demo.
+            // The frontend reads it only to disable the destructive owner-level
+            // controls (delete/rename the workspace, change email/password,
+            // enable 2FA/passkeys, remove members) with a "disabled in the demo"
+            // tooltip — the server enforces every block regardless (see
+            // PreventDestructiveDemoActions), so this is UI affordance only.
+            'demoMode' => Inertia::once(fn (): bool => (bool) config('demo.mode'))->as($instance.':demoMode'),
+            // Single sign-on state for the login page: whether to show the
+            // "Sign in with SSO" entry point (an OIDC provider is configured),
+            // and whether the password form still applies (off only when SSO
+            // enforcement is active — AUTH_SSO_ONLY with a configured provider —
+            // where the password login POST is blocked too).
+            'sso' => Inertia::once(fn (): array => [
+                'oidcEnabled' => (bool) config('sso.oidc.enabled'),
+                'passwordLoginEnabled' => ! config('sso.enforced'),
+            ])->as($instance.':sso'),
+            // The per-file and per-message attachment caps, so the composer can
+            // reject an oversized or over-count drop client-side for instant
+            // feedback. The upload and send endpoints re-enforce them as the
+            // source of truth (see config/attachments.php).
+            'attachments' => Inertia::once(fn (): array => [
+                'maxSizeMb' => (int) config('attachments.max_size_mb'),
+                'maxPerMessage' => (int) config('attachments.max_per_message'),
+            ])->as($instance.':attachments'),
+            // Whether the Giphy `/gif` picker is available, derived from the API
+            // key being set. False fully hides the picker client-side (and the
+            // `/gif` command is absent from autocomplete), matching the 404 the
+            // search/attach endpoints return when unconfigured.
+            'gifPickerEnabled' => Inertia::once(fn (): bool => filled(config('services.giphy.key')))
+                ->as($instance.':gifPickerEnabled'),
+            // Whether the `/poll` builder is available. False fully hides the
+            // builder client-side (and the `/poll` command is absent from
+            // autocomplete), matching the 404 the poll endpoints return when off.
+            'pollsEnabled' => Inertia::once(fn (): bool => (bool) config('polls.enabled'))
+                ->as($instance.':pollsEnabled'),
+            // The integrations settings surface (bots, tokens, webhooks) hides
+            // entirely unless the platform is on, so the master toggle rides
+            // along to gate the nav entry and the Team-settings card. The
+            // permission half of that gate stays in share(): it follows the
+            // viewer's role, not the instance.
+            'integrationsEnabled' => Inertia::once(fn (): bool => (bool) config('integrations.enabled'))
+                ->as($instance.':integrationsEnabled'),
+            // How long a deleted channel stays restorable. A fixed instance-wide
+            // constant, and the delete dialog is raised from the channel shell
+            // rather than from a page of its own, so it rides along here instead
+            // of being threaded through the channel view as a page prop. A code
+            // constant rather than a config value, which `app.version` covers.
+            'channelRestoreWindowDays' => Inertia::once(fn (): int => Channel::RESTORE_WINDOW_DAYS)
+                ->as($instance.':channelRestoreWindowDays'),
+            // The auto-idle threshold rides every request because the detector
+            // that enforces it runs in the browser: a tab has to know how long
+            // "no activity" may last before it reports itself away.
+            'presence' => Inertia::once(fn (): array => [
+                'awayAfterMinutes' => max((int) config('presence.away_after_minutes'), 1),
+            ])->as($instance.':presence'),
+            'demoResetsAt' => $this->demoResetsAt(),
+            // The instance's version standing, so authenticated users see a
+            // low-key "update available" indicator when the self-hosted release
+            // is behind. `current` is always present; `latest`/`notesUrl` fill in
+            // once a scheduled check has cached a result (never when disabled).
+            //
+            // Keyed on whether anyone is signed in, because the two answers are
+            // different props: without the split, a guest's null would be the
+            // cached value a sign-in from that same tab never replaced.
+            'update' => Inertia::once(fn (): ?UpdateStatusData => $user ? app(UpdateChecker::class)->status() : null)
+                ->as('update:'.($user ? 'viewer' : 'guest'))
+                ->until(now()->addHours((int) config('updates.cache_ttl_hours', 12))),
+            'locale' => Inertia::once(fn (): string => app()->getLocale())->as('locale:'.$locale),
+            // The active locale's catalog rides the initial document as a "once"
+            // prop: it reaches the SSR render and first hydration (so the first
+            // paint is already translated) but is excluded from every subsequent
+            // SPA visit, keeping navigation payloads free of the catalog.
+            //
+            // The once key carries the locale it holds, so "already loaded" means
+            // "already loaded *this* catalog". A visit that changes the effective
+            // locale without a document load — signing in as a French user from
+            // the English guest page — therefore ships the new catalog instead of
+            // leaving the client rendering the old one (#764).
+            'translations' => Inertia::once(fn () => app(TranslationCatalog::class)->messages($locale))
+                ->as('translations:'.$locale),
+            // The selectable sidebar positions (left / right) ride every request
+            // so the user menu can offer them anywhere, not just on
+            // Settings → Appearance where the page-level prop is scoped. The enum
+            // is the single source of truth, shared the same way the settings page
+            // sources its own options. Locale-keyed rather than fingerprinted,
+            // because the labels are translated server-side.
+            'sidebarPositions' => Inertia::once(SidebarPosition::options(...))->as('sidebarPositions:'.$locale),
+            'invitableRoles' => Inertia::once(TeamRole::assignable(...))->as('invitableRoles:'.$locale),
+            // The composer's slash-command autocomplete manifest, built from the
+            // registry with copy already translated under the active locale.
+            // Server-authoritative: a newly registered command appears in
+            // autocomplete with no frontend change.
+            //
+            // Shared everywhere rather than only inside the workspace: a once
+            // prop has one value per prop name for the life of the page, so a
+            // settings visit answering `[]` would be the value a later workspace
+            // visit restored. It is a global registry, so there is one honest
+            // answer, and it is paid for once.
+            'slashCommands' => Inertia::once(fn (): array => app(SlashCommandRegistry::class)->manifest())
+                ->as("slashCommands:{$locale}:".config('app.version')),
+            // A readable name for the device this request came from, so a surface
+            // that has to name it (the post-registration passkey prompt prefills
+            // its name field with it) does not re-derive the parse client-side.
+            // Joined into one line by the frontend through the `:browser on
+            // :platform` key the session list already uses, so it follows a live
+            // locale switch rather than freezing at render time.
+            //
+            // Keyed on the raw header rather than on the session: the parse is a
+            // function of the header alone, and hashing it is what keeps the
+            // regexes off the navigation path. Truncated for the same reason the
+            // instance digest is — the key rides a request header on every
+            // navigation, and a collision costs a device name, not correctness.
+            'currentDevice' => Inertia::once(fn (): array => UserAgentParser::parse($request->userAgent()))
+                ->as('currentDevice:'.substr(hash('xxh128', (string) $request->userAgent()), 0, 8)),
+            // The one-time account-security prompt owed to an account created in
+            // this session, or null. Read from the session rather than the user so
+            // it dies with the session — a returning user is no longer "just
+            // registered" — and re-gated per request, so switching the feature off
+            // withdraws the prompt instead of offering something that would 404.
+            //
+            // Cached only while there is nothing to offer, which is every visit
+            // but a handful: a queued prompt is forced through so that registering
+            // in a tab that has already cached the empty answer still raises it.
+            // Answering it clears the session key and reloads this prop by name
+            // (see `usePostRegistrationPrompt`), which is what stops a refresh
+            // re-asking.
+            'postRegistrationPrompt' => Inertia::once(fn (): ?string => $prompt)->fresh($prompt !== null),
+        ];
+    }
+
+    /**
+     * The next hourly demo wipe, as the banner's "Resets in X min" chip counts
+     * down to it — null off the demo, where there is no wipe to count down to.
+     *
+     * The one prop here whose trigger is purely a clock: it holds until the top
+     * of the next hour and is then recomputed, instead of being recomputed on
+     * every click for an answer that changes hourly. Its TTL is also the
+     * shortest in this file, and a once prop's TTL **caps the lifetime of a
+     * prefetched page** — an hour against the 30 s prefetch cache is no
+     * constraint at all, but a TTL shorter than 30 s here would silently shrink
+     * that cache instead (#1237).
+     */
+    protected function demoResetsAt(): OnceProp
+    {
+        if (! config('demo.mode')) {
+            return Inertia::once(fn (): null => null);
+        }
+
+        $resetsAt = now()->startOfHour()->addHour();
+
+        return Inertia::once(fn (): string => $resetsAt->toIso8601String())->until($resetsAt);
     }
 
     /**

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -305,7 +305,7 @@ class HandleInertiaRequests extends Middleware
             'presence' => Inertia::once(fn (): array => [
                 'awayAfterMinutes' => max((int) config('presence.away_after_minutes'), 1),
             ])->as($instance.':presence'),
-            'demoResetsAt' => $this->demoResetsAt(),
+            'demoResetsAt' => $this->demoResetsAt($instance),
             // The instance's version standing, so authenticated users see a
             // low-key "update available" indicator when the self-hosted release
             // is behind. `current` is always present; `latest`/`notesUrl` fill in
@@ -316,7 +316,7 @@ class HandleInertiaRequests extends Middleware
             // cached value a sign-in from that same tab never replaced.
             'update' => Inertia::once(fn (): ?UpdateStatusData => $user ? app(UpdateChecker::class)->status() : null)
                 ->as('update:'.($user ? 'viewer' : 'guest'))
-                ->until(now()->addHours((int) config('updates.cache_ttl_hours', 12))),
+                ->until(now()->addHours(max((int) config('updates.cache_ttl_hours', 12), 1))),
             'locale' => Inertia::once(fn (): string => app()->getLocale())->as('locale:'.$locale),
             // The active locale's catalog rides the initial document as a "once"
             // prop: it reaches the SSR render and first hydration (so the first
@@ -391,16 +391,24 @@ class HandleInertiaRequests extends Middleware
      * prefetched page** — an hour against the 30 s prefetch cache is no
      * constraint at all, but a TTL shorter than 30 s here would silently shrink
      * that cache instead (#1237).
+     *
+     * It carries the instance key in both branches even though only one of them
+     * has a clock, because *whether* there is a wipe to count down to is
+     * instance config like any other: keeping one key for the prop is what stops
+     * an instance that switches the demo on from being answered under a key the
+     * client already holds the other answer for.
      */
-    protected function demoResetsAt(): OnceProp
+    protected function demoResetsAt(string $instance): OnceProp
     {
+        $key = $instance.':demoResetsAt';
+
         if (! config('demo.mode')) {
-            return Inertia::once(fn (): null => null);
+            return Inertia::once(fn (): null => null)->as($key);
         }
 
         $resetsAt = now()->startOfHour()->addHour();
 
-        return Inertia::once(fn (): string => $resetsAt->toIso8601String())->until($resetsAt);
+        return Inertia::once(fn (): string => $resetsAt->toIso8601String())->as($key)->until($resetsAt);
     }
 
     /**

--- a/app/Support/InstanceFingerprint.php
+++ b/app/Support/InstanceFingerprint.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Http\Middleware\HandleInertiaRequests;
+
+/**
+ * A short digest of the instance configuration the shell's constant props are
+ * drawn from, used as the invalidation key those props are shared under.
+ *
+ * They are constants of the deployment rather than of the request — the app's
+ * name, the branding, the Reverb and web-push connection details, the feature
+ * toggles — so a client that has them once has them until the operator changes
+ * one. This digest is what "until the operator changes one" means: every value
+ * below is already in memory when the request starts, so recomputing it per
+ * request costs a hash over a handful of scalars, and a changed value yields a
+ * different key, which reships the whole group on the client's next visit
+ * without a hard reload.
+ *
+ * Two deliberate properties:
+ *
+ * 1. **One digest for the whole group, not one per prop.** They change
+ *    together — an operator edits `.env` and restarts — so a per-prop digest
+ *    would buy nothing and cost fifteen more hashes.
+ * 2. **The logo is not in it.** Resolving whether the operator has supplied one
+ *    is a filesystem stat, and keeping that on the per-request path is precisely
+ *    what {@see HandleInertiaRequests::shareOnce()} exists to stop. A logo
+ *    dropped onto a running instance therefore reaches clients on their next
+ *    hard load, which is accepted.
+ *
+ * Over-invalidating is safe and under-invalidating is not, so the sources are
+ * read generously: `app.version` stands in for everything that is a code
+ * constant rather than a config value (the channel restore window, the role and
+ * sidebar-position enums), since those can only change with a deploy.
+ */
+final class InstanceFingerprint
+{
+    /**
+     * The config keys the instance-config props read, and nothing else.
+     *
+     * Kept in step with the group by `SharedOncePropsTest`, which changes each
+     * one and asserts the props come back.
+     *
+     * @var list<string>
+     */
+    private const array SOURCES = [
+        'app.name',
+        'app.version',
+        'branding.attribution',
+        'broadcasting.connections.reverb',
+        'webpush.vapid.public_key',
+        'webpush.vapid.private_key',
+        'fortify.features',
+        'fortify.email_verification_enabled',
+        'demo.mode',
+        'sso.oidc.enabled',
+        'sso.enforced',
+        'attachments.max_size_mb',
+        'attachments.max_per_message',
+        'services.giphy.key',
+        'polls.enabled',
+        'integrations.enabled',
+        'presence.away_after_minutes',
+    ];
+
+    /**
+     * How much of the digest is kept.
+     *
+     * It is carried in a request header once per prop in the group, so its
+     * length is paid on every navigation while the saving it buys is paid once.
+     * Thirty-two bits is ample for the job: a collision does not corrupt
+     * anything, it only means one config change reaches clients on their next
+     * hard load rather than their next visit.
+     */
+    private const int LENGTH = 8;
+
+    /**
+     * The digest of this instance's configuration as it stands.
+     */
+    public static function current(): string
+    {
+        $values = array_map(static fn (string $key): mixed => config($key), self::SOURCES);
+
+        return substr(hash('xxh128', (string) json_encode($values)), 0, self::LENGTH);
+    }
+}

--- a/app/Support/WorkspaceShell.php
+++ b/app/Support/WorkspaceShell.php
@@ -9,7 +9,6 @@ use App\Data\ChannelSectionData;
 use App\Data\CustomEmojiData;
 use App\Data\MessageReminderData;
 use App\Data\MessageSearchCriteria;
-use App\Data\SlashCommandData;
 use App\Data\UnreadDigestData;
 use App\Data\UserData;
 use App\Data\UserGroupData;
@@ -20,7 +19,6 @@ use App\Http\Middleware\HandleInertiaRequests;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
-use App\SlashCommands\SlashCommandRegistry;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\ProvidesScrollMetadata;
@@ -28,8 +26,7 @@ use Inertia\ProvidesScrollMetadata;
 /**
  * Everything an in-workspace page needs to draw its shell — the sidebar's
  * channels, sections, members and reminders, the emoji and group vocabularies
- * message bodies resolve against, the composer's command manifest, and the dock
- * panels' payloads.
+ * message bodies resolve against, and the dock panels' payloads.
  *
  * It exists so that "the shell" is an addressable thing rather than 40-odd
  * unrelated closures in a middleware. Two properties matter:
@@ -240,21 +237,6 @@ final readonly class WorkspaceShell
             'searchResults' => $panel->results(...),
             'searchWorkspaceChannels' => $panel->workspaceChannels(...),
         ];
-    }
-
-    /**
-     * The composer's slash-command autocomplete manifest.
-     *
-     * Global and unscoped to a team — the v1 commands are unrestricted — but
-     * built per request so its copy reflects the active locale. Server
-     * authoritative: a newly registered command appears in autocomplete with no
-     * frontend change.
-     *
-     * @return array<int, SlashCommandData>
-     */
-    public function slashCommands(): array
-    {
-        return app(SlashCommandRegistry::class)->manifest();
     }
 
     /**

--- a/resources/js/composables/useLocale.test.ts
+++ b/resources/js/composables/useLocale.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const patch = vi.hoisted(() => vi.fn());
+const reload = vi.hoisted(() => vi.fn());
+const setMessages = vi.hoisted(() => vi.fn());
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { patch, reload },
+    usePage: () => ({ props: { auth: { user: { locale: 'en' } } } }),
+}));
+
+vi.mock('@/lib/i18n', () => ({
+    fetchCatalog: vi.fn().mockResolvedValue({ Channels: 'Canaux' }),
+    i18n: { locale: 'en' },
+    setMessages,
+}));
+
+const { useLocale } = await import('@/composables/useLocale');
+
+describe('useLocale', () => {
+    it('swaps the catalog before persisting, so the UI re-renders at once', async () => {
+        await useLocale().updateLocale('fr');
+
+        expect(setMessages).toHaveBeenCalledWith('fr', { Channels: 'Canaux' });
+        expect(patch).toHaveBeenCalledWith(
+            expect.any(String),
+            { locale: 'fr' },
+            expect.objectContaining({ preserveState: true }),
+        );
+    });
+
+    it('asks back for the props the server renders in the reader own language', async () => {
+        await useLocale().updateLocale('fr');
+
+        // Those props are cached per locale, so a language the reader has
+        // already used this session is one the client believes it holds; only a
+        // partial reload naming them escapes the exclusion (#1251).
+        patch.mock.calls.at(-1)?.[2]?.onSuccess();
+
+        expect(reload).toHaveBeenCalledWith(
+            expect.objectContaining({
+                async: true,
+                preserveUrl: true,
+                only: [
+                    'locale',
+                    'translations',
+                    'slashCommands',
+                    'sidebarPositions',
+                    'invitableRoles',
+                ],
+            }),
+        );
+    });
+});

--- a/resources/js/composables/useLocale.ts
+++ b/resources/js/composables/useLocale.ts
@@ -1,6 +1,8 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import { fetchCatalog, i18n, setMessages } from '@/lib/i18n';
+import { LOCALE_PROPS } from '@/lib/reloadProps';
 import { update } from '@/routes/locale';
 import type { AppLocale } from '@/types';
 
@@ -19,6 +21,16 @@ export function useLocale() {
      * Switch language: swap the catalog first so the UI re-renders immediately
      * without a full reload, then persist the choice. The shared prop refreshes
      * from the redirect, so no optimistic state is needed.
+     *
+     * The redirect alone does not refresh the props the *server* renders in the
+     * reader's language, because those are cached per locale and a language the
+     * reader has already used this session is one the client believes it holds.
+     * {@link LOCALE_PROPS} is what asks for them, and it is a request of its own
+     * rather than an `only` on the write: a partial response is only recognised
+     * as one when it names the component the client is on, which a write that
+     * ends in a redirect cannot promise. It is a background visit because the
+     * reader is not waiting on it — the catalog swap above already re-rendered
+     * everything the *client* translates.
      */
     async function updateLocale(next: AppLocale): Promise<void> {
         const messages = await fetchCatalog(next);
@@ -27,7 +39,12 @@ export function useLocale() {
         router.patch(
             update().url,
             { locale: next },
-            { preserveScroll: true, preserveState: true },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onSuccess: () =>
+                    router.reload({ ...backgroundVisit, only: LOCALE_PROPS }),
+            },
         );
     }
 

--- a/resources/js/composables/usePostRegistrationPrompt.test.ts
+++ b/resources/js/composables/usePostRegistrationPrompt.test.ts
@@ -7,8 +7,22 @@ vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({ props: { postRegistrationPrompt: null } }),
 }));
 
-const { shouldPromptForPasskey } =
+const { shouldPromptForPasskey, usePostRegistrationPrompt } =
     await import('@/composables/usePostRegistrationPrompt');
+
+describe('answering the prompt', () => {
+    it('names the prop it invalidates, since the empty answer is cached', () => {
+        // The prompt is a once prop: without naming it, the reply would be
+        // subject to the exclusion and the client would keep restoring the
+        // prompt it just answered (#1251).
+        usePostRegistrationPrompt().answer();
+
+        expect(visit).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ only: ['postRegistrationPrompt'] }),
+        );
+    });
+});
 
 describe('shouldPromptForPasskey', () => {
     it('prompts when the session queued the passkey prompt', () => {

--- a/resources/js/composables/usePostRegistrationPrompt.ts
+++ b/resources/js/composables/usePostRegistrationPrompt.ts
@@ -1,6 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import { destroy as answerPrompt } from '@/actions/App/Http/Controllers/PostRegistrationPromptController';
+import { POST_REGISTRATION_PROMPT_PROPS } from '@/lib/reloadProps';
 
 /**
  * Whether the passkey enrolment prompt should be presented on this landing.
@@ -35,9 +36,14 @@ export function usePostRegistrationPrompt() {
     /**
      * Record that the prompt has been answered, whichever way. Idempotent server
      * side, so enrolling and then dismissing (or two tabs racing) is harmless.
+     *
+     * Names the prop it invalidates, because a cleared prompt is the *cached*
+     * answer: without it the reply would be subject to the once exclusion and
+     * the client would keep restoring the prompt it just answered.
      */
     function answer(): void {
         router.delete(answerPrompt().url, {
+            only: POST_REGISTRATION_PROMPT_PROPS,
             preserveScroll: true,
             preserveState: true,
         });

--- a/resources/js/lib/reloadProps.test.ts
+++ b/resources/js/lib/reloadProps.test.ts
@@ -4,7 +4,9 @@ import {
     CHANNEL_LIST_PROPS,
     CHANNEL_SECTION_PROPS,
     COLLAPSED_SECTION_PROPS,
+    LOCALE_PROPS,
     PIN_PROPS,
+    POST_REGISTRATION_PROMPT_PROPS,
     SCHEDULED_MESSAGE_PROPS,
     THREAD_PROPS,
     THREAD_RESET_PROPS,
@@ -69,6 +71,25 @@ describe('reloadProps', () => {
         expect(THREAD_RESET_PROPS).toEqual(['threadReplies']);
     });
 
+    it('names everything the server renders in the reader own language', () => {
+        // A locale the reader has already used this session is one the client
+        // believes it holds, so moving back to it restores the copy of the
+        // language they just left unless these are asked for by name (#1251).
+        expect(LOCALE_PROPS).toEqual([
+            'locale',
+            'translations',
+            'slashCommands',
+            'sidebarPositions',
+            'invitableRoles',
+        ]);
+    });
+
+    it('names the one-time security prompt, which is cached while empty', () => {
+        expect(POST_REGISTRATION_PROMPT_PROPS).toEqual([
+            'postRegistrationPrompt',
+        ]);
+    });
+
     it.each([
         ['AUTH_PROPS', arrayLiteralOf(/'auth'/)],
         ['CHANNEL_LIST_PROPS', arrayLiteralOf(/'channels'/)],
@@ -77,7 +98,17 @@ describe('reloadProps', () => {
             'COLLAPSED_SECTION_PROPS',
             arrayLiteralOf(/'collapsedChannelSections'/),
         ],
+        [
+            'LOCALE_PROPS',
+            arrayLiteralOf(
+                /'locale',\s*'translations',\s*'slashCommands',\s*'sidebarPositions',\s*'invitableRoles',?/,
+            ),
+        ],
         ['PIN_PROPS', arrayLiteralOf(/'pins',\s*'pinCount'/)],
+        [
+            'POST_REGISTRATION_PROMPT_PROPS',
+            arrayLiteralOf(/'postRegistrationPrompt',?/),
+        ],
         ['SCHEDULED_MESSAGE_PROPS', arrayLiteralOf(/'scheduledMessages'/)],
         ['THREAD_PROPS', arrayLiteralOf(/'thread',\s*'threadReplies'/)],
         ['THREAD_RESET_PROPS', arrayLiteralOf(/'threadReplies'/)],

--- a/resources/js/lib/reloadProps.ts
+++ b/resources/js/lib/reloadProps.ts
@@ -9,11 +9,11 @@
  * `pinCount` are two readings of one fact, and so are `thread` and
  * `threadReplies`.
  *
- * Eight invalidation sets live here; the ninth, {@see REMINDER_PROPS}, is next
+ * Ten invalidation sets live here; the eleventh, {@see REMINDER_PROPS}, is next
  * door in {@see reminderReload} with the visit options a reminder mutation
- * carries. All nine are enforced the same way, by a test that fails on a second
- * copy. {@link THREAD_RESET_PROPS} is not one of them — it names what a thread
- * load *resets* rather than what a write invalidates.
+ * carries. All eleven are enforced the same way, by a test that fails on a
+ * second copy. {@link THREAD_RESET_PROPS} is not one of them — it names what a
+ * thread load *resets* rather than what a write invalidates.
  *
  * Every set is typed as a mutable `string[]` because that is what Inertia's
  * `only` takes; a `readonly` tuple would force an `as string[]` cast back at
@@ -97,3 +97,38 @@ export const THREAD_RESET_PROPS: string[] = ['threadReplies'];
 
 /** The channel's pending scheduled messages, as the later-delivery tray lists them. */
 export const SCHEDULED_MESSAGE_PROPS: string[] = ['scheduledMessages'];
+
+/**
+ * Everything the server renders in the reader's own language.
+ *
+ * These are `once` props keyed by the locale they hold (#1251), which answers
+ * moving *to* a new language: the key is one the client has never declared, so
+ * the props ship. It does not answer moving *back*. The client stores a once
+ * prop by key but restores it by prop name, so `en → fr → en` finds `locale:en`
+ * already declared, excludes the props, and restores the French copy it happens
+ * to be holding — labels frozen in the language the reader just left.
+ *
+ * A partial reload is what closes that, because the once exclusion is bypassed
+ * on partial requests. Hence the one write that changes the reader's language
+ * asks for these by name; the visit that persists the preference cannot do it
+ * on its own, since it is an ordinary visit and subject to the exclusion.
+ */
+export const LOCALE_PROPS: string[] = [
+    'locale',
+    'translations',
+    'slashCommands',
+    'sidebarPositions',
+    'invitableRoles',
+];
+
+/**
+ * The one-time security prompt owed to an account created in this session.
+ *
+ * Cached while there is nothing to offer — which is every visit but a handful —
+ * so answering it has to say so by name. Without this the dismissal would leave
+ * the client restoring the prompt it just answered, and the modal would come
+ * back on the next navigation.
+ */
+export const POST_REGISTRATION_PROMPT_PROPS: string[] = [
+    'postRegistrationPrompt',
+];

--- a/tests/Feature/Auth/PostRegistrationPromptTest.php
+++ b/tests/Feature/Auth/PostRegistrationPromptTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Enums\PostRegistrationPrompt;
-use App\Models\Channel;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
@@ -19,18 +18,6 @@ function registerAccount(): User
     ])->assertSessionHasNoErrors();
 
     return User::where('email', 'test@example.com')->sole();
-}
-
-/**
- * The workspace page the registering user lands on — the team's `#general`
- * channel, which is where `channels.index` forwards them.
- */
-function workspaceUrl(User $user): string
-{
-    return route('channels.show', [
-        'team' => $user->currentTeam->slug,
-        'channel' => Channel::GENERAL_SLUG,
-    ]);
 }
 
 test('registering queues the passkey prompt and confirms the password for the session', function (): void {
@@ -53,7 +40,7 @@ test('the shared prop offers the prompt while passkeys are available', function 
 
     $user = registerAccount();
 
-    $this->get(workspaceUrl($user))
+    $this->get(workspaceUrl($user->currentTeam))
         ->assertInertia(fn (Assert $page): Assert => $page
             ->where('postRegistrationPrompt', PostRegistrationPrompt::Passkey->value));
 });
@@ -66,7 +53,7 @@ test('the shared props name the device the request came from', function (): void
     // The prompt prefills its name field with this, so the passkey the user keeps
     // is named after the device they enrolled it on.
     $this->withHeader('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/140.0.0.0')
-        ->get(workspaceUrl($user))
+        ->get(workspaceUrl($user->currentTeam))
         ->assertInertia(fn (Assert $page): Assert => $page
             ->where('currentDevice.browser', 'Chrome')
             ->where('currentDevice.platform', 'macOS'));
@@ -79,7 +66,7 @@ test('the shared prop withholds the prompt when passkeys are switched off', func
 
     config(['fortify.passkeys_enabled' => false]);
 
-    $this->get(workspaceUrl($user))
+    $this->get(workspaceUrl($user->currentTeam))
         ->assertInertia(fn (Assert $page): Assert => $page
             ->where('postRegistrationPrompt', null));
 });
@@ -91,7 +78,7 @@ test('the shared prop withholds the prompt under enforced single sign-on', funct
 
     config(['sso.enforced' => true]);
 
-    $this->get(workspaceUrl($user))
+    $this->get(workspaceUrl($user->currentTeam))
         ->assertInertia(fn (Assert $page): Assert => $page
             ->where('postRegistrationPrompt', null));
 });
@@ -106,7 +93,7 @@ test('the shared prop ignores a session value that is not a known prompt', funct
     foreach (['no-such-prompt', ['passkey'], 42] as $queued) {
         $this->actingAs($user)
             ->withSession([PostRegistrationPrompt::SESSION_KEY => $queued])
-            ->get(workspaceUrl($user))
+            ->get(workspaceUrl($user->currentTeam))
             ->assertInertia(fn (Assert $page): Assert => $page
                 ->where('postRegistrationPrompt', null));
     }
@@ -120,7 +107,7 @@ test('a user who simply signs in is never prompted', function (): void {
     $this->post(route('login.store'), ['email' => $user->email, 'password' => 'password'])
         ->assertSessionHasNoErrors();
 
-    $this->get(workspaceUrl($user))
+    $this->get(workspaceUrl($user->currentTeam))
         ->assertInertia(fn (Assert $page): Assert => $page
             ->where('postRegistrationPrompt', null));
 });

--- a/tests/Feature/Channels/SharedOncePropsTest.php
+++ b/tests/Feature/Channels/SharedOncePropsTest.php
@@ -1,0 +1,252 @@
+<?php
+
+use App\Enums\AppLocale;
+use App\Enums\PostRegistrationPrompt;
+use App\Models\User;
+use App\Support\Branding\BrandingAssets;
+use Illuminate\Support\Facades\Date;
+
+/*
+|--------------------------------------------------------------------------
+| The once'd shell props (#1251)
+|--------------------------------------------------------------------------
+|
+| Roughly twenty shared props are instance constants and session facts that
+| cannot change between two clicks. They are declared in `shareOnce()` and
+| excluded from the second visit onwards, so this file's subject is the
+| difference between a first load and a second click — which is an HTTP fact,
+| and only reachable through a real Inertia visit (the exclusion happens in
+| the response pipeline, so a direct call to `share()` would not exercise it).
+|
+| `revisit()` in `tests/Helpers.php` is what makes the second click: it reads
+| the once keys off the previous response and declares them back, exactly as
+| the client does.
+|
+*/
+
+/**
+ * Every prop this issue moves out of the ordinary navigation.
+ *
+ * @var list<string>
+ */
+const ONCE_PROPS = [
+    // Instance config, behind one fingerprint.
+    'name',
+    'branding',
+    'reverb',
+    'webPush',
+    'registrationEnabled',
+    'emailVerificationEnabled',
+    'demoMode',
+    'sso',
+    'attachments',
+    'gifPickerEnabled',
+    'pollsEnabled',
+    'integrationsEnabled',
+    'channelRestoreWindowDays',
+    'presence',
+    // TTL'd.
+    'demoResetsAt',
+    'update',
+    // Session-, locale- or version-keyed.
+    'locale',
+    'translations',
+    'currentDevice',
+    'slashCommands',
+    'sidebarPositions',
+    'invitableRoles',
+    'postRegistrationPrompt',
+];
+
+test('a first load carries every once prop', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $page = visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page');
+
+    expect(array_keys($page['props']))->toContain(...ONCE_PROPS);
+});
+
+test('a second visit carries none of them', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $second = revisit($first, workspaceUrl($team))->assertOk();
+
+    expect(array_intersect(ONCE_PROPS, array_keys((array) $second->json('props'))))->toBe([]);
+});
+
+test('a second visit still carries what an ordinary navigation owes', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $props = (array) revisit($first, workspaceUrl($team))->assertOk()->json('props');
+
+    expect(array_keys($props))->toContain('errors', 'unread', 'auth', 'sidebarOpen')
+        ->and($props['sidebarOpen'])->toBeTrue();
+});
+
+test('a partial reload naming one of them still receives it', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The sixteen `only: [...]` call sites already in the app keep working for
+    // exactly this reason: the once exclusion is gated on the request not being
+    // a partial one, so naming a prop is enough to have it resolved again.
+    $reloaded = revisit($first, workspaceUrl($team), [
+        'X-Inertia-Partial-Component' => (string) $first->viewData('page')['component'],
+        'X-Inertia-Partial-Data' => 'branding,slashCommands',
+    ])->assertOk();
+
+    expect(array_keys((array) $reloaded->json('props')))
+        ->toContain('branding', 'slashCommands')
+        ->not->toContain('presence');
+});
+
+test('changing a config value reships the whole instance group on the next visit', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // Whichever value moves, the fingerprint moves with it, so the group comes
+    // back together rather than one prop at a time.
+    config(['polls.enabled' => ! config('polls.enabled')]);
+
+    expect(array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props')))
+        ->toContain('pollsEnabled', 'name', 'branding', 'presence');
+});
+
+test('leaving the config alone keeps the instance group off the next visit', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    expect(array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props')))
+        ->not->toContain('pollsEnabled', 'name', 'branding', 'presence');
+});
+
+test('a second visit no longer stats the branding directory', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $branding = Mockery::spy(BrandingAssets::class);
+    $this->instance(BrandingAssets::class, $branding);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+    revisit($first, workspaceUrl($team))->assertOk();
+
+    // Stands in for the whole group: a once prop is excluded *before* it is
+    // resolved, so the work behind it — this stat, and the user-agent regexes
+    // behind `currentDevice` — happens on the first load and never again.
+    $branding->shouldHaveReceived('logoPath')->once();
+});
+
+test('the demo reset instant holds until the top of the next hour', function (): void {
+    config(['demo.mode' => true]);
+    $this->travelTo(Date::parse('2026-08-04 14:20:00'));
+
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $page = visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page');
+
+    expect($page['props']['demoResetsAt'])->toBe(Date::parse('2026-08-04 15:00:00')->toIso8601String())
+        ->and($page['onceProps']['demoResetsAt']['expiresAt'])
+        ->toBe(Date::parse('2026-08-04 15:00:00')->getTimestamp() * 1000);
+});
+
+test('off the demo there is no reset instant and nothing to expire', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $page = visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page');
+
+    expect($page['props']['demoResetsAt'])->toBeNull()
+        ->and($page['onceProps']['demoResetsAt']['expiresAt'])->toBeNull();
+});
+
+test('the version standing holds for as long as the check that feeds it', function (): void {
+    config(['updates.cache_ttl_hours' => 6]);
+    $this->travelTo(Date::parse('2026-08-04 14:20:00'));
+
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    expect(visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page')['onceProps']['update:viewer']['expiresAt'])
+        ->toBe(Date::parse('2026-08-04 20:20:00')->getTimestamp() * 1000);
+});
+
+test('signing in without a document load still ships the version standing', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    // A guest is handed null, and it is that null the client caches. Were the two
+    // answers shared one key, the sign-in that follows in the same tab would be
+    // told it already holds the prop and the indicator would never appear.
+    $guest = $this->get(route('login'))->assertOk();
+
+    expect($guest->viewData('page')['props']['update'])->toBeNull();
+
+    $this->actingAs($viewer);
+
+    expect((array) revisit($guest, workspaceUrl($team))->assertOk()->json('props.update'))
+        ->toHaveKey('current');
+});
+
+test('a queued prompt is forced through even into a tab that has cached the empty answer', function (): void {
+    config(['fortify.passkeys_enabled' => true]);
+
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    // Nothing queued: the answer is null, and the client caches it.
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props'))
+        ->not->toHaveKey('postRegistrationPrompt');
+
+    $this->withSession([PostRegistrationPrompt::SESSION_KEY => PostRegistrationPrompt::Passkey->value]);
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.postRegistrationPrompt'))
+        ->toBe(PostRegistrationPrompt::Passkey->value);
+});
+
+test('reading in a new language ships the props whose copy is translated', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The same failure `translations` guards against (#764), for the props that
+    // carry server-translated copy: a locale that changes without a document
+    // load must not leave the client rendering the previous language's labels.
+    $viewer->update(['locale' => AppLocale::French->value]);
+
+    expect(array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props')))
+        ->toContain('locale', 'translations', 'sidebarPositions', 'invitableRoles', 'slashCommands')
+        ->not->toContain('name', 'branding');
+});
+
+test('arriving on another device ships that device its own name', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = $this->actingAs($viewer)
+        ->withHeader('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/140.0.0.0')
+        ->get(workspaceUrl($team))
+        ->assertOk();
+
+    expect($first->viewData('page')['props']['currentDevice'])
+        ->toBe(['browser' => 'Chrome', 'platform' => 'macOS']);
+
+    $onPhone = revisit($first, workspaceUrl($team), [
+        'User-Agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) FxiOS/120.0',
+    ])->assertOk();
+
+    expect($onPhone->json('props.currentDevice'))
+        ->toBe(['browser' => 'Firefox', 'platform' => 'iOS']);
+});
+
+test('off a workspace route the same props are carried once and then not at all', function (): void {
+    $viewer = User::factory()->create();
+
+    $first = $this->actingAs($viewer)->get(route('profile.edit'))->assertOk();
+
+    expect(array_keys($first->viewData('page')['props']))->toContain(...ONCE_PROPS)
+        ->and(array_intersect(ONCE_PROPS, array_keys((array) revisit($first, route('profile.edit'))->assertOk()->json('props'))))
+        ->toBe([]);
+});

--- a/tests/Feature/Channels/SharedOncePropsTest.php
+++ b/tests/Feature/Channels/SharedOncePropsTest.php
@@ -148,20 +148,21 @@ test('the demo reset instant holds until the top of the next hour', function ():
 
     ['owner' => $viewer, 'team' => $team] = teamWithChannel();
 
-    $page = visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page');
+    $visit = visitWorkspaceAs($viewer, $team)->assertOk();
 
-    expect($page['props']['demoResetsAt'])->toBe(Date::parse('2026-08-04 15:00:00')->toIso8601String())
-        ->and($page['onceProps']['demoResetsAt']['expiresAt'])
+    expect($visit->viewData('page')['props']['demoResetsAt'])
+        ->toBe(Date::parse('2026-08-04 15:00:00')->toIso8601String())
+        ->and(onceExpiry($visit, 'demoResetsAt'))
         ->toBe(Date::parse('2026-08-04 15:00:00')->getTimestamp() * 1000);
 });
 
 test('off the demo there is no reset instant and nothing to expire', function (): void {
     ['owner' => $viewer, 'team' => $team] = teamWithChannel();
 
-    $page = visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page');
+    $visit = visitWorkspaceAs($viewer, $team)->assertOk();
 
-    expect($page['props']['demoResetsAt'])->toBeNull()
-        ->and($page['onceProps']['demoResetsAt']['expiresAt'])->toBeNull();
+    expect($visit->viewData('page')['props']['demoResetsAt'])->toBeNull()
+        ->and(onceExpiry($visit, 'demoResetsAt'))->toBeNull();
 });
 
 test('the version standing holds for as long as the check that feeds it', function (): void {
@@ -170,8 +171,21 @@ test('the version standing holds for as long as the check that feeds it', functi
 
     ['owner' => $viewer, 'team' => $team] = teamWithChannel();
 
-    expect(visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page')['onceProps']['update:viewer']['expiresAt'])
+    expect(onceExpiry(visitWorkspaceAs($viewer, $team)->assertOk(), 'update'))
         ->toBe(Date::parse('2026-08-04 20:20:00')->getTimestamp() * 1000);
+});
+
+test('a nonsensical check interval still leaves the version standing an interval', function (): void {
+    config(['updates.cache_ttl_hours' => 0]);
+    $this->travelTo(Date::parse('2026-08-04 14:20:00'));
+
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    // An expiry in the present is one the client treats as already past, which
+    // would put the prop back on every navigation — the one thing this file is
+    // about. The floor is the same one `presence.away_after_minutes` carries.
+    expect(onceExpiry(visitWorkspaceAs($viewer, $team)->assertOk(), 'update'))
+        ->toBe(Date::parse('2026-08-04 15:20:00')->getTimestamp() * 1000);
 });
 
 test('signing in without a document load still ships the version standing', function (): void {

--- a/tests/Feature/Channels/SharedOncePropsTest.php
+++ b/tests/Feature/Channels/SharedOncePropsTest.php
@@ -111,11 +111,13 @@ test('changing a config value reships the whole instance group on the next visit
     $first = visitWorkspaceAs($viewer, $team)->assertOk();
 
     // Whichever value moves, the fingerprint moves with it, so the group comes
-    // back together rather than one prop at a time.
+    // back together rather than one prop at a time. `slashCommands` rides along
+    // for a reason of its own: `/poll` is registered only where polls are on, so
+    // switching them off has to take the command out of autocomplete with it.
     config(['polls.enabled' => ! config('polls.enabled')]);
 
     expect(array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props')))
-        ->toContain('pollsEnabled', 'name', 'branding', 'presence');
+        ->toContain('pollsEnabled', 'name', 'branding', 'presence', 'slashCommands', 'update');
 });
 
 test('leaving the config alone keeps the instance group off the next visit', function (): void {
@@ -124,7 +126,7 @@ test('leaving the config alone keeps the instance group off the next visit', fun
     $first = visitWorkspaceAs($viewer, $team)->assertOk();
 
     expect(array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props')))
-        ->not->toContain('pollsEnabled', 'name', 'branding', 'presence');
+        ->not->toContain('pollsEnabled', 'name', 'branding', 'presence', 'slashCommands', 'update');
 });
 
 test('a second visit no longer stats the branding directory', function (): void {

--- a/tests/Feature/Channels/SlashCommandManifestTest.php
+++ b/tests/Feature/Channels/SlashCommandManifestTest.php
@@ -15,12 +15,15 @@ use Inertia\Testing\AssertableInertia as Assert;
 | page to read them back was proving the registry through the widest interface
 | in the application.
 |
-| These two are not about the contents. The first is that `share()` hands the
-| client every registered command with its copy resolved under the *request's*
-| locale rather than the process's — middleware behaviour the registry cannot
-| state, since it is handed an already-active translator. The second is the
-| `$shell?->slashCommands() ?? []` fallback off the workspace, which is the
-| Inertia contract for a page with no channel.
+| These two are not about the contents. The first is that the middleware hands
+| the client every registered command with its copy resolved under the
+| *request's* locale rather than the process's — behaviour the registry cannot
+| state, since it is handed an already-active translator. The second is that
+| the manifest rides every page rather than only the workspace ones: it became
+| a once prop in #1251, and a once prop holds one value per prop name for the
+| life of the page, so a settings visit answering `[]` would be the value a
+| later workspace visit restored. It is a global registry with one honest
+| answer, and the client pays for it once.
 |
 */
 
@@ -38,10 +41,12 @@ test('a channel page ships every registered command, translated under the reques
         );
 });
 
-test('the manifest is omitted off the workspace', function (): void {
+test('the manifest rides a page outside the workspace too', function (): void {
     ['owner' => $owner] = teamWithChannel();
 
     $this->actingAs($owner)
         ->get(route('profile.edit'))
-        ->assertInertia(fn (Assert $page): Assert => $page->where('slashCommands', []));
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('slashCommands', count(app(SlashCommandRegistry::class)->manifest()))
+        );
 });

--- a/tests/Feature/Channels/WorkspacePermissionPropsTest.php
+++ b/tests/Feature/Channels/WorkspacePermissionPropsTest.php
@@ -3,11 +3,8 @@
 use App\Enums\ChannelCreationPolicy;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
-use App\Models\Channel;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Testing\TestResponse;
 use Inertia\Testing\AssertableInertia as Assert;
 
 /*
@@ -27,17 +24,6 @@ use Inertia\Testing\AssertableInertia as Assert;
 | the derivation itself, without a round-trip.
 |
 */
-
-/**
- * A workspace visit to the team's `#general` as the given viewer.
- */
-function visitWorkspaceAs(User $viewer, Team $team): TestResponse
-{
-    return test()->actingAs($viewer)->get(route('channels.show', [
-        'team' => $team->slug,
-        'channel' => Channel::GENERAL_SLUG,
-    ]));
-}
 
 test('a workspace visit reports the six permission props for the viewer role', function (
     string $role,

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -6,6 +6,7 @@ use App\Actions\Teams\CreateTeam;
 use App\Data\ChannelData;
 use App\Data\UnreadCountsData;
 use App\Enums\TeamRole;
+use App\Http\Middleware\HandleInertiaRequests;
 use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\Team;
@@ -16,6 +17,7 @@ use Database\Factories\ChannelMemberFactory;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Testing\TestResponse;
 
 /*
 |--------------------------------------------------------------------------
@@ -196,6 +198,71 @@ function channelMembership(Channel $channel, User $user, ?Closure $state = null)
     $membership->forceFill($stated->make()->getAttributes())->save();
 
     return $membership;
+}
+
+/*
+|--------------------------------------------------------------------------
+| The second visit (#1251)
+|--------------------------------------------------------------------------
+|
+| Most of the shell contract is a statement about the *second* click, and a
+| test can only make it by arriving the way the SPA does: as an Inertia
+| request that declares back every once prop the previous response handed
+| over. Hence {@see revisit()}, which reads those keys off the first response
+| rather than spelling them out — the keys are a private arrangement between
+| the middleware and the client, and a test that hardcoded them would be
+| asserting the key format instead of the behaviour it carries.
+|
+*/
+
+/**
+ * The URL of a team's #general — the workspace visit the shell tests drive.
+ */
+function workspaceUrl(Team $team): string
+{
+    return route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]);
+}
+
+/**
+ * A workspace visit to the team's #general as the given viewer.
+ */
+function visitWorkspaceAs(User $viewer, Team $team): TestResponse
+{
+    return test()->actingAs($viewer)->get(workspaceUrl($team));
+}
+
+/**
+ * The once-prop keys a response handed the client, whether it rendered a
+ * document or answered an Inertia visit.
+ *
+ * @return array<int, string>
+ */
+function oncePropKeys(TestResponse $response): array
+{
+    $page = $response->headers->get('X-Inertia') === 'true'
+        ? (array) $response->json()
+        : (array) $response->viewData('page');
+
+    /** @var array<string, mixed> $onceProps */
+    $onceProps = $page['onceProps'] ?? [];
+
+    return array_keys($onceProps);
+}
+
+/**
+ * The next visit in the same session, made the way the client makes it: over
+ * Inertia, declaring back the once props `$previous` delivered.
+ *
+ * @param  array<string, string>  $headers  extra headers, e.g. a partial reload's
+ */
+function revisit(TestResponse $previous, string $url, array $headers = []): TestResponse
+{
+    return test()->withHeaders([
+        'X-Inertia' => 'true',
+        'X-Inertia-Version' => (string) app(HandleInertiaRequests::class)->version(request()),
+        'X-Inertia-Except-Once-Props' => implode(',', oncePropKeys($previous)),
+        ...$headers,
+    ])->get($url);
 }
 
 /*

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -250,6 +250,28 @@ function oncePropKeys(TestResponse $response): array
 }
 
 /**
+ * When the client is told a once prop expires, as a millisecond timestamp —
+ * null when it is told to hold it indefinitely.
+ *
+ * Looked up by prop name rather than by key, because the key is the middleware's
+ * business and a test that spelled one out would break on every change to how
+ * they are composed.
+ */
+function onceExpiry(TestResponse $response, string $prop): ?int
+{
+    $page = (array) $response->viewData('page');
+
+    /** @var array<string, array{prop: string, expiresAt: int|null}> $onceProps */
+    $onceProps = $page['onceProps'] ?? [];
+
+    $entry = collect($onceProps)->firstWhere('prop', $prop);
+
+    expect($entry)->not->toBeNull("no once metadata for [{$prop}]");
+
+    return $entry['expiresAt'];
+}
+
+/**
  * The next visit in the same session, made the way the client makes it: over
  * Inertia, declaring back the once props `$previous` delivered.
  *

--- a/tests/Integration/Support/WorkspaceShellTest.php
+++ b/tests/Integration/Support/WorkspaceShellTest.php
@@ -85,8 +85,7 @@ test('the shell is constructible from a viewer and a team alone', function (): v
         ->and($shell->customEmojis())->toBe([])
         ->and($shell->userGroups())->toBe([])
         ->and($shell->reminders(MessageReminderStatus::Pending))->toBe([])
-        ->and($shell->unreadDigest()->threads)->toBeFalse()
-        ->and($shell->slashCommands())->not->toBeEmpty();
+        ->and($shell->unreadDigest()->threads)->toBeFalse();
 });
 
 test('the team roster is ordered by name and lists the viewer among the others', function (): void {


### PR DESCRIPTION
Closes #1251. Third of the shell-contract children on [perf: navigation feels instant](https://github.com/deskhq/the-desk/issues/1248), after #1249 and #1250. Introduces the `shareOnce()` home the next two extend.

## What changed

**Twenty-three props leave the ordinary navigation**, declared in a `shareOnce()` home next to `share()` rather than wrapped inline. Inertia excludes a once prop *before* resolving it, so each one costs zero bytes and zero closure time on a second click.

1. **Instance config behind one `App\Support\InstanceFingerprint`** — `name`, `branding`, `reverb`, `webPush`, `registrationEnabled`, `emailVerificationEnabled`, `demoMode`, `sso`, `attachments`, `gifPickerEnabled`, `pollsEnabled`, `integrationsEnabled`, `channelRestoreWindowDays`, `presence`. One digest over config values already in memory; `app.version` stands in for the code constants (the restore window, the two enums). `branding.logo` is deliberately **not** in it, which is the point: keeping it means keeping the `is_file()` stat this removes.
2. **TTL'd** — `demoResetsAt` holds until the top of the next hour, `update` for the check interval that feeds it.
3. **Session-, locale- or version-keyed** — `locale`, `currentDevice` (on a hash of the raw `User-Agent`, so the regexes never re-run), `slashCommands`, `sidebarPositions`, `invitableRoles`, `postRegistrationPrompt`. `translations` was already `once`'d and only moves house.

## Three things the issue's shape did not survive, and why

**"One key across the whole group" is not implementable on `@inertiajs/core@3.6.1`.** The client stores once props as `key → { prop, expiresAt }` and restores them **by prop path** (`CurrentPage.mergeOncePropsIntoResponse`); server side `PropsResolver::collectOnceMetadata` writes `$onceProps[$key] = ['prop' => $path]`, last-write-wins. Sixteen props sharing `instance:<hash>` would collapse to one entry, and on a full visit — where the client replaces `page.props` wholesale — the other fifteen would come back **absent** rather than cached. So: one shared fingerprint, one key per prop (`instance:<hash>:<prop>`). The alternative, collapsing the group into a nested `instance` prop, buys ~570 B of request header for ~72 frontend call sites, which is not this child's blast radius.

**`slashCommands` stops being shell-gated.** Same client property: a once prop has one value per prop *name* for the life of the page, so a settings visit answering `[]` is the value a later workspace visit restores. The registry is global and unscoped to a team, so it is shared everywhere and paid for once. It costs the auth pages 333 B on a cold load and saves it on every click after.

**Two keyed props needed an explicit invalidation**, because a key that returns to a value the client already holds restores the *other* one:

- **Locale.** `en → fr → en` finds `locale:en` already declared and restores the French copy. `LOCALE_PROPS` in `reloadProps.ts`, fired as a background partial reload from `useLocale.updateLocale` — the once exclusion is bypassed on partial requests, which is what makes that registry the mechanism rather than something new. It is its own request rather than an `only` on the write, because a partial response is only recognised as one when it names the component the client is on, and a write that ends in a redirect cannot promise that.
- **The post-registration prompt.** Cached while empty, forced fresh while queued, and its dismissal now names `POST_REGISTRATION_PROMPT_PROPS` — without it the client keeps restoring the prompt it just answered.

## Numbers

Shared-prop bytes on a channel visit (one-channel, one-member workspace — every prop here is workspace-size-independent, which is the point):

| | before | after |
|---|---:|---:|
| props on a second visit | 4,979 B | **4,067 B** |
| props once'd away | — | 912 B over 23 props |
| `X-Inertia-Except-Once-Props` | — | 624 B over 23 keys |

The header is the honest cost, and it is the one that compresses: an identical value repeated across requests is a single HPACK dynamic-table reference over HTTP/2, while the 912 B is saved on every click. The digests are truncated to 32 bits for the same reason — a collision costs one config change reaching clients on their next hard load, not correctness.

Not measured in time, per the epic's budget: the expected delta is under the ~50 ms noise floor. What is gone from the ordinary path and is not a byte: up to two `is_file()` stats, the user-agent regex pass, the command-manifest build, and the catalog lookup.

## Testing

- New `tests/Feature/Channels/SharedOncePropsTest.php` at the seam the issue names — real Inertia visits, with `revisit()` in `tests/Helpers.php` making the second click the way the client does (reading the once keys off the previous response rather than spelling them out). Sixteen cases: a first load carries all twenty-three and a second carries none; the per-visit residue is intact; a partial reload naming one still receives it; a config change reships the whole group and leaving it alone does not; the branding stat runs once across two visits; the demo TTL lands on the hour and a nonsensical check interval is still floored; a sign-in without a document load still gets the version standing; a queued prompt is forced into a tab that cached the empty answer; a new locale ships the translated props; another device gets its own name; and off a workspace route the same holds.
- `reloadProps.test.ts`, a new `useLocale.test.ts`, and `usePostRegistrationPrompt.test.ts` cover the two client invalidations and keep the no-second-copy guard honest.
- `SlashCommandManifestTest` and `WorkspaceShellTest` follow the manifest to its new home; `visitWorkspaceAs`/`workspaceUrl` are consolidated into `tests/Helpers.php` from the two test files that each had a copy.
- Gates green: `composer test` at **Total: 100.0 %** (3,543 tests), plus lint / format / types / 2,726 Vitest / build. The full browser suite (355 tests) passes too, which is what proves a real client restores twenty-three excluded props across real SPA navigations.

No user-facing copy changed, so no new translation keys. Nothing operator-facing, so no `docs/` change.

## CodeRabbit

Five findings over three passes, four applied: floor the update-check interval like `presence.away_after_minutes` already is; key `demoResetsAt` on the instance in both branches so the demo switching on is not answered under a key the client holds the other answer for; and — the one that mattered — key `slashCommands` and `update` on the instance too. `/poll` and `/gif` are registered only where their feature is configured, so without it an operator switching polls off would have left the command in autocomplete until a hard reload.

Declined: clamping the `demoResetsAt` TTL to a 30 s floor near the hour boundary. It guards a once prop's TTL capping the prefetch cache, which is real and documented where the TTL is declared, but prefetch is a later child of this epic and the exposure is one second per hour on the demo. The cost — a countdown that lags the wipe by up to a minute — is worse than the second it saves.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788482109&installation_model_id=428379&pr_number=1268&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1268&signature=e1231a488fb26c2993167c78cf34cfdd1823d90c23c6a2987d0a586dec91f864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->