### PR TITLE
perf: once the third-party-mutable shared props behind aggregate fingerprints

### DIFF
--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -151,11 +151,16 @@ trait HasTeams
     /**
      * Get the user's teams as a collection of UserTeam objects.
      *
+     * The member counts are batched onto the list query rather than counted per
+     * row: every tile carries its workspace's size, and a `count()` per team is
+     * an N+1 that only shows itself on an account with several of them.
+     *
      * @return Collection<int, UserTeam>
      */
     public function toUserTeams(bool $includeCurrent = false): Collection
     {
         return $this->teams()
+            ->withCount('members')
             ->get()
             ->reject(fn (Team $team): bool => ! $includeCurrent && $this->isCurrentTeam($team))
             ->map(fn (Team $team): UserTeam => $this->toUserTeam($team))
@@ -164,6 +169,9 @@ trait HasTeams
 
     /**
      * Get the user's team as a UserTeam object.
+     *
+     * The size is taken off the row when {@see toUserTeams()} has already
+     * batched it there, and counted only for a team handed over on its own.
      */
     public function toUserTeam(Team $team): UserTeam
     {
@@ -176,7 +184,7 @@ trait HasTeams
             isPersonal: $team->is_personal,
             role: $role?->value,
             roleLabel: $role?->label(),
-            membersCount: $team->members()->count(),
+            membersCount: $team->members_count ?? $team->members()->count(),
             isCurrent: $this->isCurrentTeam($team),
         );
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -18,9 +18,11 @@ use App\Support\InstanceFingerprint;
 use App\Support\MessageSearchPanel;
 use App\Support\PendingInvitations;
 use App\Support\ReverbConfig;
+use App\Support\RosterFingerprint;
 use App\Support\TranslationCatalog;
 use App\Support\UpdateChecker;
 use App\Support\UserAgentParser;
+use App\Support\UserWorkspaces;
 use App\Support\WebPushConfig;
 use App\Support\WorkspacePermissions;
 use App\Support\WorkspaceShell;
@@ -71,14 +73,15 @@ class HandleInertiaRequests extends Middleware
      *
      * What is *not* here is the instance's own description — its name, branding,
      * connection details and feature toggles — along with the session facts that
-     * settle at sign-in, and the rosters that move only when the viewer writes.
-     * None of those can change between two clicks on their own, so they are
-     * declared next door in {@see self::shareOnce()} and reach the client once.
+     * settle at sign-in, and every roster: the ones that move when the viewer
+     * writes, and the ones a third party moves behind their back. All of those
+     * have an honest trigger for when they change, so they are declared next
+     * door in {@see self::shareOnce()} and reach the client once per trigger.
      *
      * What is left is the residue that genuinely moves under the viewer while
-     * they read: `unread`, and the member roster whose presence dots follow
-     * other people. Those are recomputed on every navigation, and are the reason
-     * this list is not simply {@see self::shareOnce()}.
+     * they read: `unread`, the affordance flags, and the dock panels' payloads.
+     * Those are recomputed on every navigation, and are the reason this list is
+     * not simply {@see self::shareOnce()}.
      *
      * @see https://inertiajs.com/shared-data
      *
@@ -95,8 +98,6 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
-            'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
-            'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],
             // The dock header's "invite" affordance reuses the member-invite modal,
             // so the current team's invite permission and the assignable roles ride
             // along with every workspace request.
@@ -131,18 +132,6 @@ class HandleInertiaRequests extends Middleware
             // to badge, but the rail still draws its cross-workspace dots, so
             // the per-workspace half is answered there too.
             'unread' => fn (): UnreadDigestData => $shell?->unreadDigest() ?? WorkspaceUnread::digest($user),
-            // The current team's members feed the DM entry points (the sidebar
-            // people picker and the ⌘K "People" group); empty off the workspace.
-            'teamMembers' => fn (): array => $shell?->teamMembers() ?? [],
-            // The current team's custom emoji as a flat name->url map, so message
-            // bodies and reaction pills can resolve `:name:` shortcodes to images.
-            // A revoked emoji is simply absent, so its token falls back to text.
-            'customEmojis' => fn (): array => $shell?->customEmojis() ?? [],
-            // The current team's mentionable user groups, feeding the composer's
-            // `@` menu and the anti-spoof check that decides whether a
-            // `group:<id>` token renders as a pill or as plain text. A deleted
-            // group is simply absent, so its token falls back to text.
-            'userGroups' => fn (): array => $shell?->userGroups() ?? [],
             // The Threads panel's inbox and its "Unread" tally, present only while
             // the dock actually has that destination pinned.
             ...$shell?->threadsPanelProps($pinned, ThreadInboxFilter::fromQuery($request->query('filter'))) ?? [],
@@ -165,7 +154,7 @@ class HandleInertiaRequests extends Middleware
      * on an ordinary navigation; that is why the two that read the filesystem
      * and parse a user agent are closures rather than eager values.
      *
-     * Five groups, distinguished only by what their key is made of:
+     * Six groups, distinguished only by what their key is made of:
      *
      * 1. **Instance config**, behind one shared {@see InstanceFingerprint}. The
      *    key is the same digest for all of them because they change together.
@@ -176,9 +165,14 @@ class HandleInertiaRequests extends Middleware
      *    prompt their registration queued.
      * 4. **Viewer-keyed** — `auth`, `collapsedChannelSections` and
      *    `frequentEmojis`, which change when the viewer themselves writes.
-     * 5. **Workspace-keyed** — the four rosters whose answer is one team's.
-     *    Absent off a workspace route rather than empty, for the reason given
-     *    on the group itself.
+     * 5. **Workspace-keyed** — the rosters whose answer is one team's. Absent
+     *    off a workspace route rather than empty, for the reason given on the
+     *    group itself.
+     * 6. **Fingerprinted** — the rosters a *third party* moves: the workspace
+     *    list here, and `teamMembers` / `customEmojis` / `userGroups` in group
+     *    5. Their key carries an aggregate over their own source rows, so the
+     *    trigger is the change itself rather than anyone remembering to name
+     *    them (#1253); see {@see RosterFingerprint}.
      *
      * Groups 4 and 5 are the ones with no key-shaped trigger at all: nothing
      * about a clock, a config value or a session says when a channel was
@@ -186,6 +180,8 @@ class HandleInertiaRequests extends Middleware
      * after that write, since the exclusion below is bypassed on partial
      * requests — the sets in `resources/js/lib/reloadProps.ts` are the
      * invalidation, and adding a prop here means checking it has one (#1252).
+     * Group 6 is what is left once that runs out: a roster nobody in this
+     * browser wrote, so nothing in this browser reloads it.
      *
      * Every key carries its own discriminator because the **client stores once
      * props by key and restores them by prop path**: two props sharing one key
@@ -195,8 +191,11 @@ class HandleInertiaRequests extends Middleware
      *
      * That same property is why a key may never come back round to a value the
      * prop path no longer holds — it would restore the other one. Which is what
-     * the viewer and workspace discriminators are for, and why the four rosters
-     * are absent off a workspace route rather than shipped empty.
+     * the viewer and workspace discriminators are for, and why the workspace
+     * rosters are absent off a workspace route rather than shipped empty. A
+     * fingerprinted key is the one exception, and safely so: it is a digest of
+     * the answer, so coming back round to it is coming back round to the value
+     * the client is holding under it.
      *
      * @see https://inertiajs.com/shared-data
      *
@@ -214,6 +213,12 @@ class HandleInertiaRequests extends Middleware
         $activeChannel = $boundChannel instanceof Channel ? $boundChannel : null;
         $viewer = $this->viewerFingerprint($request);
         $sessionless = ! $request->hasSession();
+        $workspaces = UserWorkspaces::forRequest($request);
+        // One digest for the pair: they are two readings of one list, so a
+        // change to it has to move both keys or the rail and the sheet would
+        // disagree about the same workspace. The locale rides along because
+        // `roleLabel` is translated server-side, exactly as `invitableRoles` is.
+        $workspaceList = $viewer.':workspaces:'.$locale.':'.$workspaces->fingerprint();
 
         return [
             'name' => Inertia::once(fn (): string => (string) config('app.name'))->as($instance.':name'),
@@ -423,6 +428,22 @@ class HandleInertiaRequests extends Middleware
             'frequentEmojis' => Inertia::once(fn (): array => FrequentEmoji::forUser($user))
                 ->as($viewer.':frequentEmojis:'.($user?->currentTeam?->getKey() ?? 'none'))
                 ->fresh($sessionless),
+            // Every workspace the viewer belongs to, and which of them they are
+            // standing in — the rail's tiles, the workspace sheet's rows, and
+            // the workspace named on every settings page. Shared everywhere
+            // rather than only inside the workspace for that last reason: there
+            // is one honest answer, so there is one value per prop path.
+            //
+            // The first pair keyed on something nobody in this browser did. A
+            // teammate joining moves a member count the viewer is looking at,
+            // and no write of theirs fires to say so — so the key is a digest
+            // of the list itself, over one indexed aggregate rather than the
+            // list it stands for. Both halves come off one derivation, which is
+            // also what stops the current workspace being counted twice.
+            'teams' => Inertia::once($workspaces->all(...))->as($workspaceList.':teams')->fresh($sessionless),
+            'currentTeam' => Inertia::once($workspaces->current(...))
+                ->as($workspaceList.':currentTeam')
+                ->fresh($sessionless),
             // The workspace's own rosters. Absent off a workspace route rather
             // than empty: a once prop has one value per prop path for the life
             // of the page, so an empty roster shipped from a settings page would
@@ -454,6 +475,18 @@ class HandleInertiaRequests extends Middleware
      * rather than the next click, which is the one thing this child knowingly
      * gives up; closing it needs broadcasts the server does not send yet.
      *
+     * The last three are the ones a third party moves outright, and they are
+     * keyed on a digest of their own source rows instead (#1253) — including
+     * `teamMembers`, the largest shared prop there is: a 300-member workspace
+     * used to re-serialise tens of kilobytes of roster on every click for an
+     * answer that had not changed. What that key deliberately does not reach is
+     * a *clock*: a
+     * teammate's quiet hours opening writes no row, so the do-not-disturb badge
+     * now follows `BroadcastDndScheduleEdges`' announcement rather than the
+     * next navigation, and lands on the next hard load without one. Everything
+     * else about a member — a lapsed status, a cleared pause, an avatar — is a
+     * write, and a write moves the digest.
+     *
      * @return array<string, mixed>
      */
     protected function workspaceProps(WorkspaceShell $shell, string $viewer, ?Channel $activeChannel): array
@@ -480,6 +513,24 @@ class HandleInertiaRequests extends Middleware
             // lands, which is a partial request and so reaches the client.
             'firedReminders' => Inertia::once(fn (): array => $shell->reminders(MessageReminderStatus::Fired))
                 ->as($workspace.':firedReminders'),
+            // The workspace's members, feeding the DM entry points (the sidebar
+            // people picker and the ⌘K "People" group) and the presence dots.
+            // The expensive one, and the reason this group exists at all.
+            'teamMembers' => Inertia::once($shell->teamMembers(...))
+                ->as($workspace.':teamMembers:'.$shell->teamMembersFingerprint()),
+            // The workspace's custom emoji as a flat name->url map, so message
+            // bodies and reaction pills can resolve `:name:` shortcodes to
+            // images. A revoked emoji is simply absent, so its token falls back
+            // to text — which is why the count is in the key: a revocation moves
+            // no timestamp forward.
+            'customEmojis' => Inertia::once($shell->customEmojis(...))
+                ->as($workspace.':customEmojis:'.$shell->customEmojisFingerprint()),
+            // The workspace's mentionable user groups, feeding the composer's
+            // `@` menu and the anti-spoof check that decides whether a
+            // `group:<id>` token renders as a pill or as plain text. A deleted
+            // group is simply absent, so its token falls back to text.
+            'userGroups' => Inertia::once($shell->userGroups(...))
+                ->as($workspace.':userGroups:'.$shell->userGroupsFingerprint()),
         ];
     }
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, TeamInvitation> $invitations
  * @property-read Collection<int, Membership> $memberships
  * @property-read Collection<int, User> $members
+ * @property-read int|null $members_count
  * @property-read Collection<int, Channel> $channels
  * @property-read Collection<int, CustomEmoji> $customEmojis
  * @property-read Collection<int, UserGroup> $userGroups

--- a/app/Support/RosterFingerprint.php
+++ b/app/Support/RosterFingerprint.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A short digest of the rows a roster is built from, used as the invalidation
+ * key that roster is shared under.
+ *
+ * The counterpart to {@see InstanceFingerprint}, for the props no viewer write
+ * moves. An instance constant changes when the operator edits `.env`; a roster
+ * changes when *somebody else* joins, leaves, uploads an emoji or renames a
+ * workspace — so there is no write of the viewer's to hang the invalidation on,
+ * and for `customEmojis` and `userGroups` no invalidation trigger existed at
+ * all: every consumer of them is read-only. Their trigger is this.
+ *
+ * **Push for latency, fingerprint for correctness.** Where an Echo event exists
+ * it still fires a targeted partial reload for an instant refresh, and that is
+ * strictly faster than waiting for a navigation. What the fingerprint adds is
+ * that a *missed* event self-heals on the very next one — which is what keeps
+ * Echo non-load-bearing on a self-hosted instance, where Reverb is the piece
+ * most likely to be misconfigured and a member who joined must not be missing
+ * until someone thinks to hard-reload.
+ *
+ * Three properties are deliberate:
+ *
+ * 1. **An aggregate, never a hydrate.** Each reading below is one indexed
+ *    `count(*)` plus a summed write clock over rows the database never hands
+ *    back. At 300 members that is one aggregate replacing a 300-row hydrate and
+ *    tens of kilobytes of serialised roster, on every click.
+ * 2. **Summed rather than newest.** Eloquent persists these columns at second
+ *    resolution, so a `max(updated_at)` is blind to a second write landing in
+ *    the same second as the newest one the client was already answered under —
+ *    a teammate renaming themselves right after another did. Summing the whole
+ *    column instead puts *every* row's write clock in the digest, so any one of
+ *    them moving moves the key.
+ * 3. **The count sits beside it.** A deletion moves no clock forward at all, so
+ *    a revoked emoji or a departed member would otherwise be invisible; the
+ *    count is what sees them leave.
+ *
+ * The last property is that each aggregate reaches wherever its prop reads:
+ * `userGroups` carries a membership count that lives on a pivot the group's own
+ * row knows nothing about, and the workspace list carries a member count for
+ * every workspace in it. Both are folded in, because a fingerprint that
+ * under-invalidates is a roster that goes stale and stays stale.
+ *
+ * The keys these compose are {@see HandleInertiaRequests}'s business, as every
+ * other once key is; what lives here is only what the digest is taken over.
+ */
+final class RosterFingerprint
+{
+    /**
+     * How much of each digest is kept.
+     *
+     * Carried in a request header once per prop on every navigation, so its
+     * length is paid continuously while the saving it buys is paid once —
+     * exactly the trade {@see InstanceFingerprint::LENGTH} makes, and the same
+     * thirty-two bits. A collision costs one roster reaching the client on its
+     * next hard load rather than its next click.
+     */
+    private const int LENGTH = 8;
+
+    /**
+     * The workspace's member roster, as `teamMembers` serialises it.
+     *
+     * Two write clocks rather than one, because two different rows move it: a
+     * member editing their profile writes to `users`, and a member joining
+     * writes a membership.
+     */
+    public static function forTeamMembers(Team $team): string
+    {
+        return self::digest(
+            DB::table('team_members')
+                ->join('users', 'users.id', '=', 'team_members.user_id')
+                ->where('team_members.team_id', $team->getKey())
+                ->selectRaw('count(*) as members')
+                ->selectRaw('coalesce(sum(extract(epoch from users.updated_at)), 0) as profiled_at')
+                ->selectRaw('coalesce(sum(extract(epoch from team_members.updated_at)), 0) as joined_at')
+                ->first()
+        );
+    }
+
+    /**
+     * The workspace's custom emoji, as the shortcode map serialises them.
+     */
+    public static function forCustomEmojis(Team $team): string
+    {
+        return self::digest(
+            DB::table('custom_emojis')
+                ->where('team_id', $team->getKey())
+                ->selectRaw('count(*) as emojis')
+                ->selectRaw('coalesce(sum(extract(epoch from updated_at)), 0) as changed_at')
+                ->first()
+        );
+    }
+
+    /**
+     * The workspace's mentionable user groups, including how many people each
+     * holds.
+     *
+     * The membership half is a left join rather than a second reading: adding
+     * someone to a group touches the pivot and nothing else, so a digest over
+     * `user_groups` alone would leave the `@` menu quoting a count that is no
+     * longer true. Groups with no members still have to be counted, hence the
+     * distinct count on the outer side.
+     */
+    public static function forUserGroups(Team $team): string
+    {
+        return self::digest(
+            DB::table('user_groups')
+                ->leftJoin('user_group_user', 'user_group_user.user_group_id', '=', 'user_groups.id')
+                ->where('user_groups.team_id', $team->getKey())
+                ->selectRaw('count(distinct user_groups.id) as groups')
+                ->selectRaw('count(user_group_user.id) as group_members')
+                ->selectRaw('coalesce(sum(extract(epoch from user_groups.updated_at)), 0) as changed_at')
+                ->selectRaw('coalesce(sum(extract(epoch from user_group_user.updated_at)), 0) as joined_at')
+                ->first()
+        );
+    }
+
+    /**
+     * The viewer's workspaces, as the rail's tiles and the workspace sheet list
+     * them.
+     *
+     * Scoped to every membership of every workspace the viewer belongs to,
+     * because each tile carries that workspace's size: someone joining a
+     * workspace the viewer is merely *in* moves a number they are looking at.
+     * Soft-deleted workspaces are excluded to match the relation the prop is
+     * built from, so a deleted one leaves the count as it leaves the list.
+     *
+     * Which workspace is current rides along on its own. It is not a roster
+     * change at all — it is a column on the viewer — and without it a switch
+     * would be answered under the key the client already holds.
+     */
+    public static function forUserTeams(User $user): string
+    {
+        $memberships = DB::table('team_members')
+            ->join('teams', 'teams.id', '=', 'team_members.team_id')
+            ->whereIn('team_members.team_id', fn (Builder $viewers): Builder => $viewers
+                ->select('team_id')
+                ->from('team_members')
+                ->where('user_id', $user->getKey()))
+            ->whereNull('teams.deleted_at')
+            ->selectRaw('count(*) as memberships')
+            ->selectRaw('coalesce(sum(extract(epoch from team_members.updated_at)), 0) as joined_at')
+            ->selectRaw('coalesce(sum(extract(epoch from teams.updated_at)), 0) as changed_at')
+            ->first();
+
+        return self::digest([$memberships, $user->current_team_id]);
+    }
+
+    /**
+     * The digest of one aggregate reading.
+     */
+    private static function digest(mixed $reading): string
+    {
+        return substr(hash('xxh128', (string) json_encode($reading)), 0, self::LENGTH);
+    }
+}

--- a/app/Support/RosterFingerprint.php
+++ b/app/Support/RosterFingerprint.php
@@ -45,6 +45,14 @@ use Illuminate\Support\Facades\DB;
  *    a revoked emoji or a departed member would otherwise be invisible; the
  *    count is what sees them leave.
  *
+ * What second resolution still leaves is one row written *twice* inside a single
+ * second, with a navigation between the two: the column reads the same both
+ * times, so the digest does. Closing that would mean a monotonic revision column
+ * on `users`, `custom_emojis` and `user_groups` and a write path that advances
+ * it — a schema change for a window in which the same row is edited twice a
+ * second, and in which anything else moving in the roster corrects it anyway.
+ * Deliberately not taken.
+ *
  * The last property is that each aggregate reaches wherever its prop reads:
  * `userGroups` carries a membership count that lives on a pivot the group's own
  * row knows nothing about, and the workspace list carries a member count for

--- a/app/Support/UserWorkspaces.php
+++ b/app/Support/UserWorkspaces.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\UserTeam;
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+/**
+ * The workspaces the viewer belongs to, and which of them they are standing in
+ * — the pair the rail's tiles, the workspace sheet and every settings page that
+ * names the current workspace are drawn from.
+ *
+ * It exists because they are one answer, not two. `currentTeam` used to be
+ * derived on its own, which meant the workspace the viewer is in had its role
+ * looked up and its members counted a second time, for a row already sitting in
+ * `teams`. Invisible at one workspace and an N+1 across ten, so the list is
+ * derived once here and the current workspace is read *out of* it.
+ *
+ * Derived lazily and at most once per instance, the shape
+ * {@see WorkspacePermissions} uses: both props are once props keyed on the same
+ * fingerprint, so on an ordinary navigation neither closure runs at all and the
+ * derivation below is never reached.
+ *
+ * The props themselves stay named in {@see HandleInertiaRequests}, which is
+ * glue; what the fingerprint is taken over is {@see RosterFingerprint}'s.
+ */
+final class UserWorkspaces
+{
+    private bool $derived = false;
+
+    /** @var array<int, UserTeam> */
+    private array $workspaces = [];
+
+    public function __construct(private readonly ?User $viewer) {}
+
+    /**
+     * The workspaces of whoever made this request — none at all for a guest.
+     */
+    public static function forRequest(Request $request): self
+    {
+        $user = $request->user();
+
+        return new self($user instanceof User ? $user : null);
+    }
+
+    /**
+     * Every workspace the viewer belongs to, the current one included.
+     *
+     * @return array<int, UserTeam>
+     */
+    public function all(): array
+    {
+        $this->derive();
+
+        return $this->workspaces;
+    }
+
+    /**
+     * The workspace the viewer is standing in, or null when they are in none.
+     *
+     * Read out of the list rather than derived beside it, which is the whole
+     * point of this class: the current workspace is one of the viewer's, so the
+     * list already holds the answer and asking the database again for it is the
+     * duplicate query this removes.
+     */
+    public function current(): ?UserTeam
+    {
+        return collect($this->all())->first(fn (UserTeam $workspace): bool => $workspace->isCurrent === true);
+    }
+
+    /**
+     * The invalidation key the pair is shared under: what the list holds, plus
+     * which of them is current.
+     */
+    public function fingerprint(): string
+    {
+        return $this->viewer instanceof User ? RosterFingerprint::forUserTeams($this->viewer) : 'guest';
+    }
+
+    /**
+     * Build the list, once.
+     */
+    private function derive(): void
+    {
+        if ($this->derived) {
+            return;
+        }
+
+        $this->derived = true;
+        $this->workspaces = $this->viewer?->toUserTeams(includeCurrent: true)->all() ?? [];
+    }
+}

--- a/app/Support/WorkspaceShell.php
+++ b/app/Support/WorkspaceShell.php
@@ -111,6 +111,34 @@ final readonly class WorkspaceShell
     }
 
     /**
+     * The member roster's state, as a once key's discriminator.
+     *
+     * The first of three rosters a *third party* moves, and so the first with
+     * no write of the viewer's to hang an invalidation on. Each is keyed on an
+     * aggregate over the rows its prop is built from, so a teammate joining, an
+     * emoji being revoked or a group being renamed is a different key and the
+     * next navigation ships the roster again — with Reverb switched off.
+     * {@see RosterFingerprint} has what each digest is taken over, and why the
+     * count sits beside the timestamp.
+     */
+    public function teamMembersFingerprint(): string
+    {
+        return RosterFingerprint::forTeamMembers($this->team);
+    }
+
+    /** The custom-emoji vocabulary's state, on the same terms. */
+    public function customEmojisFingerprint(): string
+    {
+        return RosterFingerprint::forCustomEmojis($this->team);
+    }
+
+    /** The mentionable groups' state, memberships included, on the same terms. */
+    public function userGroupsFingerprint(): string
+    {
+        return RosterFingerprint::forUserGroups($this->team);
+    }
+
+    /**
      * The team's members, feeding the DM entry points (the sidebar people picker
      * and the command palette's "People" group). Ordered by name and including the
      * viewer themselves — a self-DM renders as "You".

--- a/resources/js/composables/useLocale.test.ts
+++ b/resources/js/composables/useLocale.test.ts
@@ -47,6 +47,8 @@ describe('useLocale', () => {
                     'slashCommands',
                     'sidebarPositions',
                     'invitableRoles',
+                    'teams',
+                    'currentTeam',
                 ],
             }),
         );

--- a/resources/js/lib/reloadProps.test.ts
+++ b/resources/js/lib/reloadProps.test.ts
@@ -78,12 +78,16 @@ describe('reloadProps', () => {
         // A locale the reader has already used this session is one the client
         // believes it holds, so moving back to it restores the copy of the
         // language they just left unless these are asked for by name (#1251).
+        // The workspace list is here for `roleLabel`, which the server
+        // translates like any other piece of copy (#1253).
         expect(LOCALE_PROPS).toEqual([
             'locale',
             'translations',
             'slashCommands',
             'sidebarPositions',
             'invitableRoles',
+            'teams',
+            'currentTeam',
         ]);
     });
 
@@ -128,7 +132,7 @@ describe('reloadProps', () => {
         [
             'LOCALE_PROPS',
             arrayLiteralOf(
-                /'locale',\s*'translations',\s*'slashCommands',\s*'sidebarPositions',\s*'invitableRoles',?/,
+                /'locale',\s*'translations',\s*'slashCommands',\s*'sidebarPositions',\s*'invitableRoles',\s*'teams',\s*'currentTeam',?/,
             ),
         ],
         ['PIN_PROPS', arrayLiteralOf(/'pins',\s*'pinCount'/)],

--- a/resources/js/lib/reloadProps.ts
+++ b/resources/js/lib/reloadProps.ts
@@ -122,6 +122,10 @@ export const SCHEDULED_MESSAGE_PROPS: string[] = ['scheduledMessages'];
  * on partial requests. Hence the one write that changes the reader's language
  * asks for these by name; the visit that persists the preference cannot do it
  * on its own, since it is an ordinary visit and subject to the exclusion.
+ *
+ * The workspace list is here for one field of it: `roleLabel` is translated
+ * server-side, so "Owner" and "Propriétaire" are the same prop in two languages
+ * and the round trip above applies to it unchanged (#1253).
  */
 export const LOCALE_PROPS: string[] = [
     'locale',
@@ -129,6 +133,8 @@ export const LOCALE_PROPS: string[] = [
     'slashCommands',
     'sidebarPositions',
     'invitableRoles',
+    'teams',
+    'currentTeam',
 ];
 
 /**

--- a/tests/Feature/Channels/GroupMentionTest.php
+++ b/tests/Feature/Channels/GroupMentionTest.php
@@ -227,13 +227,17 @@ test('the workspace groups ride along on every in-workspace request', function (
         );
 });
 
-test('the shared groups payload is empty off the workspace', function (): void {
+test('the shared groups payload is absent off the workspace', function (): void {
     ['owner' => $owner, 'team' => $team] = teamWithChannel();
     userGroupWith($team, 'dev-team');
 
+    // Absent rather than `[]` since #1253 once'd it: a once prop has one value
+    // per prop path for the life of the page, so an empty list shipped from a
+    // settings page would be the answer a later workspace visit restored. Every
+    // consumer already defaults it.
     $this->actingAs($owner)
         ->get(route('teams.edit', $team))
-        ->assertInertia(fn (Assert $page): Assert => $page->where('userGroups', []));
+        ->assertInertia(fn (Assert $page): Assert => $page->missing('userGroups'));
 });
 
 test('a group mention is unwrapped to its handle for search indexing', function (): void {

--- a/tests/Feature/Channels/TeamMembersPropTest.php
+++ b/tests/Feature/Channels/TeamMembersPropTest.php
@@ -21,9 +21,12 @@ test('the workspace ships the team members for the DM entry points', function ()
 test('the team members prop is absent off the channel workspace', function (): void {
     ['owner' => $owner] = teamWithChannel();
 
+    // Absent rather than `[]` since #1253 once'd it, for the reason every
+    // workspace-keyed once prop is: an empty roster shipped from a settings page
+    // would be the answer a later workspace visit restored.
     $this->actingAs($owner)
         ->get(route('profile.edit'))
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->where('teamMembers', [])
+            ->missing('teamMembers')
         );
 });

--- a/tests/Feature/Channels/ThirdPartyOncePropsTest.php
+++ b/tests/Feature/Channels/ThirdPartyOncePropsTest.php
@@ -1,0 +1,321 @@
+<?php
+
+use App\Enums\AppLocale;
+use App\Models\CustomEmoji;
+use App\Models\UserGroup;
+
+/*
+|--------------------------------------------------------------------------
+| The props a third party mutates (#1253)
+|--------------------------------------------------------------------------
+|
+| The last of the three `once` groups, after the instance constants of #1251
+| and the viewer's own writes of #1252. What is left is the residue neither of
+| those reaches: rosters a *teammate* moves. No write of the viewer's fires, so
+| there is no partial reload to piggyback on, and two of them — `customEmojis`
+| and `userGroups` — have no invalidation trigger at all today, being read-only
+| everywhere they are consumed.
+|
+| Their trigger is therefore built rather than borrowed: each key carries a
+| cheap aggregate fingerprint over the prop's source rows, so a changed roster
+| is a changed key and the next navigation ships it. Where an Echo event exists
+| it still fires a targeted reload for an instant refresh, but the fingerprint
+| underneath is what makes a *missed* event self-heal — which is the whole
+| point on a self-hosted instance, where Reverb is the piece most likely to be
+| misconfigured.
+|
+| Every test here therefore proves the fingerprint alone: the suite runs with
+| `BROADCAST_CONNECTION=null` (pinned below), so nothing an assertion sees can
+| have come from a broadcast.
+|
+| The fingerprints are never asserted directly. A test naming a hash literal
+| asserts the implementation and fails on the next honest refactor, so the
+| claim is always made through the visit: change the source rows, and the prop
+| comes back.
+|
+*/
+
+/**
+ * The rosters whose answer is one workspace's, carried only inside one.
+ *
+ * @var list<string>
+ */
+const TEAM_ONCE_PROPS = [
+    'teamMembers',
+    'customEmojis',
+    'userGroups',
+];
+
+/**
+ * The rosters whose answer is the viewer's, carried on every route — the
+ * workspace switcher draws them from the settings pages too.
+ *
+ * @var list<string>
+ */
+const WORKSPACE_LIST_ONCE_PROPS = [
+    'teams',
+    'currentTeam',
+];
+
+test('the suite proves these props without a broadcaster', function (): void {
+    // The premise of every test below, pinned rather than assumed: an
+    // assertion that a change reached the client can only be about the
+    // fingerprint when there is no connection for an event to have taken.
+    // `BROADCAST_CONNECTION=null` in `phpunit.xml`, which `env()` reads back as
+    // PHP null rather than as the string.
+    expect(config('broadcasting.default'))->toBeNull();
+});
+
+test('a first load carries every third-party-mutable prop', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $page = visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page');
+
+    expect(array_keys($page['props']))
+        ->toContain(...TEAM_ONCE_PROPS)
+        ->toContain(...WORKSPACE_LIST_ONCE_PROPS);
+});
+
+test('a second visit with nothing changed carries none of them', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $props = array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props'));
+
+    expect(array_intersect([...TEAM_ONCE_PROPS, ...WORKSPACE_LIST_ONCE_PROPS], $props))->toBe([]);
+});
+
+test('a partial reload naming one of them still receives it', function (string $prop): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    expect(array_keys((array) partialRevisit($first, workspaceUrl($team), [$prop])->assertOk()->json('props')))
+        ->toContain($prop);
+})->with([...TEAM_ONCE_PROPS, ...WORKSPACE_LIST_ONCE_PROPS]);
+
+test('a member joining reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    teamMemberInChannel($general, ['name' => 'Amy Member']);
+
+    expect(collect((array) revisit($first, workspaceUrl($team))->assertOk()->json('props.teamMembers'))
+        ->pluck('name'))
+        ->toContain('Amy Member');
+});
+
+test('a member leaving reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $leaver = teamMemberInChannel($general, ['name' => 'Amy Member']);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // A deletion moves no write clock forward at all, which is why the count
+    // sits in the key beside it: the departure is only visible as one fewer row.
+    $team->memberships()->where('user_id', $leaver->id)->delete();
+
+    expect(collect((array) revisit($first, workspaceUrl($team))->assertOk()->json('props.teamMembers'))
+        ->pluck('name'))
+        ->not->toContain('Amy Member');
+});
+
+test('a member editing their own profile reaches other clients', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $mate = teamMemberInChannel($general, ['name' => 'Amy Member']);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // Eloquent persists `updated_at` at second resolution, so a rename in the
+    // same second as the row was created leaves the column — and any digest
+    // over it — untouched. That is the fingerprint's real granularity rather
+    // than something the test works around, so the clock moves instead.
+    $this->travel(1)->second();
+
+    $mate->update(['name' => 'Amy Renamed']);
+
+    expect(collect((array) revisit($first, workspaceUrl($team))->assertOk()->json('props.teamMembers'))
+        ->pluck('name'))
+        ->toContain('Amy Renamed');
+});
+
+test('a custom emoji being added reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    CustomEmoji::factory()->for($team)->create(['name' => 'shipit']);
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.customEmojis'))
+        ->toHaveKey('shipit');
+});
+
+test('a custom emoji being revoked reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $emoji = CustomEmoji::factory()->for($team)->create(['name' => 'shipit']);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $emoji->delete();
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.customEmojis'))->toBe([]);
+});
+
+test('a user group being created reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    UserGroup::factory()->for($team)->create(['name' => 'Dev Team', 'slug' => 'dev-team']);
+
+    expect(collect((array) revisit($first, workspaceUrl($team))->assertOk()->json('props.userGroups'))
+        ->pluck('slug'))
+        ->toContain('dev-team');
+});
+
+test('a user group being deleted reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $group = UserGroup::factory()->for($team)->create(['name' => 'Dev Team', 'slug' => 'dev-team']);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    $group->delete();
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.userGroups'))->toBe([]);
+});
+
+test('someone joining a group moves the count the mention menu draws', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $group = UserGroup::factory()->for($team)->create(['name' => 'Dev Team', 'slug' => 'dev-team']);
+    $mate = teamMemberInChannel($general);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // The group's own row does not move when its membership does, so the
+    // fingerprint reaches through to the pivot: `membersCount` is on the prop.
+    $group->members()->attach($mate->id);
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.userGroups.0.membersCount'))
+        ->toBe(1);
+});
+
+test('a workspace being renamed reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // Second resolution again — see the profile rename above.
+    $this->travel(1)->second();
+
+    $team->update(['name' => 'Acme Renamed']);
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.currentTeam.name'))
+        ->toBe('Acme Renamed');
+});
+
+test('someone joining the workspace moves the size the switcher draws', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    teamMemberInChannel($general);
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.currentTeam.membersCount'))
+        ->toBe(2);
+});
+
+test('joining another workspace reaches the next navigation', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+    ['team' => $other, 'channel' => $otherGeneral] = teamWithChannel('Globex');
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    joinTeamAndChannel($otherGeneral, $viewer);
+
+    expect(collect((array) revisit($first, workspaceUrl($team))->assertOk()->json('props.teams'))
+        ->pluck('name'))
+        ->toContain($other->name);
+});
+
+test('the workspace rosters are absent off a workspace route', function (): void {
+    ['owner' => $viewer] = teamWithChannel();
+
+    $props = (array) $this->actingAs($viewer)->get(route('profile.edit'))->assertOk()->viewData('page')['props'];
+
+    // Absent rather than empty, for the reason the rosters of #1252 are: a once
+    // prop has one value per prop path for the life of the page, so an empty
+    // roster shipped from a settings page would be the answer a later workspace
+    // visit restored. Every consumer already defaults it.
+    expect(array_intersect(TEAM_ONCE_PROPS, array_keys($props)))->toBe([]);
+});
+
+test('the workspace list is carried off a workspace route too', function (): void {
+    ['owner' => $viewer] = teamWithChannel();
+
+    $props = (array) $this->actingAs($viewer)->get(route('profile.edit'))->assertOk()->viewData('page')['props'];
+
+    // Unlike the three above, these are the viewer's own list rather than one
+    // workspace's, and the settings pages draw them — so there is one honest
+    // answer everywhere and it is shared everywhere.
+    expect(array_keys($props))->toContain(...WORKSPACE_LIST_ONCE_PROPS);
+});
+
+test('switching workspace reships the list under its new standing', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+    ['team' => $other, 'channel' => $otherGeneral] = teamWithChannel('Globex');
+    joinTeamAndChannel($otherGeneral, $viewer);
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // Which workspace is current is not a roster change at all, so it rides the
+    // key in its own right: without it the switch would be excluded under the
+    // key the client already holds and the rail would keep its old tile lit.
+    $viewer->switchTeam($other);
+
+    expect(revisit($first, workspaceUrl($other))->assertOk()->json('props.currentTeam.slug'))
+        ->toBe($other->slug);
+});
+
+test('a guest is answered under a key the account that signs in does not hold', function (): void {
+    $page = (array) $this->get(route('login'))->assertOk()->viewData('page');
+
+    expect($page['props']['teams'])->toBe([])
+        ->and($page['props']['currentTeam'])->toBeNull();
+});
+
+test('the workspace list follows the language it is labelled in', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+
+    $first = visitWorkspaceAs($viewer, $team)->assertOk();
+
+    // `roleLabel` is translated server-side, so the language the viewer reads in
+    // is part of the answer — the same reason `invitableRoles` carries it. Going
+    // *back* to a language the client has already been answered in is what
+    // `LOCALE_PROPS` names these for; the key alone only answers moving to a new
+    // one.
+    $viewer->update(['locale' => AppLocale::French->value]);
+
+    expect(revisit($first, workspaceUrl($team))->assertOk()->json('props.currentTeam.roleLabel'))
+        ->toBe('Propriétaire');
+});
+
+test('the current workspace is read out of the list rather than beside it', function (): void {
+    ['owner' => $viewer, 'team' => $team] = teamWithChannel();
+    ['team' => $other, 'channel' => $otherGeneral] = teamWithChannel('Globex');
+    joinTeamAndChannel($otherGeneral, $viewer);
+
+    $props = (array) visitWorkspaceAs($viewer, $team)->assertOk()->viewData('page')['props'];
+
+    // One derivation feeding both props, which is what stops the current
+    // workspace having its role looked up and its members counted a second
+    // time for a row already sitting in `teams`.
+    expect($props['currentTeam']->id)->toBe($team->id)
+        ->and(collect($props['teams'])->pluck('id'))->toContain($team->id, $other->id);
+});

