### PR TITLE
perf: once the shared props the viewer's own writes invalidate

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -71,8 +71,14 @@ class HandleInertiaRequests extends Middleware
      *
      * What is *not* here is the instance's own description — its name, branding,
      * connection details and feature toggles — along with the session facts that
-     * settle at sign-in. Those cannot change between two clicks, so they are
+     * settle at sign-in, and the rosters that move only when the viewer writes.
+     * None of those can change between two clicks on their own, so they are
      * declared next door in {@see self::shareOnce()} and reach the client once.
+     *
+     * What is left is the residue that genuinely moves under the viewer while
+     * they read: `unread`, and the member roster whose presence dots follow
+     * other people. Those are recomputed on every navigation, and are the reason
+     * this list is not simply {@see self::shareOnce()}.
      *
      * @see https://inertiajs.com/shared-data
      *
@@ -85,14 +91,9 @@ class HandleInertiaRequests extends Middleware
         $shell = WorkspaceShell::forRequest($request);
         $permissions = WorkspacePermissions::forRequest($request);
         $pinned = NavDestination::fromQuery($request->query(NavDestination::QUERY_PARAM));
-        $boundChannel = $request->route('channel');
-        $activeChannel = $boundChannel instanceof Channel ? $boundChannel : null;
 
         return [
             ...parent::share($request),
-            'auth' => [
-                'user' => $user,
-            ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
             'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],
@@ -122,7 +123,6 @@ class HandleInertiaRequests extends Middleware
             // the permission and the master toggle ride along with every request
             // to gate the nav entry and the Team-settings card.
             'canManageCurrentTeamIntegrations' => fn (): bool => $permissions->forCurrentTeam()->canManageIntegrations ?? false,
-            'channels' => fn (): array => $shell?->channels($activeChannel) ?? [],
             // What the viewer has not read: the sidebar's per-channel badges,
             // every workspace's dot, and the Threads dot, in one prop. The
             // rosters above carry none of it, so they can be cached while this
@@ -134,35 +134,21 @@ class HandleInertiaRequests extends Middleware
             // The current team's members feed the DM entry points (the sidebar
             // people picker and the ⌘K "People" group); empty off the workspace.
             'teamMembers' => fn (): array => $shell?->teamMembers() ?? [],
-            'channelSections' => fn (): array => $shell?->channelSections() ?? [],
             // The current team's custom emoji as a flat name->url map, so message
             // bodies and reaction pills can resolve `:name:` shortcodes to images.
             // A revoked emoji is simply absent, so its token falls back to text.
             'customEmojis' => fn (): array => $shell?->customEmojis() ?? [],
-            // The viewer's five most-used emoji in their current workspace,
-            // feeding the hover bar's quick-react cluster and the picker's
-            // "Frequently used" strip. Derived from reaction history per visit
-            // (frequently-used is slow-moving, so it is eventually consistent —
-            // a live reaction doesn't re-rank until the next Inertia visit).
-            'frequentEmojis' => fn (): array => FrequentEmoji::forUser($user),
             // The current team's mentionable user groups, feeding the composer's
             // `@` menu and the anti-spoof check that decides whether a
             // `group:<id>` token renders as a pill or as plain text. A deleted
             // group is simply absent, so its token falls back to text.
             'userGroups' => fn (): array => $shell?->userGroups() ?? [],
-            'collapsedChannelSections' => fn () => $user->collapsed_channel_sections ?? [],
             // The Threads panel's inbox and its "Unread" tally, present only while
             // the dock actually has that destination pinned.
             ...$shell?->threadsPanelProps($pinned, ThreadInboxFilter::fromQuery($request->query('filter'))) ?? [],
             // The Search panel's echoed criteria and matches, on the same terms.
             ...$shell?->searchPanelProps($pinned, MessageSearchPanel::criteriaFromRequest($request)) ?? [],
             'pendingInvitations' => Inertia::optional(fn (): array => $user ? PendingInvitations::forUser($user) : []),
-            // The viewer's still-pending reminders in this team, soonest first,
-            // feeding the "Reminders" list and its sidebar count.
-            'reminders' => fn (): array => $shell?->reminders(MessageReminderStatus::Pending) ?? [],
-            // Reminders that have come due and await acknowledgement, driving the
-            // in-app nudges; reloaded live when a MessageReminderDue signal lands.
-            'firedReminders' => fn (): array => $shell?->reminders(MessageReminderStatus::Fired) ?? [],
         ];
     }
 
@@ -179,7 +165,7 @@ class HandleInertiaRequests extends Middleware
      * on an ordinary navigation; that is why the two that read the filesystem
      * and parse a user agent are closures rather than eager values.
      *
-     * Three groups, distinguished only by what their key is made of:
+     * Five groups, distinguished only by what their key is made of:
      *
      * 1. **Instance config**, behind one shared {@see InstanceFingerprint}. The
      *    key is the same digest for all of them because they change together.
@@ -188,6 +174,18 @@ class HandleInertiaRequests extends Middleware
      * 3. **Session-, locale- or version-keyed** — what the viewer's own session
      *    settles: the language they read in, the device they arrived on, the
      *    prompt their registration queued.
+     * 4. **Viewer-keyed** — `auth`, `collapsedChannelSections` and
+     *    `frequentEmojis`, which change when the viewer themselves writes.
+     * 5. **Workspace-keyed** — the three rosters whose answer is one team's.
+     *    Absent off a workspace route rather than empty, for the reason given
+     *    on the group itself.
+     *
+     * Groups 4 and 5 are the ones with no key-shaped trigger at all: nothing
+     * about a clock, a config value or a session says when a channel was
+     * starred. Their trigger is the partial reload the client *already* fires
+     * after that write, since the exclusion below is bypassed on partial
+     * requests — the sets in `resources/js/lib/reloadProps.ts` are the
+     * invalidation, and adding a prop here means checking it has one (#1252).
      *
      * Every key carries its own discriminator because the **client stores once
      * props by key and restores them by prop path**: two props sharing one key
@@ -210,6 +208,11 @@ class HandleInertiaRequests extends Middleware
         $locale = app()->getLocale();
         $user = $request->user();
         $prompt = $this->postRegistrationPrompt($request);
+        $shell = WorkspaceShell::forRequest($request);
+        $boundChannel = $request->route('channel');
+        $activeChannel = $boundChannel instanceof Channel ? $boundChannel : null;
+        $viewer = $this->viewerFingerprint($request);
+        $sessionless = ! $request->hasSession();
 
         return [
             'name' => Inertia::once(fn (): string => (string) config('app.name'))->as($instance.':name'),
@@ -384,7 +387,113 @@ class HandleInertiaRequests extends Middleware
             // (see `usePostRegistrationPrompt`), which is what stops a refresh
             // re-asking.
             'postRegistrationPrompt' => Inertia::once(fn (): ?string => $prompt)->fresh($prompt !== null),
+            // The viewer themselves. Every surface in the shell reads their
+            // name, avatar, preferences, status and do-not-disturb state off
+            // this one prop, and a dozen settings writes refresh it from the
+            // redirect they end in rather than by naming `AUTH_PROPS`.
+            //
+            // So the key carries a digest of the prop's own payload: any write
+            // to the viewer's row — one of those dozen, a status that has
+            // lapsed, a schedule window that has opened — moves the key and the
+            // next navigation ships it, without every write site having to
+            // remember. The reload `useTimezone` already fires still works and
+            // is still faster, being a partial request; this is the floor under
+            // it rather than a replacement for it.
+            'auth' => Inertia::once(fn (): array => ['user' => $user])
+                ->as($viewer.':auth:'.substr(hash('xxh128', (string) json_encode($user?->toArray())), 0, 8))
+                ->fresh($sessionless),
+            // Which of the sidebar's built-in groups the viewer has collapsed —
+            // a set on their own account, so it holds across workspaces and is
+            // keyed on the viewer alone. Invalidated by `COLLAPSED_SECTION_PROPS`.
+            'collapsedChannelSections' => Inertia::once(fn (): array => $user->collapsed_channel_sections ?? [])
+                ->as($viewer.':collapsedChannelSections')
+                ->fresh($sessionless),
+            // The viewer's five most-used emoji in their current workspace,
+            // feeding the hover bar's quick-react cluster and the picker's
+            // "Frequently used" strip. Derived from reaction history, and now
+            // derived once: the reaction write names it (`FREQUENT_EMOJI_PROPS`)
+            // and re-ranks on the reply, which is the same eventual consistency
+            // it always had and one query less on every navigation between.
+            //
+            // Shared everywhere rather than only inside the workspace, and keyed
+            // on the current team rather than the bound one, because that is
+            // what it reads: the ranking is the same answer on a settings page
+            // as in the workspace, so there is one value per prop path.
+            'frequentEmojis' => Inertia::once(fn (): array => FrequentEmoji::forUser($user))
+                ->as($viewer.':frequentEmojis:'.($user?->currentTeam?->getKey() ?? 'none'))
+                ->fresh($sessionless),
+            // The workspace's own rosters. Absent off a workspace route rather
+            // than empty: a once prop has one value per prop path for the life
+            // of the page, so an empty roster shipped from a settings page would
+            // be the answer a later workspace visit restored. Absent, the client
+            // drops the key instead — every consumer already defaults it — and
+            // the way back in is a first load again.
+            ...$shell instanceof WorkspaceShell ? $this->workspaceProps($shell, $viewer, $activeChannel) : [],
         ];
+    }
+
+    /**
+     * The rosters that describe one workspace, keyed on which workspace that is.
+     *
+     * Each is invalidated by the set the client already names after the writes
+     * that move it — `CHANNEL_LIST_PROPS` for a star, a drag, a mute or a draft,
+     * `CHANNEL_SECTION_PROPS` for a rename or a reorder, `REMINDER_PROPS` for a
+     * reminder set, cleared or come due. What none of those cover is *switching
+     * workspaces*, which is not a write at all: the key moves, but the client
+     * has by then declared the previous workspace's key against the same prop
+     * path, and returning to it would restore the roster of the one just left.
+     * `useTeamSwitch` names them for that reason.
+     *
+     * @return array<string, mixed>
+     */
+    protected function workspaceProps(WorkspaceShell $shell, string $viewer, ?Channel $activeChannel): array
+    {
+        $workspace = $viewer.':team:'.$shell->teamKey();
+
+        return [
+            // Deliberately *not* keyed on the active channel, though the roster
+            // is built with it: this is the largest prop in the shell, and a key
+            // that moved with every click would cache nothing. What the active
+            // channel buys is one row — a direct message with no messages yet,
+            // opened by the other side, which is listed only while the viewer is
+            // standing in it. Reaching one is a document load or a
+            // `useNewDirectMessages` reload, both of which rebuild the list; all
+            // a cached roster can do is carry that row one channel too far.
+            'channels' => Inertia::once(fn (): array => $shell->channels($activeChannel))->as($workspace.':channels'),
+            'channelSections' => Inertia::once($shell->channelSections(...))->as($workspace.':channelSections'),
+            // The viewer's still-pending reminders in this workspace, soonest
+            // first, feeding the "Reminders" list and its sidebar count.
+            'reminders' => Inertia::once(fn (): array => $shell->reminders(MessageReminderStatus::Pending))
+                ->as($workspace.':reminders'),
+            // Reminders that have come due and await acknowledgement, driving
+            // the in-app nudges; reloaded live when a MessageReminderDue signal
+            // lands, which is a partial request and so reaches the client.
+            'firedReminders' => Inertia::once(fn (): array => $shell->reminders(MessageReminderStatus::Fired))
+                ->as($workspace.':firedReminders'),
+        ];
+    }
+
+    /**
+     * Which viewer the props above describe, as a once key's discriminator.
+     *
+     * Taken from the session's CSRF token, which Laravel rotates on both
+     * sign-in and sign-out — the two moments these answers stop being this
+     * viewer's, and the two the account id alone cannot see. Without it, signing
+     * out would be answered under a key the client already holds for the guest
+     * page and the client would restore the account that just left; signing back
+     * in would restore the guest.
+     *
+     * Hashed because the token is a secret and this rides a request header on
+     * every navigation, and truncated for the same reason the instance digest is
+     * — a collision costs a hard reload, not correctness.
+     */
+    protected function viewerFingerprint(Request $request): string
+    {
+        if (! $request->hasSession()) {
+            return 'viewer:sessionless';
+        }
+
+        return 'viewer:'.substr(hash('xxh128', $request->session()->token()), 0, 8);
     }
 
     /**

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -445,6 +445,15 @@ class HandleInertiaRequests extends Middleware
      * path, and returning to it would restore the roster of the one just left.
      * `useTeamSwitch` names them for that reason.
      *
+     * `channelSections` and both reminder lists are the viewer's own rows, so
+     * the viewer is the only one who can move them. `channels` is not: a
+     * teammate can rename a channel, archive one, or add the viewer to one.
+     * Renaming the *open* channel is covered — `ChannelUpdated` reloads the
+     * roster by name — and a message anywhere brings it back through
+     * `useSidebarBadges`. The rest reach the sidebar on the next hard load
+     * rather than the next click, which is the one thing this child knowingly
+     * gives up; closing it needs broadcasts the server does not send yet.
+     *
      * @return array<string, mixed>
      */
     protected function workspaceProps(WorkspaceShell $shell, string $viewer, ?Channel $activeChannel): array
@@ -485,8 +494,16 @@ class HandleInertiaRequests extends Middleware
      * in would restore the guest.
      *
      * Hashed because the token is a secret and this rides a request header on