--- a/tests/Feature/Channels/ViewerOncePropsTest.php
+++ b/tests/Feature/Channels/ViewerOncePropsTest.php
@@ -84,10 +84,11 @@ test('a second visit still carries what an ordinary navigation owes', function (
 
     $first = visitWorkspaceAs($viewer, $team)->assertOk();
 
-    // What is left is the genuinely volatile half: what the viewer has not
-    // read, and the roster whose presence dots move without any write of theirs.
+    // What is left is the genuinely volatile half: what the viewer has not read.
+    // `teamMembers` was here until #1253 keyed it on a digest of the roster
+    // itself, which is the last group to leave this list.
     expect(array_keys((array) revisit($first, workspaceUrl($team))->assertOk()->json('props')))
-        ->toContain('errors', 'unread', 'teamMembers');
+        ->toContain('errors', 'unread');
 });
 
 test('a partial reload naming a set receives it', function (string $prop): void {

--- a/tests/Integration/Http/SharedPropsQueryCountTest.php
+++ b/tests/Integration/Http/SharedPropsQueryCountTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\UserWorkspaces;
+use App\Support\WorkspaceShell;
+use Illuminate\Support\Facades\DB;
+
+/*
+|--------------------------------------------------------------------------
+| What the fingerprints cost (#1253)
+|--------------------------------------------------------------------------
+|
+| The last `once` group buys its correctness with a key, and a key has to be
+| computed on every navigation — including the ones where it turns out to match
+| and nothing ships. So the whole trade rests on that computation being an
+| indexed aggregate rather than a hydrate, and nothing enforces that but a test
+| that counts: this is the shared props' equivalent of
+| `SidebarChannelsQueryCountTest` for the sidebar.
+|
+| Both pins below are constants rather than comparisons against a baseline, so
+| a regression that adds a query whatever the workspace's size is caught as
+| well as one that scales with it.
+|
+*/
+
+/**
+ * One aggregate per fingerprinted prop group: the member roster, the custom
+ * emoji, the user groups, and the viewer's workspace list.
+ *
+ * Every one is a `count(*)` and a summed write clock over rows the database
+ * never hands back, so this number is the whole per-navigation cost of the
+ * group — the roster's hydrate and its payload having gone with it.
+ */
+const SHARED_PROP_FINGERPRINT_BUDGET = 4;
+
+/**
+ * Compute every key the fingerprinted props are shared under, and report the
+ * queries it took.
+ */
+function fingerprintQueries(User $viewer, Team $team): int
+{
+    $shell = new WorkspaceShell($viewer, $team);
+    $workspaces = new UserWorkspaces($viewer);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $shell->teamMembersFingerprint();
+    $shell->customEmojisFingerprint();
+    $shell->userGroupsFingerprint();
+    $workspaces->fingerprint();
+
+    $queries = count(DB::connection()->getQueryLog());
+
+    DB::connection()->disableQueryLog();
+
+    return $queries;
+}
+
+/**
+ * Draw both halves of the workspace list — every workspace, and which of them
+ * is current — and report the queries it took.
+ */
+function workspaceListQueries(User $viewer): int
+{
+    $workspaces = new UserWorkspaces($viewer);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $workspaces->all();
+    $workspaces->current();
+
+    $queries = count(DB::connection()->getQueryLog());
+
+    DB::connection()->disableQueryLog();
+
+    return $queries;
+}
+
+it('keys every fingerprinted prop off one aggregate each, whatever the workspace holds', function (): void {
+    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $small = fingerprintQueries($viewer, $team);
+
+    collect(range(1, 8))->each(fn (): User => teamMemberInChannel($general));
+
+    $large = fingerprintQueries($viewer, $team);
+
+    expect($small)->toBe(SHARED_PROP_FINGERPRINT_BUDGET)
+        ->and($large)->toBe(SHARED_PROP_FINGERPRINT_BUDGET);
+});
+
+it('counts the members of each workspace once, and the current one no more than the rest', function (): void {
+    $viewer = User::factory()->create();
+
+    // One workspace: the list query and the viewer's standing in it. Its size
+    // and that standing used to be resolved twice over — once for `teams` and
+    // again for `currentTeam` — which is invisible here and an N+1 below.
+    expect(workspaceListQueries($viewer->fresh()))->toBe(2);
+
+    collect(range(1, 4))->each(function () use ($viewer): void {
+        Team::factory()->create()->members()->attach($viewer, ['role' => TeamRole::Member->value]);
+    });
+
+    // Four more workspaces cost four more role lookups and nothing else: the
+    // member counts ride the list query rather than costing one each, and the
+    // current workspace is still read out of the list rather than asked for.
+    expect(workspaceListQueries($viewer->fresh()))->toBe(6);
+});


### PR DESCRIPTION
Closes #1253.

The last of the three `once` groups, after the instance constants of #1251 and the viewer's own writes of #1252. What is left is the residue neither reaches: rosters a **third party** moves. No write of the viewer's fires, so there is no partial reload to piggyback on, and `customEmojis` and `userGroups` had no invalidation trigger at all — every consumer of them is read-only.

## What changes

`teamMembers`, `customEmojis`, `userGroups`, `teams` and `currentTeam` become `once` props, each keyed on a cheap aggregate fingerprint over its own source rows (`App\Support\RosterFingerprint`). Key differs → the prop reships; key matches → it is excluded before its closure runs.

**Push for latency, fingerprint for correctness.** Where an Echo event exists it still fires its targeted reload for an instant refresh. What the fingerprint adds is that a *missed* event self-heals on the very next navigation, which is what keeps Reverb non-load-bearing on a self-hosted instance.

Two decisions the issue did not spell out:

- **The write clock is `sum(extract(epoch from updated_at))`, not `max`.** Eloquent persists these columns at second resolution, so a `max` is blind to a second row being written in the same second as the newest one the client was already answered under — a teammate renaming themselves right after another did. Summing puts *every* row's clock in the digest. The count sits beside it because a deletion moves no clock forward at all. What is still open — one row written *twice* inside a single second, with a navigation between — is documented on the class and deliberately not closed; closing it needs a monotonic revision column on `users`, `custom_emojis` and `user_groups`.
- **`teams`/`currentTeam` carry the locale in their key and join `LOCALE_PROPS`.** `roleLabel` is translated server-side, so without it an `en → fr → en` round trip would restore the language the reader just left, exactly as it would for `invitableRoles`.

`teamMembers`, `customEmojis` and `userGroups` are now **absent** off a workspace route rather than `[]`, for the reason every workspace-keyed once prop is: an empty roster shipped from a settings page would be the answer a later workspace visit restored. Every consumer already defaults them. `teams`/`currentTeam` stay shared everywhere — the settings pages draw them.

### The N+1 in the same prop group

`toUserTeam` ran `$team->members()->count()` per team, and `currentTeam` ran it a second time for a team already in `teams`. The counts are now batched onto the list query (`withCount('members')`), and `currentTeam` is read *out of* the list rather than derived beside it — `App\Support\UserWorkspaces` owns that one derivation, in the shape `WorkspacePermissions` uses.

## Numbers

Measured through a real Inertia second visit on a 300-member workspace, before and after:

| | before | after |
|---|---|---|
| shared + page props on a second channel visit | 139,705 B | 96,637 B |
| queries on that visit | 40 | 34 |

−43,068 bytes (−31%) and −6 queries per navigation. Byte figures are exact; no time number.

**Fingerprint cost: 4 queries**, one indexed aggregate per prop group (member roster, custom emoji, user groups, workspace list), pinned by `tests/Integration/Http/SharedPropsQueryCountTest.php` as a constant so a regression that adds a query at *any* workspace size is caught. The workspace list itself is now 1 query + one role lookup per workspace, pinned at 2 for one workspace and 6 for five.

## Testing

`tests/Feature/Channels/ThirdPartyOncePropsTest.php` drives the seam the props actually live on — the Inertia HTTP visit — and never asserts a hash literal: every claim is made by changing the source rows and checking the prop comes back. The suite runs with `BROADCAST_CONNECTION=null`, pinned in the file, so nothing an assertion sees can have come from a broadcast.

- a second visit with nothing changed carries none of them
- a member joining, leaving, or editing their own profile; an emoji added or revoked; a group created, deleted, or joined; a workspace renamed, joined, or switched to — each reaches the next navigation
- existing partial reloads naming any of them still receive it
- the workspace list follows the language it is labelled in

The two rename tests move the clock a second first, because that *is* the fingerprint's granularity rather than something being worked around.

Full gate green at 100% coverage; frontend lint/format/types/vitest/build green. No user-facing copy and no operator-facing change, so no `lang/fr.json` or `docs/` update.

## Knowingly given up

A teammate's quiet-hours window *opening* writes no row, so the do-not-disturb badge now follows `BroadcastDndScheduleEdges`' per-minute announcement rather than the next navigation, and lands on the next hard load without one. Everything else about a member — a lapsed status, a cleared pause, an avatar — is a write, and a write moves the digest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788530576&installation_model_id=428379&pr_number=1271&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1271&signature=a4e805c827b2ef69f4a6722dd221603ff13230f0fdb388c63ddacabe6608a5ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->