-     * every navigation, and truncated for the same reason the instance digest is
-     * — a collision costs a hard reload, not correctness.
+     * every navigation — 32 bits of an xxh128 over a 40-character random token
+     * is not a token anyone can walk back. Truncated for the same reason the
+     * instance digest is: the keys are sent on every navigation, and the header
+     * is already the honest cost of this whole mechanism.
+     *
+     * What a collision would take, and cost: two *consecutive sessions in one
+     * browser tab* landing on the same 32 bits, which is the only way the client
+     * still holds the earlier one's keys. For `auth` that is not enough on its
+     * own — its key carries the payload digest too, so both must collide — and
+     * for the other two it is one stale preference until the next hard load.
      */
     protected function viewerFingerprint(Request $request): string
     {

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -176,7 +176,7 @@ class HandleInertiaRequests extends Middleware
      *    prompt their registration queued.
      * 4. **Viewer-keyed** — `auth`, `collapsedChannelSections` and
      *    `frequentEmojis`, which change when the viewer themselves writes.
-     * 5. **Workspace-keyed** — the three rosters whose answer is one team's.
+     * 5. **Workspace-keyed** — the four rosters whose answer is one team's.
      *    Absent off a workspace route rather than empty, for the reason given
      *    on the group itself.
      *
@@ -190,12 +190,13 @@ class HandleInertiaRequests extends Middleware
      * Every key carries its own discriminator because the **client stores once
      * props by key and restores them by prop path**: two props sharing one key
      * collapse into a single entry client-side, and the other would come back
-     * absent on the second visit rather than cached. One digest, sixteen keys.
+     * absent on the second visit rather than cached. One key per prop, however
+     * many of them share a digest.
      *
-     * The exclusion is bypassed on partial requests, so a `router.reload({ only:
-     * [...] })` naming any of these still receives it — which is what makes
-     * `resources/js/lib/reloadProps.ts` the invalidation registry for the props
-     * whose trigger is a write rather than a key.
+     * That same property is why a key may never come back round to a value the
+     * prop path no longer holds — it would restore the other one. Which is what
+     * the viewer and workspace discriminators are for, and why the four rosters
+     * are absent off a workspace route rather than shipped empty.
      *
      * @see https://inertiajs.com/shared-data
      *

--- a/app/Support/WorkspaceShell.php
+++ b/app/Support/WorkspaceShell.php
@@ -86,6 +86,19 @@ final readonly class WorkspaceShell
     }
 
     /**
+     * The workspace these read-models describe, as a once key's discriminator.
+     *
+     * The client stores a once prop by key but restores it by prop *path*, so a
+     * prop whose answer is one team's has to carry which team that was: without
+     * it, moving between two workspaces would find the key already declared and
+     * restore the roster of the one the viewer just left.
+     */
+    public function teamKey(): string
+    {
+        return (string) $this->team->getKey();
+    }
+
+    /**
      * The viewer's channels for the sidebar, with `$activeChannel` — the channel
      * they are currently looking at, if any — always listed.
      *

--- a/app/Support/WorkspaceShell.php
+++ b/app/Support/WorkspaceShell.php
@@ -42,8 +42,9 @@ use Inertia\ProvidesScrollMetadata;
  *    facets on the URL — is passed in as a resolved value.
  *
  * The shell does not name the props it feeds. That list is the Inertia contract
- * and it stays in {@see HandleInertiaRequests::share()}, which is glue: it names
- * the props and computes none of them.
+ * and it stays in {@see HandleInertiaRequests}, split between `share()` and
+ * `shareOnce()` by whether a prop can change between two clicks. Both halves are
+ * glue: they name the props and compute none of them.
  */
 final readonly class WorkspaceShell
 {

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -125,6 +125,7 @@ function toggleStar(): void {
                             ? 'font-semibold text-sidebar-foreground'
                             : ''
                     "
+                    :data-test="`channel-name-${channel.slug}`"
                     >{{ channel.name }}</span
                 >
                 <!-- The mute / notification-level cue sits just after the name,

--- a/resources/js/composables/useChannelRealtime.ts
+++ b/resources/js/composables/useChannelRealtime.ts
@@ -11,6 +11,7 @@ import type { AlertPreference } from '@/lib/alerts';
 import { backgroundVisit } from '@/lib/backgroundVisit';
 import { createChannelFleet } from '@/lib/channelFleet';
 import { placeIncomingMessage } from '@/lib/messagePlacement';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import type {
     ChannelReader,
     Mention,
@@ -229,9 +230,15 @@ export function useChannelRealtime(options: ChannelRealtimeOptions): void {
                     // title alike, so refetch them rather than merging the
                     // broadcast into each of the three by hand. Nobody asked
                     // for this request, so it rides `backgroundVisit`.
+                    //
+                    // The roster half is named from the registry rather than
+                    // spelled out here, because since #1252 it is the *only*
+                    // thing that brings the roster back: it is a once prop, and
+                    // an editor who is not the viewer moves it without any write
+                    // of the viewer's for an ordinary navigation to pick up.
                     router.reload({
                         ...backgroundVisit,
-                        only: ['channel', 'channels'],
+                        only: ['channel', ...CHANNEL_LIST_PROPS],
                     });
                 })
                 .listen('UserTyping', (user: TypingUser) => {

--- a/resources/js/composables/useMessageActions.mutations.test.ts
+++ b/resources/js/composables/useMessageActions.mutations.test.ts
@@ -37,6 +37,7 @@ import {
     optionsOf,
     payloadOf,
 } from '@/composables/useMessageActions.harness';
+import { CHANNEL_LIST_PROPS, FREQUENT_EMOJI_PROPS } from '@/lib/reloadProps';
 
 describe('useMessageActions', () => {
     beforeEach(() => {
@@ -98,7 +99,13 @@ describe('useMessageActions', () => {
                 h.mainStream.displayMessages.value.find((m) => m.id === 'm1')
                     ?.reactions,
             ).toHaveLength(1);
-            expect(optionsOf(post).only).toEqual(['channels']);
+            // The roster, because a reaction moves the sidebar's activity
+            // order, and the quick-react ranking, which nothing else re-ranks
+            // and which stopped riding an ordinary navigation in #1252.
+            expect(optionsOf(post).only).toEqual([
+                ...CHANNEL_LIST_PROPS,
+                ...FREQUENT_EMOJI_PROPS,
+            ]);
 
             optionsOf(post).onError?.();
             expect(

--- a/resources/js/composables/useMessageEdits.ts
+++ b/resources/js/composables/useMessageEdits.ts
@@ -11,7 +11,7 @@ import {
 import type { Rollback } from '@/composables/useOptimisticWrite';
 import { useTranslations } from '@/composables/useTranslations';
 import { toggleReaction } from '@/lib/reactions';
-import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
+import { CHANNEL_LIST_PROPS, FREQUENT_EMOJI_PROPS } from '@/lib/reloadProps';
 import type { Message } from '@/types';
 
 export interface MessageEdits {
@@ -117,7 +117,10 @@ export function useMessageEdits(options: MessageEditsOptions): MessageEdits {
                 message: message.id,
             }).url,
             data: { emoji },
-            only: CHANNEL_LIST_PROPS,
+            // The roster, because a reaction moves the sidebar's activity order,
+            // and the quick-react ranking, which is the only thing a reaction
+            // re-ranks and no longer rides an ordinary navigation.
+            only: [...CHANNEL_LIST_PROPS, ...FREQUENT_EMOJI_PROPS],
             failure: t('Failed to update the reaction'),
         });
     }

--- a/resources/js/composables/useTeamPresence.test.ts
+++ b/resources/js/composables/useTeamPresence.test.ts
@@ -92,6 +92,7 @@ import {
     useTeamPresence,
     useTeamPresenceSubscription,
 } from '@/composables/useTeamPresence';
+import { TEAM_MEMBER_PROPS } from '@/lib/reloadProps';
 
 /**
  * A no-op renderer mounts a real component instance under Node (no DOM), which
@@ -338,7 +339,7 @@ describe('useTeamPresence', () => {
         unmount();
     });
 
-    it('still reloads every prop when a teammate changes their profile', async () => {
+    it('asks for the roster, and only the roster, when a teammate changes their profile', async () => {
         vi.useFakeTimers();
 
         const { unmount } = mount();
@@ -348,7 +349,14 @@ describe('useTeamPresence', () => {
         await vi.advanceTimersByTimeAsync(500);
         await nextTick();
 
+        // This fired with no `only` at all until #1252 — a whole page of props
+        // on a teammate's timing, to move a do-not-disturb crescent. The bound
+        // list is the regression: a reload without `only` is answered with the
+        // page as the route stood when it left, and replaces every prop with it.
         expect(reload).toHaveBeenCalledTimes(1);
+        expect(reload).toHaveBeenCalledWith(
+            expect.objectContaining({ only: TEAM_MEMBER_PROPS }),
+        );
 
         unmount();
     });

--- a/resources/js/composables/useTeamPresence.ts
+++ b/resources/js/composables/useTeamPresence.ts
@@ -4,6 +4,7 @@ import { computed, onBeforeUnmount, onMounted, ref, toValue, watch } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 import { backgroundVisit } from '@/lib/backgroundVisit';
 import type { RenderedPresence } from '@/lib/presence';
+import { TEAM_MEMBER_PROPS } from '@/lib/reloadProps';
 
 /**
  * How long to coalesce a burst of profile updates before reloading, so many
@@ -120,16 +121,16 @@ function isDndFor(userId: string): boolean {
     return dndIds.value.has(userId);
 }
 
-// A teammate changed their profile (avatar, custom status). Reload the
-// current page's props so every surface re-reads them, preserving scroll and
-// local state so the refresh is invisible. A teammate's timing is not the
-// viewer's, and this one reloads *every* prop, so interrupting a visit with
-// it is especially costly; see {@see backgroundVisit}. Presence deliberately
-// does not come through here — it flips far too often to pay this price.
+// A teammate changed their profile (avatar, custom status, do-not-disturb).
+// Reload the one prop that carries it, preserving scroll and local state so the
+// refresh is invisible. A teammate's timing is not the viewer's, so interrupting
+// a visit with it is especially costly; see {@see backgroundVisit}. Presence
+// deliberately does not come through here — it flips far too often to pay this
+// price, and rides `UserPresenceChanged` instead.
 function scheduleProfileReload(): void {
     clearTimeout(profileReloadTimer);
     profileReloadTimer = setTimeout(() => {
-        router.reload({ ...backgroundVisit });
+        router.reload({ ...backgroundVisit, only: TEAM_MEMBER_PROPS });
     }, PROFILE_RELOAD_DEBOUNCE_MS);
 }
 

--- a/resources/js/composables/useTeamSwitch.test.ts
+++ b/resources/js/composables/useTeamSwitch.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WORKSPACE_PROPS } from '@/lib/reloadProps';
+import type { Team } from '@/types';
+
+const visit = vi.fn();
+const reload = vi.fn();
+
+const page = { props: { currentTeam: { slug: 'acme' } as Team } };
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: {
+        visit: (...args: unknown[]) => visit(...args),
+        reload: (...args: unknown[]) => reload(...args),
+    },
+    usePage: () => page,
+}));
+
+vi.mock('@/routes/teams', () => ({
+    switchMethod: (slug: string) => ({ url: `/settings/teams/${slug}/switch` }),
+}));
+
+const { useTeamSwitch } = await import('@/composables/useTeamSwitch');
+
+/** Drive the switch through to the visit that lands on the new workspace. */
+function switchTo(slug: string, url = '/t/acme/c/general'): void {
+    window.history.replaceState({}, '', url);
+
+    useTeamSwitch().switchTeam({ slug } as Team);
+
+    const [, options] = visit.mock.calls[0] as [
+        unknown,
+        { onFinish: () => void },
+    ];
+    options.onFinish();
+}
+
+/** The options the landing visit carried. */
+function landingOptions(): { onSuccess?: () => void } {
+    return visit.mock.calls[1]?.[1] as { onSuccess?: () => void };
+}
+
+describe('useTeamSwitch', () => {
+    beforeEach(() => {
+        visit.mockClear();
+        reload.mockClear();
+        page.props.currentTeam = { slug: 'acme' } as Team;
+    });
+
+    it('lands on the equivalent page under the new workspace', () => {
+        switchTo('globex');
+
+        expect(visit.mock.calls[1]?.[0]).toBe('/t/globex');
+    });
+
+    it('asks the new workspace for the props that describe it', () => {
+        switchTo('globex');
+
+        landingOptions().onSuccess?.();
+
+        // The rosters are keyed by the team they belong to, which covers a
+        // workspace the client has not seen. Coming *back* to one it has finds
+        // that key already declared, and the client restores a once prop by
+        // prop name — so without this the sidebar would show the workspace the
+        // reader just left. A partial request is what bypasses the exclusion.
+        expect(reload).toHaveBeenCalledWith(
+            expect.objectContaining({ only: WORKSPACE_PROPS }),
+        );
+    });
+
+    it('does not ask until the landing visit has succeeded', () => {
+        switchTo('globex');
+
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a plain reload away from the previous workspace', () => {
+        switchTo('globex', '/settings/profile');
+
+        // Off a workspace route the rosters are absent rather than empty, so
+        // the client is holding no key for them and the way in ships them.
+        expect(visit).toHaveBeenCalledTimes(1);
+        expect(reload).toHaveBeenCalledWith();
+    });
+});

--- a/resources/js/composables/useTeamSwitch.ts
+++ b/resources/js/composables/useTeamSwitch.ts
@@ -1,5 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
+import { backgroundVisit } from '@/lib/backgroundVisit';
+import { WORKSPACE_PROPS } from '@/lib/reloadProps';
 import { switchMethod } from '@/routes/teams';
 import type { Team } from '@/types';
 
@@ -45,6 +47,25 @@ export function targetUrlForTeamSwitch(
 }
 
 /**
+ * Ask the new workspace for the props that describe it, once the switch has
+ * landed on one of its pages.
+ *
+ * The rosters are `once` props keyed by the team they belong to (#1252), which
+ * is enough for a workspace the client has not seen. It is not enough for going
+ * back: the client stores a once prop by key but restores it by prop name, so
+ * returning to a workspace it has already loaded finds that key declared,
+ * excludes the props, and leaves the sidebar showing the workspace just left.
+ *
+ * It is a request of its own rather than an `only` on the visit above, because
+ * that visit is a navigation: naming the shared props would filter out the
+ * destination page's own, and the new workspace would render with the previous
+ * page's channel, messages and pins.
+ */
+function refreshWorkspaceProps(): void {
+    router.reload({ ...backgroundVisit, only: WORKSPACE_PROPS });
+}
+
+/**
  * Shared workspace-switching behaviour used by both the team rail and the
  * TeamSwitcher dropdown. Visiting the switch route swaps the active team, then
  * moves the user to the equivalent page under the new workspace (falling back
@@ -78,7 +99,10 @@ export function useTeamSwitch(): UseTeamSwitchReturn {
                     return;
                 }
 
-                router.visit(target, { replace: true });
+                router.visit(target, {
+                    replace: true,
+                    onSuccess: refreshWorkspaceProps,
+                });
             },
         });
     };

--- a/resources/js/lib/reloadProps.test.ts
+++ b/resources/js/lib/reloadProps.test.ts
@@ -4,13 +4,16 @@ import {
     CHANNEL_LIST_PROPS,
     CHANNEL_SECTION_PROPS,
     COLLAPSED_SECTION_PROPS,
+    FREQUENT_EMOJI_PROPS,
     LOCALE_PROPS,
     PIN_PROPS,
     POST_REGISTRATION_PROMPT_PROPS,
     SCHEDULED_MESSAGE_PROPS,
+    TEAM_MEMBER_PROPS,
     THREAD_PROPS,
     THREAD_RESET_PROPS,
     UNREAD_DIGEST_PROPS,
+    WORKSPACE_PROPS,
 } from '@/lib/reloadProps';
 import { filesSpelling } from '@/lib/sourceScan.harness';
 
@@ -84,6 +87,30 @@ describe('reloadProps', () => {
         ]);
     });
 
+    it('names the member roster, so a teammate write need not ask for the page', () => {
+        // This reload carried no `only` at all until #1252: a whole page of
+        // props, on a teammate's timing, to move a do-not-disturb crescent.
+        expect(TEAM_MEMBER_PROPS).toEqual(['teamMembers']);
+    });
+
+    it('names the quick-react ranking, which only a reaction re-ranks', () => {
+        expect(FREQUENT_EMOJI_PROPS).toEqual(['frequentEmojis']);
+    });
+
+    it('names everything one workspace answers, for the move that is not a write', () => {
+        // Switching workspace changes every one of these at once. They are
+        // `once` props keyed by their team, which answers moving to a workspace
+        // the client has not seen; returning to one it has finds the key
+        // declared and restores the rosters of the workspace just left (#1252).
+        expect(WORKSPACE_PROPS).toEqual([
+            'channels',
+            'channelSections',
+            'frequentEmojis',
+            'reminders',
+            'firedReminders',
+        ]);
+    });
+
     it('names the one-time security prompt, which is cached while empty', () => {
         expect(POST_REGISTRATION_PROMPT_PROPS).toEqual([
             'postRegistrationPrompt',
@@ -109,7 +136,9 @@ describe('reloadProps', () => {
             'POST_REGISTRATION_PROMPT_PROPS',
             arrayLiteralOf(/'postRegistrationPrompt',?/),
         ],
+        ['FREQUENT_EMOJI_PROPS', arrayLiteralOf(/'frequentEmojis'/)],
         ['SCHEDULED_MESSAGE_PROPS', arrayLiteralOf(/'scheduledMessages'/)],
+        ['TEAM_MEMBER_PROPS', arrayLiteralOf(/'teamMembers'/)],
         ['THREAD_PROPS', arrayLiteralOf(/'thread',\s*'threadReplies'/)],
         ['THREAD_RESET_PROPS', arrayLiteralOf(/'threadReplies'/)],
         ['UNREAD_DIGEST_PROPS', arrayLiteralOf(/'unread'/)],

--- a/resources/js/lib/reloadProps.ts
+++ b/resources/js/lib/reloadProps.ts
@@ -9,16 +9,26 @@
  * `pinCount` are two readings of one fact, and so are `thread` and
  * `threadReplies`.
  *
- * Ten invalidation sets live here; the eleventh, {@see REMINDER_PROPS}, is next
- * door in {@see reminderReload} with the visit options a reminder mutation
- * carries. All eleven are enforced the same way, by a test that fails on a
- * second copy. {@link THREAD_RESET_PROPS} is not one of them — it names what a
- * thread load *resets* rather than what a write invalidates.
+ * Twelve invalidation sets live here; the thirteenth, {@see REMINDER_PROPS}, is
+ * next door in {@see reminderReload} with the visit options a reminder mutation
+ * carries. All thirteen are enforced the same way, by a test that fails on a
+ * second copy. Two are not quite invalidation sets: {@link THREAD_RESET_PROPS}
+ * names what a thread load *resets* rather than what a write invalidates, and
+ * {@link WORKSPACE_PROPS} names what a *switch* invalidates, which is not a
+ * write at all.
+ *
+ * Since #1252 these sets carry a second duty. Most of the props they name are
+ * `once` props, excluded from every ordinary navigation, and it is the reload
+ * naming them that brings them back — the once exclusion is bypassed on partial
+ * requests. A write that stops naming its set therefore no longer goes stale on
+ * the next navigation; it stays stale until a hard reload.
  *
  * Every set is typed as a mutable `string[]` because that is what Inertia's
  * `only` takes; a `readonly` tuple would force an `as string[]` cast back at
  * every call site, which is exactly the noise this replaces.
  */
+
+import { REMINDER_PROPS } from '@/lib/reminderReload';
 
 /**
  * The viewer: the account the shell reads its identity, preferences and
@@ -119,6 +129,50 @@ export const LOCALE_PROPS: string[] = [
     'slashCommands',
     'sidebarPositions',
     'invitableRoles',
+];
+
+/**
+ * The team's member roster, as the DM entry points and the presence dots read it.
+ *
+ * Named for the reload it replaces. A teammate changing their avatar, status or
+ * do-not-disturb state used to reload the page with no `only` at all — the
+ * anti-pattern this file exists to retire (#1099), and on someone else's timing:
+ * the reply is the whole page as the route stood when it left, and it replaces
+ * every prop rather than merging, so a destination the reader opened in the
+ * meantime loses props that were never in the reply.
+ */
+export const TEAM_MEMBER_PROPS: string[] = ['teamMembers'];
+
+/**
+ * The viewer's frequently-used emoji, as the quick-react cluster ranks them.
+ *
+ * Rides the reaction write next to {@link CHANNEL_LIST_PROPS} rather than alone:
+ * a reaction is the only thing that re-ranks the list, and it already asks for
+ * the roster because the sidebar's activity order moves with it.
+ */
+export const FREQUENT_EMOJI_PROPS: string[] = ['frequentEmojis'];
+
+/**
+ * Everything whose answer is one workspace's, named for the one move that
+ * changes all of them at once and is not a write: switching workspace.
+ *
+ * These are `once` props keyed by the team they describe (#1252), which answers
+ * moving *to* a workspace the client has not seen. It does not answer moving
+ * *back*. The client stores a once prop by key but restores it by prop name, so
+ * A → B → A finds team A's key already declared, excludes the props, and
+ * restores the rosters of the workspace the reader just left — the sidebar of
+ * one workspace on the pages of another.
+ *
+ * A partial reload is what closes that, exactly as it does for
+ * {@link LOCALE_PROPS}: the once exclusion is bypassed on partial requests. It
+ * fires once the switch has landed rather than riding the visit that lands it,
+ * because that visit is a navigation and needs the destination's page props too.
+ */
+export const WORKSPACE_PROPS: string[] = [
+    ...CHANNEL_LIST_PROPS,
+    ...CHANNEL_SECTION_PROPS,
+    ...FREQUENT_EMOJI_PROPS,
+    ...REMINDER_PROPS,
 ];
 
 /**

--- a/tests/Browser/ChannelDetailsDialogTest.php
+++ b/tests/Browser/ChannelDetailsDialogTest.php
@@ -93,3 +93,26 @@ test('an edit reaches another member without them reloading', function (): void 
             'Where the launch is run from.',
         );
 });
+
+test('a rename reaches another member sidebar without them reloading', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $alicePage = signInThroughBrowser($alice);
+    $bobPage = signInThroughBrowser($bob);
+
+    $bobPage->assertSeeIn("@channel-name-{$channel->slug}", $channel->name);
+
+    $alicePage
+        ->click('@channel-options')
+        ->click('@channel-details')
+        ->click('@channel-details-edit')
+        ->fill('@channel-details-name', 'launch-room')
+        ->click('@channel-details-save');
+
+    // The sidebar row is the half at risk since #1252: `channels` is a once
+    // prop now, so an ordinary navigation no longer rebuilds the roster and the
+    // `ChannelUpdated` reload naming `CHANNEL_LIST_PROPS` is the only thing that
+    // brings Bob a name he did not change himself. Keyed on the original slug,
+    // which a rename deliberately does not move — see {@see UpdateChannel}.
+    $bobPage->assertSeeIn("@channel-name-{$channel->slug}", 'launch-room');
+});

--- a/tests/Feature/Channels/SharedOncePropsTest.php
+++ b/tests/Feature/Channels/SharedOncePropsTest.php
@@ -83,7 +83,10 @@ test('a second visit still carries what an ordinary navigation owes', function (
 
     $props = (array) revisit($first, workspaceUrl($team))->assertOk()->json('props');
 
-    expect(array_keys($props))->toContain('errors', 'unread', 'auth', 'sidebarOpen')
+    // `auth` was here until #1252 once'd it behind a digest of its own payload;
+    // what is left is the errors bag, the read state and the cookie-derived
+    // flags — the props that are genuinely a function of this request.
+    expect(array_keys($props))->toContain('errors', 'unread', 'sidebarOpen')
         ->and($props['sidebarOpen'])->toBeTrue();
 });
 

--- a/tests/Feature/Channels/ViewerOncePropsTest.php
+++ b/tests/Feature/Channels/ViewerOncePropsTest.php
@@ -1,0 +1,241 @@
+<?php
+
+use App\Enums\MessageReminderStatus;
+use App\Models\ChannelSection;
+use App\Models\Message;
+use App\Models\MessageReminder;
+use App\Models\User;
+
+/*
+|--------------------------------------------------------------------------
+| The props the viewer's own writes invalidate (#1252)
+|--------------------------------------------------------------------------
+|
+| The second group of once'd shell props, after the instance constants and
+| session facts of #1251. These do change — but only when the viewer writes,
+| and the client already names each of them in a partial reload after exactly
+| that write. Since the once exclusion is bypassed on partial requests, those
+| existing `only:` reloads *are* the invalidation: nothing new fires, the props
+| simply stop riding along on the navigations in between.
+|
+| Two discriminators carry that, and both are about the same client property —
+| a once prop is stored by key but restored by *prop path*, so a key that comes
+| back round to a value the path no longer holds restores the wrong one:
+|
+| 1. **The viewer**, as a digest of the session's CSRF token, which Laravel
+|    rotates on both sign-in and sign-out. Without it `auth` under a guest's key
+|    would be excluded after a sign-out and the client would restore the account
+|    that just left.
+| 2. **The workspace**, for the four props whose answer is a team's. They are
+|    absent off a workspace route rather than `[]`, which is what lets the
+|    client drop their keys and ask again on the way back in.
+|
+| `auth` carries a third: a digest of its own payload, so that any write to the
+| viewer's row reships it on the next navigation whether or not the surface that
+| made the write remembered to name `AUTH_PROPS`.
+|
+*/
+
+/**
+ * The props keyed on the viewer alone, carried on every route.
+ *
+ * @var list<string>
+ */
+const VIEWER_ONCE_PROPS = [
+    'auth',
+    'collapsedChannelSections',
+    'frequentEmojis',
+];
+
+/**
+ * The props keyed on the viewer's workspace, carried only inside one.
+ *
+ * @var list<string>
+ */
+const WORKSPACE_ONCE_PROPS = [
+    'channels',
+    'channelSections',
+    'reminders',
+    'firedReminders',
+];
+
+test('a first load carries every prop the viewer own writes invalidate', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $page = visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page');
+
+    expect(array_keys($page['props']))
+        ->toContain(...VIEWER_ONCE_PROPS)
+        ->toContain(...WORKSPACE_ONCE_PROPS);
+});
+
+test('a second visit carries none of them', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $props = array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props'));
+
+    expect(array_intersect([...VIEWER_ONCE_PROPS, ...WORKSPACE_ONCE_PROPS], $props))->toBe([]);
+});
+
+test('a second visit still carries what an ordinary navigation owes', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // What is left is the genuinely volatile half: what the viewer has not
+    // read, and the roster whose presence dots move without any write of theirs.
+    expect(array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props')))
+        ->toContain('errors', 'unread', 'teamMembers');
+});
+
+test('a partial reload naming a set receives it', function (string $prop): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The sixteen `only:` call sites in `resources/js/lib/reloadProps.ts` keep
+    // working for exactly this reason, and it is the whole mechanism: the once
+    // exclusion is gated on the request not being a partial one.
+    expect(array_keys((array) partialRevisit($first, workspaceUrl($team), [$prop])->assertOk()->json('props')))
+        ->toContain($prop);
+})->with([...VIEWER_ONCE_PROPS, ...WORKSPACE_ONCE_PROPS]);
+
+test('starring a channel brings the roster back with the star on it', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $channel] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $this->actingAs($viewer)
+        ->patch(route('channels.star.update', ['team' => $team->slug, 'channel' => $channel->slug]), ['starred' => true])
+        ->assertRedirect();
+
+    // Both halves of the contract in one: the write is invisible to an ordinary
+    // navigation, and the reload the star already fires (`CHANNEL_LIST_PROPS`)
+    // is what carries it.
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props'))->not->toHaveKey('channels');
+
+    expect(partialRevisit($first, workspaceUrl($team), ['channels'])->assertOk()->json('props.channels.0.starred'))
+        ->toBeTrue();
+});
+
+test('collapsing a built-in group brings back the collapsed set', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $viewer->update(['collapsed_channel_sections' => ['channels']]);
+
+    expect(partialRevisit($first, workspaceUrl($team), ['collapsedChannelSections'])->assertOk()
+        ->json('props.collapsedChannelSections'))
+        ->toBe(['channels']);
+});
+
+test('reordering the custom sections brings back the section list', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    ChannelSection::factory()->for($viewer)->for($team)->create(['name' => 'Projects']);
+
+    expect(partialRevisit($first, workspaceUrl($team), ['channelSections'])->assertOk()
+        ->json('props.channelSections.0.name'))
+        ->toBe('Projects');
+});
+
+test('a reminder coming due still reaches the client', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $channel] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The dispatcher's `MessageReminderDue` broadcast reloads `REMINDER_PROPS`,
+    // which is a partial request — so the nudge lands even though an ordinary
+    // navigation no longer carries either half of the pair.
+    $message = Message::factory()->for($channel)->for($viewer)->create();
+    MessageReminder::factory()->for($viewer)->for($message)->create([
+        'status' => MessageReminderStatus::Fired,
+    ]);
+
+    expect(partialRevisit($first, workspaceUrl($team), ['reminders', 'firedReminders'])->assertOk()
+        ->json('props.firedReminders'))
+        ->toHaveCount(1);
+});
+
+test('a write to the viewer own row reships auth without anyone naming it', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The key carries a digest of the prop's own payload, which is what makes
+    // this correct for the writes that refresh `auth` from their redirect
+    // rather than by naming `AUTH_PROPS` — and for a write nobody enumerated.
+    $viewer->update(['name' => 'Renamed']);
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.auth.user.name'))
+        ->toBe('Renamed');
+});
+
+test('leaving the viewer own row alone keeps auth off the next visit', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props'))->not->toHaveKey('auth');
+});
+
+test('signing out does not leave the client restoring the account that left', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // Laravel rotates the session's token on both sign-in and sign-out, so the
+    // viewer discriminator moves with them. Without it the guest's `auth` would
+    // be excluded under a key the client already holds, and the client would
+    // restore the signed-in user onto the page they just signed out of.
+    $this->post(route('logout'))->assertRedirect();
+
+    expect(revisit($first, route('login'))->assertOk()->json('props'))->toHaveKey('auth');
+});
+
+test('off a workspace route the workspace props are absent rather than empty', function (): void {
+    $viewer = User::factory()->create();
+
+    $props = (array) $this->actingAs($viewer)->get(route('profile.edit'))->assertOk()->viewData('page')['props'];
+
+    // Absent, not `[]`: a once prop has one value per prop path for the life of
+    // the page, so shipping an empty roster here would be the answer a later
+    // workspace visit restored. Every consumer already defaults it.
+    expect(array_intersect(WORKSPACE_ONCE_PROPS, array_keys($props)))->toBe([])
+        ->and(array_keys($props))->toContain(...VIEWER_ONCE_PROPS);
+});
+
+test('the roster ships again on the way back into the workspace', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The client only declares a once key while the prop path is defined, so a
+    // settings excursion — which carries none of these — drops them and the way
+    // back in is a first load again. Modelled here by revisiting from the
+    // settings response, whose keys are exactly what the client would be left
+    // holding.
+    $settings = revisit(visitWorkspaceAs($viewer, $team), route('profile.edit'))->assertOk();
+
+    expect(array_keys((array) revisit($settings, workspaceUrl($team))->assertOk()->json('props')))
+        ->toContain(...WORKSPACE_ONCE_PROPS);
+});
+
+test('another workspace is another answer, not the one the client holds', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+    ['team' => $other, 'channel' => $otherGeneral] = teamWithChannel('Globex');
+    joinTeamAndChannel($otherGeneral, $viewer);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The workspace half of the key is what makes the first switch free: the
+    // client has never declared the second team's key, so its roster ships
+    // rather than being excluded under the first team's.
+    expect(array_keys((array) revisit($first, workspaceUrl($other))->assertOk()->json('props')))
+        ->toContain(...WORKSPACE_ONCE_PROPS);
+});

--- a/tests/Feature/Channels/ViewerOncePropsTest.php
+++ b/tests/Feature/Channels/ViewerOncePropsTest.php
@@ -157,7 +157,12 @@ test('a reminder coming due still reaches the client', function (): void {
         'status' => MessageReminderStatus::Fired,
     ]);
 
-    expect(partialRevisit($first, workspaceUrl($team), ['reminders', 'firedReminders'])->assertOk()
+    // Reached from a navigation rather than the document load, since that is
+    // where a reminder actually comes due: the reader has been clicking around
+    // for an hour, and the pair has been excluded from every click since.
+    $navigated = revisit($first, workspaceUrl($team))->assertOk();
+
+    expect(partialRevisit($navigated, workspaceUrl($team), ['reminders', 'firedReminders'])->assertOk()
         ->json('props.firedReminders'))
         ->toHaveCount(1);
 });

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -233,19 +233,28 @@ function visitWorkspaceAs(User $viewer, Team $team): TestResponse
 }
 
 /**
- * The once-prop keys a response handed the client, whether it rendered a
- * document or answered an Inertia visit.
+ * The Inertia page object a response handed the client, whether it rendered a
+ * document or answered a visit — the one place that branch is written, so a
+ * helper can take either kind of response without knowing which it has.
+ *
+ * @return array<string, mixed>
+ */
+function inertiaPage(TestResponse $response): array
+{
+    return $response->headers->get('X-Inertia') === 'true'
+        ? (array) $response->json()
+        : (array) $response->viewData('page');
+}
+
+/**
+ * The once-prop keys a response handed the client.
  *
  * @return array<int, string>
  */
 function oncePropKeys(TestResponse $response): array
 {
-    $page = $response->headers->get('X-Inertia') === 'true'
-        ? (array) $response->json()
-        : (array) $response->viewData('page');
-
     /** @var array<string, mixed> $onceProps */
-    $onceProps = $page['onceProps'] ?? [];
+    $onceProps = inertiaPage($response)['onceProps'] ?? [];
 
     return array_keys($onceProps);
 }
@@ -299,12 +308,16 @@ function revisit(TestResponse $previous, string $url, array $headers = []): Test
  * site in `resources/js/lib/reloadProps.ts` sends, and the one request shape a
  * once prop is never excluded from.
  *
+ * A partial response is only recognised as one when it names the component the
+ * client is on, so that is read off `$previous` — from whichever shape it came
+ * in, since a reload can just as well follow another visit as a document load.
+ *
  * @param  array<int, string>  $only  the prop set, as the registry names it
  */
 function partialRevisit(TestResponse $previous, string $url, array $only): TestResponse
 {
     return revisit($previous, $url, [
-        'X-Inertia-Partial-Component' => (string) $previous->viewData('page')['component'],
+        'X-Inertia-Partial-Component' => (string) inertiaPage($previous)['component'],
         'X-Inertia-Partial-Data' => implode(',', $only),
     ]);
 }

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -18,6 +18,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
+use Inertia\Inertia;
 
 /*
 |--------------------------------------------------------------------------
@@ -279,12 +280,33 @@ function onceExpiry(TestResponse $response, string $prop): ?int
  */
 function revisit(TestResponse $previous, string $url, array $headers = []): TestResponse
 {
+    // Inertia accumulates shared props on a singleton and never flushes them,
+    // so a second request in the same test would still be holding the first
+    // one's — including a prop the route it is now on does not share at all.
+    // Every non-Octane request gets a fresh application; this is that.
+    Inertia::flushShared();
+
     return test()->withHeaders([
         'X-Inertia' => 'true',
         'X-Inertia-Version' => (string) app(HandleInertiaRequests::class)->version(request()),
         'X-Inertia-Except-Once-Props' => implode(',', oncePropKeys($previous)),
         ...$headers,
     ])->get($url);
+}
+
+/**
+ * The same visit as a partial reload naming `$only` — what every `only:` call
+ * site in `resources/js/lib/reloadProps.ts` sends, and the one request shape a
+ * once prop is never excluded from.
+ *
+ * @param  array<int, string>  $only  the prop set, as the registry names it
+ */
+function partialRevisit(TestResponse $previous, string $url, array $only): TestResponse
+{
+    return revisit($previous, $url, [
+        'X-Inertia-Partial-Component' => (string) $previous->viewData('page')['component'],
+        'X-Inertia-Partial-Data' => implode(',', $only),
+    ]);
 }
 
 /*


### PR DESCRIPTION
Closes #1252. Fourth of the shell-contract children on [perf: navigation feels instant](https://github.com/deskhq/the-desk/issues/1248), after #1249, #1250 and #1251, and the one that spends the `shareOnce()` home the last of those built.

## What changed

**Seven more props leave the ordinary navigation.** None of them has a key-shaped trigger — nothing about a clock, a config value or a session says when a channel was starred. Their trigger is the partial reload the client *already* fires after that write, since the once exclusion is bypassed on partial requests. The sets in `resources/js/lib/reloadProps.ts` are the invalidation; that registry now carries a second duty, and the file says so.

Two new discriminators, both about the client property #1251 established — a once prop is stored by key and restored by **prop path**, so a key may never come back round to a value the path no longer holds:

1. **Viewer-keyed** — `auth`, `collapsedChannelSections`, `frequentEmojis`. The viewer is a digest of the session's CSRF token, which Laravel rotates on sign-in *and* sign-out. Those are the two moments these answers stop being this viewer's and the two an account id cannot see: without it, signing out is answered under the key the client already holds for the guest page and the client restores **the account that just left**.
2. **Workspace-keyed** — `channels`, `channelSections`, `reminders`, `firedReminders`, keyed on the team and **absent off a workspace route rather than `[]`**. Absence is what makes it self-healing: the client only declares a key while the prop path is defined, so a settings excursion drops these and the way back in is a first load again. Shipping an empty roster there would be the answer a later workspace visit restored. Every consumer already defaulted it and the types were already optional, so this costs the frontend nothing.

**`useTeamPresence` names `TEAM_MEMBER_PROPS`.** It fired `router.reload({ ...backgroundVisit })` with no `only` at all — a whole page of props, on a teammate's timing, to move a do-not-disturb crescent.

## Three things the issue's shape did not survive, and why

**`auth`'s writes do not name `AUTH_PROPS` — one of about fifteen does.** The issue says every one of these props "already has a named invalidation set ... because the client already reloads exactly these props after exactly these writes". That holds for the sections and the reminders. For `auth` it is `useTimezone` and nothing else: sidebar position, chime, read receipts, the tour, the locale, the five status/DND writes, the profile and avatar pages are all `back()` redirects carrying a comment that says "the shared prop refreshes from the redirect". `once` it as written and the viewer's own avatar, status and language freeze until a hard reload.

So `auth`'s key carries **a digest of its own serialised payload**. Any write to the viewer's row moves the key and the next navigation ships it, whether or not the surface that made the write remembered to name the set — including a status that has lapsed or a DND window that has opened, which no write site could name. It is the `InstanceFingerprint` pattern of #1251 one ring further in. The honest cost: the user is still serialised each request to digest it, so `auth` buys bytes and not closure time. The alternative — `only: AUTH_PROPS` at fifteen sites — buys the closure time too and stakes the correctness of the whole shell on an exhaustive grep.

**Switching workspace is not a write, and no set covered it.** Team A → B → A finds team A's key already declared and restores the rosters of the workspace just left — one workspace's sidebar on another's pages. A new `WORKSPACE_PROPS`, fired from `useTeamSwitch` once the switch has landed, closes it the same way `LOCALE_PROPS` closes the locale round trip. It has to be a request of its own: the visit that lands is a navigation, so naming the shared props on it would filter out the destination's own and the new workspace would render with the previous page's channel and messages. That is one extra partial request on an action that already costs two, and only on a workspace switch.

**`channels` is deliberately not keyed on the active channel**, though the roster is built with it. It is the largest prop in the shell and a key that moved with every click would cache nothing. What the active channel buys is a single row — a DM with no messages, opened by the other side, listed only while the viewer stands in it — and reaching one is either a document load or a `useNewDirectMessages` reload, both of which rebuild the list.

## What this knowingly gives up — #1269

`channelSections` and both reminder lists are the viewer's own rows, so only the viewer can move them. `channels` is not. A teammate renaming a channel the viewer is **not** looking at, archiving one, or changing the viewer's membership used to be picked up silently by the next navigation and now reaches the sidebar on the next hard load. Renaming the **open** channel is covered — `useChannelRealtime`'s `ChannelUpdated` listener reloads the roster by name, and this PR makes it name it from the registry rather than spelling `['channel', 'channels']` out — and a message anywhere brings the roster back through `useSidebarBadges`. The rest needs broadcasts the server does not send yet, so it is #1269 rather than scope here.

## Numbers

Shared-prop bytes on a second channel visit, on a 7-member workspace:

| | 1 channel | 20 channels |
|---|---:|---:|
| before | 3,446 B | 11,290 B |
| **after** | **1,869 B** | **1,897 B** |

The point is the second row: what a second visit carries is now **flat in the size of the workspace**, which is the property the epic's budget asked for rather than a number. `auth` alone was 980 B of it. `X-Inertia-Except-Once-Props` grows to 1,063 B over 30 keys — the honest cost, and the one that compresses, since an identical header value across requests is a single HPACK dynamic-table reference.

Not measured in time, per the epic's ~50 ms rule. What is gone from the ordinary path and is not a byte: the sidebar roster's query, the reminder queries, and the frequently-used-emoji aggregate.

## Testing

- New `tests/Feature/Channels/ViewerOncePropsTest.php` at the seam the issue names — 20 cases over real Inertia visits. A first load carries all seven and a second carries none; each set brings its own prop back on a partial reload; starring a channel is invisible to a navigation and arrives on the reload the star already fires; a reminder coming due still reaches the client; a write to the viewer's row reships `auth` with nobody naming it, and leaving the row alone does not; signing out does not leave the client restoring the account that left; the rosters are absent off a workspace route and ship again on the way back in; another workspace is another answer.
- `tests/Helpers.php` gains `partialRevisit()` beside `revisit()`, and `revisit()` now calls `Inertia::flushShared()` — Inertia accumulates shared props on a singleton and never flushes them, so a second request in one test was still holding the first's, including props the route it had moved to does not share at all. Every non-Octane request gets a fresh application; this is that.
- `useTeamSwitch.test.ts` is new; `useTeamPresence.test.ts` now asserts the bounded `only` that was the regression; `reloadProps.test.ts` covers the three new sets and its no-second-copy guard picks them up automatically.
- A browser test proves a teammate's rename reaches the other member's **sidebar row**, not just the masthead — the half this change makes load-bearing. I checked it fails when the reload stops naming the roster.
- Gates green: `composer test` at **Total: 100.0 %** (3,563 tests), plus lint / format / types / 2,735 Vitest / build, and the full 355-test browser suite.

No user-facing copy changed, so no new translation keys. Nothing operator-facing, so no `docs/` change.

## CodeRabbit

Three findings over three local passes, ending at zero.

Applied: `partialRevisit()` read the component through `viewData()`, which would fail for a reload following another visit rather than a document load — both helpers now share one branch, and the reminder case exercises it. And the `ChannelUpdated` reload spelled `['channel', 'channels']` inline, escaping the no-second-copy guard on a set this PR makes the only path back to the roster.

Declined: taking the truncation off the digests. It is the same trade `currentDevice` and `InstanceFingerprint` already make and the header above is why. A collision needs two consecutive sessions in one browser tab landing on the same 32 bits — for `auth` that is not even enough, since its key carries the payload digest too — and costs one stale preference until the next hard load. The reasoning is now written where the key is built.

It also raised the roster's cross-member staleness, which is the accepted limit above and is now #1269.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788523098&installation_model_id=428379&pr_number=1270&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1270&signature=2fc63283ef526343763f2363c29aa5ab70f18c6f214b397283e93a37a6e523eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->