### PR TITLE
perf: ship the channel's bot members instead of the whole roster twice

### DIFF
--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -103,7 +103,7 @@ class ChannelController extends Controller
     {
         Gate::authorize('view', $channel);
 
-        $page = new ChannelPage($channel, $request->user(), $team);
+        $page = new ChannelPage($channel, $request->user());
 
         $window = new ChannelTimelineWindow(
             channel: $channel,
@@ -155,9 +155,12 @@ class ChannelController extends Controller
             // The viewer's own pending scheduled messages, feeding the composer's
             // "Scheduled" affordance.
             'scheduledMessages' => $page->scheduledMessages(),
-            // Feeds both the masthead member facepile and the composer's @mention
-            // autocomplete.
-            'members' => $page->roster(),
+            // The one part of the channel's roster no other prop in this response
+            // carries. The masthead facepile and the composer's @mention
+            // autocomplete read the whole roster, which the client composes from
+            // the shell's `teamMembers` (or, for a DM, `channel.dmParticipants`)
+            // and these.
+            'botMembers' => $page->botMembers(),
             // Read pointers of the channel's other members who share read receipts,
             // seeding the "Seen by" affordance at open; later advances arrive via the
             // MessageRead broadcast.

--- a/app/Support/ChannelPage.php
+++ b/app/Support/ChannelPage.php
@@ -15,14 +15,14 @@ use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\Message;
 use App\Models\MessagePin;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 
 /**
  * Everything a channel page renders that is not its timeline: the channel
  * itself, the viewer's standing in it, the controls they may reach for, the
- * pins, the roster, the read receipts and the composer's pending schedules.
+ * pins, the channel's own bots, the read receipts and the composer's pending
+ * schedules.
  *
  * It is the other half of ADR-0004. That decision moved the *window* — where a
  * channel's initial page of messages opens — out of {@see ChannelController::show()}
@@ -32,8 +32,8 @@ use Illuminate\Support\Facades\Gate;
  *
  * Two properties, the same two {@see WorkspaceShell} has:
  *
- * 1. **No request.** The constructor takes a channel, a viewer and a team, so
- *    every reading below is reachable from a test without an HTTP round-trip.
+ * 1. **No request.** The constructor takes a channel and a viewer, so every
+ *    reading below is reachable from a test without an HTTP round-trip.
  *    The window is *not* built here and is not a collaborator of this: it reads
  *    `?message=` and `?thread=`, and a read-model that knows about query strings
  *    is the friction this shape exists to avoid. The controller holds both.
@@ -55,7 +55,6 @@ final class ChannelPage
     public function __construct(
         private readonly Channel $channel,
         private readonly User $viewer,
-        private readonly Team $team,
     ) {}
 
     /**
@@ -183,30 +182,36 @@ final class ChannelPage
     }
 
     /**
-     * The people the page may name: the masthead's member facepile and the
-     * composer's `@mention` autocomplete.
+     * The only people the page adds to the ones the visit already carries: the
+     * channel's own bots.
      *
-     * A standard channel is team-scoped — you may mention anyone on the team —
-     * plus the channel's own bots, which appear in the roster (badged) but are
-     * filtered out of mention autocomplete client side (a bot has no inbox to
-     * reach). A direct message is scoped to its own participants, since
-     * mentioning someone who isn't in the conversation would never reach them
-     * (this generalizes to group DMs).
+     * The roster behind the masthead facepile and the composer's `@mention`
+     * autocomplete used to ship whole from here, which made it byte-identical to
+     * the shell's `teamMembers` on every standard channel — the same team
+     * serialised twice in one response (#1254). So the page ships the delta and
+     * the client composes: a standard channel is team-scoped (you may mention
+     * anyone on the team) plus these bots, which are channel members rather than
+     * team members and so appear in no other prop; a direct message is scoped to
+     * its own participants, which already ride `channel.dmParticipants`, and so
+     * adds nothing at all.
+     *
+     * Bots appear in the roster (badged) but are filtered out of mention
+     * autocomplete client side, a bot having no inbox to reach.
      *
      * @return array<int, UserData>
      */
-    public function roster(): array
+    public function botMembers(): array
     {
-        $roster = $this->channel->isDirectMessage()
-            ? $this->channel->members()->orderBy('name')->get()
-            : $this->team->members()->orderBy('name')->get()->concat(
-                $this->channel->members()
-                    ->where('users.type', UserType::Bot->value)
-                    ->orderBy('name')
-                    ->get()
-            );
+        if ($this->channel->isDirectMessage()) {
+            return [];
+        }
 
-        return UserData::collect($roster, 'array');
+        $bots = $this->channel->members()
+            ->where('users.type', UserType::Bot->value)
+            ->orderBy('name')
+            ->get();
+
+        return UserData::collect($bots, 'array');
     }
 
     /**

--- a/resources/js/composables/useChannelIdentity.ts
+++ b/resources/js/composables/useChannelIdentity.ts
@@ -2,13 +2,17 @@ import { usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import type { ComputedRef } from 'vue';
 import { useTranslations } from '@/composables/useTranslations';
+import { channelRoster } from '@/lib/channelRoster';
 import { groupDmMastheadName } from '@/lib/groupDm';
 import type { Channel, Mention, RosterMember } from '@/types';
 
 export interface ChannelIdentityOptions {
     channel: () => Channel;
-    /** The channel's members, as the roster and the mention menu see them. */
-    members: () => RosterMember[];
+    /**
+     * The channel's own bots — the only part of its roster the page ships, the
+     * rest being composed from props the visit already carries.
+     */
+    botMembers: () => RosterMember[];
     /** Whether the viewer belongs to the channel. */
     isMember: () => boolean;
 }
@@ -30,6 +34,8 @@ export interface ChannelIdentity {
     composerPlaceholder: ComputedRef<string | undefined>;
     /** Whether the viewer may delete anyone's message here (a team Admin+). */
     canModerate: ComputedRef<boolean>;
+    /** Everyone in the channel, as the masthead facepile draws them. */
+    members: ComputedRef<RosterMember[]>;
     /** The members the composer offers for `@`. */
     mentionableMembers: ComputedRef<RosterMember[]>;
     /** Whether the channel has a bot member. */
@@ -38,7 +44,10 @@ export interface ChannelIdentity {
 
 /**
  * How the open channel reads to this viewer: its name, its composer
- * placeholder, who they may mention, and what they are allowed to do in it.
+ * placeholder, who is in it, who they may mention, and what they are allowed to
+ * do in it.
+ *
+ * The roster is composed here rather than shipped: see {@link channelRoster}.
  *
  * A direct message renders viewer-relative: no "#", the other participant's
  * name (the viewer's own self-DM reads "You"), or a group's participant-joined
@@ -103,21 +112,28 @@ export function useChannelIdentity(
         ['admin', 'owner'].includes(page.props.currentTeam?.role ?? ''),
     );
 
+    const members = computed(() =>
+        channelRoster({
+            channel: options.channel(),
+            teamMembers: page.props.teamMembers ?? [],
+            botMembers: options.botMembers(),
+            viewerId: currentUser.value.id,
+        }),
+    );
+
     // You can't @mention yourself, and bots have no inbox to reach, so drop the
     // current user and any bots from the composer list — the roster facepile still
     // shows the bots.
     const mentionableMembers = computed(() =>
-        options
-            .members()
-            .filter(
-                (member) => member.id !== currentUser.value.id && !member.isBot,
-            ),
+        members.value.filter(
+            (member) => member.id !== currentUser.value.id && !member.isBot,
+        ),
     );
 
     // Whether this channel has a bot member, so the composer's mention menu can
     // note once, quietly, why bots aren't mentionable.
     const channelHasBots = computed(() =>
-        options.members().some((member) => member.isBot),
+        members.value.some((member) => member.isBot),
     );
 
     return {
@@ -128,6 +144,7 @@ export function useChannelIdentity(
         canAddPeople,
         composerPlaceholder,
         canModerate,
+        members,
         mentionableMembers,
         channelHasBots,
     };

--- a/resources/js/lib/channelRoster.test.ts
+++ b/resources/js/lib/channelRoster.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { channelRoster } from '@/lib/channelRoster';
+import type { Channel, RosterMember } from '@/types';
+
+function member(overrides: Partial<RosterMember> = {}): RosterMember {
+    return {
+        id: 'u-1',
+        name: 'Amy Member',
+        avatar: null,
+        isBot: false,
+        status: null,
+        presence: 'active',
+        isDnd: false,
+        ...overrides,
+    };
+}
+
+const viewer = member({ id: 'me', name: 'Zoe Owner' });
+
+function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        isDirect: false,
+        dmParticipants: null,
+        ...overrides,
+    } as Channel;
+}
+
+describe('a standard channel', () => {
+    it('resolves its roster from the shared team roster', () => {
+        const amy = member({ id: 'u-1', name: 'Amy Member' });
+
+        expect(
+            channelRoster({
+                channel: channel(),
+                teamMembers: [amy, viewer],
+                botMembers: [],
+                viewerId: viewer.id,
+            }),
+        ).toEqual([amy, viewer]);
+    });
+
+    it('appends the channel bots the shared roster cannot hold', () => {
+        const bot = member({ id: 'bot-1', name: 'Deploy Bot', isBot: true });
+
+        const roster = channelRoster({
+            channel: channel(),
+            teamMembers: [viewer],
+            botMembers: [bot],
+            viewerId: viewer.id,
+        });
+
+        // Humans first, as the facepile draws them; the bot lands after.
+        expect(roster.map((entry) => entry.id)).toEqual(['me', 'bot-1']);
+        expect(roster[1]?.isBot).toBe(true);
+    });
+});
+
+describe('a direct message', () => {
+    it('resolves its roster from its own participants, not the team roster', () => {
+        const counterpart = member({ id: 'u-1', name: 'Amy Member' });
+        const bystander = member({ id: 'u-2', name: 'Bob Bystander' });
+
+        const roster = channelRoster({
+            channel: channel({
+                isDirect: true,
+                dmParticipants: [counterpart],
+            }),
+            teamMembers: [counterpart, bystander, viewer],
+            botMembers: [],
+            viewerId: viewer.id,
+        });
+
+        expect(roster.map((entry) => entry.name)).toEqual([
+            'Amy Member',
+            'Zoe Owner',
+        ]);
+    });
+
+    it('still names a participant who has left the team', () => {
+        const departed = member({ id: 'u-gone', name: 'Ada Departed' });
+
+        const roster = channelRoster({
+            channel: channel({ isDirect: true, dmParticipants: [departed] }),
+            // The shared roster no longer holds them, which is exactly why the
+            // conversation carries its own participants.
+            teamMembers: [viewer],
+            botMembers: [],
+            viewerId: viewer.id,
+        });
+
+        expect(roster.map((entry) => entry.id)).toEqual(['u-gone', 'me']);
+    });
+
+    it('reads as the viewer alone in their own self-DM', () => {
+        expect(
+            channelRoster({
+                channel: channel({ isDirect: true, dmParticipants: [] }),
+                teamMembers: [viewer],
+                botMembers: [],
+                viewerId: viewer.id,
+            }),
+        ).toEqual([viewer]);
+    });
+
+    it('holds only its participants when the viewer is not on the roster yet', () => {
+        const counterpart = member({ id: 'u-1', name: 'Amy Member' });
+
+        expect(
+            channelRoster({
+                channel: channel({
+                    isDirect: true,
+                    dmParticipants: [counterpart],
+                }),
+                teamMembers: [],
+                botMembers: [],
+                viewerId: viewer.id,
+            }),
+        ).toEqual([counterpart]);
+    });
+});

--- a/resources/js/lib/channelRoster.ts
+++ b/resources/js/lib/channelRoster.ts
@@ -1,0 +1,47 @@
+import type { Channel, RosterMember } from '@/types';
+
+/** What the open channel's roster is composed from. */
+export interface ChannelRosterSources {
+    /** The open channel, for whether it is a DM and who is in it. */
+    channel: Pick<Channel, 'isDirect' | 'dmParticipants'>;
+    /** The workspace roster the shell already holds. */
+    teamMembers: RosterMember[];
+    /** The channel's own bots, the one part of the roster the page ships. */
+    botMembers: RosterMember[];
+    /** The viewer, who is on the team roster and in every DM they can open. */
+    viewerId: string;
+}
+
+/**
+ * The channel's roster, as the masthead facepile and the composer's `@mention`
+ * autocomplete read it — composed on the client rather than serialised again by
+ * the server.
+ *
+ * A standard channel is team-scoped, so its roster is the workspace roster the
+ * shell already holds plus the channel's own bots, which are channel members
+ * rather than team members and so appear in no other prop. A direct message is
+ * scoped to its own participants, which ride the channel itself: composing it
+ * from the team roster instead would drop anyone who has since left the team,
+ * and they are still in the conversation.
+ *
+ * Shipping the whole roster as a page prop made it byte-identical to the shell's
+ * `teamMembers` on every standard channel visit — the same fact serialised twice
+ * in one response (#1254).
+ */
+export function channelRoster(sources: ChannelRosterSources): RosterMember[] {
+    if (!sources.channel.isDirect) {
+        return [...sources.teamMembers, ...sources.botMembers];
+    }
+
+    const viewer = sources.teamMembers.find(
+        (member) => member.id === sources.viewerId,
+    );
+
+    const roster = [...(sources.channel.dmParticipants ?? [])];
+
+    if (viewer !== undefined) {
+        roster.push(viewer);
+    }
+
+    return roster.sort((one, other) => one.name.localeCompare(other.name));
+}

--- a/resources/js/pages/channels/Show.doubles.ts
+++ b/resources/js/pages/channels/Show.doubles.ts
@@ -218,7 +218,7 @@ export function mountShow(
         team: { id: 't1', name: 'Acme', slug: 'acme' },
         channel: channel(),
         messages: messagePage(),
-        members: [],
+        botMembers: [],
         canArchive: true,
         canManagePreferences: true,
         canLeave: true,

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -41,7 +41,12 @@ const props = defineProps<{
     team: { id: string; name: string; slug: string };
     channel: Channel;
     messages: MessagePage;
-    members: RosterMember[];
+    /**
+     * The channel's own bots, the one part of its roster no other prop in the
+     * visit carries. Everyone else is composed from the shared `teamMembers`, or
+     * — in a DM — from the participants on `channel`.
+     */
+    botMembers: RosterMember[];
     canArchive: boolean;
     /** Whether the viewer may delete it (a team Admin+, not #general or a DM). */
     canDelete: boolean;
@@ -115,11 +120,12 @@ const {
     canAddPeople,
     composerPlaceholder,
     canModerate,
+    members,
     mentionableMembers,
     channelHasBots,
 } = useChannelIdentity({
     channel: () => props.channel,
-    members: () => props.members,
+    botMembers: () => props.botMembers,
     isMember: () => props.isMember,
 });
 
@@ -419,7 +425,7 @@ provideMessageActions(
                 ref="header"
                 :team="props.team"
                 :channel="props.channel"
-                :members="props.members"
+                :members="members"
                 :title="mastheadTitle"
                 :can-manage-preferences="props.canManagePreferences"
                 :can-archive="props.canArchive"

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -5,10 +5,10 @@ import type {
     MessageReminder,
     MessageSearchCriteria,
     MessageSearchResult,
+    RosterMember,
     SearchWorkspaceChannel,
     ThreadInboxPage,
 } from '@/types/messages';
-import type { PersonRef } from '@/types/people';
 import type { SidebarPositionOption } from '@/types/sidebar';
 import type {
     DashboardInvitation,
@@ -82,7 +82,13 @@ declare module '@inertiajs/core' {
             channelRestoreWindowDays: number;
             invitableRoles: RoleOption[];
             channels?: Channel[];
-            teamMembers?: PersonRef[];
+            /**
+             * The workspace roster: full user records, which is what lets the
+             * open channel compose its own roster from this rather than be
+             * shipped a second copy of it. The DM pickers narrow it to a
+             * `PersonRef` themselves.
+             */
+            teamMembers?: RosterMember[];
             channelSections?: ChannelSection[];
             customEmojis?: Record<string, string>;
             frequentEmojis?: string[];

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -40,8 +40,10 @@ export type MessageType = App.Enums.MessageType;
 export type Mention = App.Data.MentionData;
 
 /**
- * A member of a channel's roster, as the channel page and the composer's
- * `@mention` autocomplete receive them.
+ * A member of a channel's roster, as the masthead facepile and the composer's
+ * `@mention` autocomplete read them. Composed on the client from the workspace
+ * roster and the channel's own bots rather than shipped whole — see
+ * `lib/channelRoster.ts`.
  *
  * The full user payload rather than a {@link Mention}: the facepile badges bots
  * and the autocomplete drops them, neither of which a mention payload can answer.

--- a/tests/Feature/Bots/BotVisibilityTest.php
+++ b/tests/Feature/Bots/BotVisibilityTest.php
@@ -24,19 +24,20 @@ function botInGeneral(): array
     return [$owner, $team, $bot];
 }
 
-test('a bot appears in the channel member roster, badged, after the humans', function (): void {
+test('a bot is shipped to the channel roster, badged', function (): void {
     [$owner, $team] = botInGeneral();
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
+        // A bot is a channel member and not a team member, so it is the one part
+        // of the roster the visit ships rather than the client composing it from
+        // the workspace roster (#1254). That it lands after the humans, badged
+        // and squared, is the composition's claim — see
+        // `resources/js/lib/channelRoster.test.ts`.
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->has('members', 2)
-            // Humans first (by name), the channel's bot appended and flagged so
-            // the roster can render its badge and squared avatar.
-            ->where('members.0.name', 'Zoe Owner')
-            ->where('members.0.isBot', false)
-            ->where('members.1.name', 'Deploy Bot')
-            ->where('members.1.isBot', true)
+            ->has('botMembers', 1)
+            ->where('botMembers.0.name', 'Deploy Bot')
+            ->where('botMembers.0.isBot', true)
         );
 });
 

--- a/tests/Feature/Channels/ChannelRosterDeltaTest.php
+++ b/tests/Feature/Channels/ChannelRosterDeltaTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelType;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/*
+|--------------------------------------------------------------------------
+| A channel visit serialises the roster once (#1254)
+|--------------------------------------------------------------------------
+|
+| The team's people ride the shell's `teamMembers`; the page adds only what that
+| roster cannot hold — the channel's own bots, which are not team members — and
+| a direct message adds nothing at all, its participants already riding the
+| `channel` prop. The composition back into one roster is the client's, stated
+| in `resources/js/lib/channelRoster.test.ts`.
+|
+*/
+
+/**
+ * A team whose #general has a bot member, plus a second human.
+ *
+ * @return array{User, Team, Channel, User}
+ */
+function teamWithBotInGeneral(): array
+{
+    $owner = User::factory()->create(['name' => 'Zoe Owner']);
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::query()->where('team_id', $team->id)->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+
+    $member = User::factory()->create(['name' => 'Amy Member']);
+    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+
+    $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
+    channelMembership($general, $bot);
+
+    return [$owner, $team, $general, $bot];
+}
+
+test('a standard channel adds only the members the shared roster cannot hold', function (): void {
+    [$owner, $team, $general, $bot] = teamWithBotInGeneral();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('botMembers', 1)
+            ->where('botMembers.0.id', $bot->id)
+            ->where('botMembers.0.name', 'Deploy Bot')
+            ->where('botMembers.0.isBot', true)
+        );
+});
+
+test('no member is serialised twice in a channel visit', function (): void {
+    [$owner, $team, $general] = teamWithBotInGeneral();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(function (Assert $page): void {
+            $props = $page->toArray()['props'];
+
+            $shared = collect($props['teamMembers'])->pluck('id');
+            $delta = collect($props['botMembers'])->pluck('id');
+
+            expect($shared)->not->toBeEmpty()
+                ->and($delta)->not->toBeEmpty()
+                ->and($delta->intersect($shared))->toBeEmpty();
+        });
+});
+
+test('a channel with no bots adds nothing to the shared roster', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    teamMemberInChannel($general, ['name' => 'Amy Member']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page): Assert => $page->where('botMembers', []));
+});
+
+test('a direct message adds no roster, its participants riding the channel prop', function (): void {
+    $owner = User::factory()->create(['name' => 'Zoe Owner']);
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = User::factory()->create(['name' => 'Amy Member']);
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+
+    $this->actingAs($owner)->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $other->id]);
+    $dm = Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->firstOrFail();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]))
+        // The counterpart the client composes the conversation's roster from is
+        // already on the `channel` prop — see MentionMembersPropTest.
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('botMembers', [])
+            ->has('channel.dmParticipants', 1)
+        );
+});

--- a/tests/Feature/Channels/MentionMembersPropTest.php
+++ b/tests/Feature/Channels/MentionMembersPropTest.php
@@ -7,6 +7,17 @@ use App\Models\Channel;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
+/*
+|--------------------------------------------------------------------------
+| Who the composer may offer for `@`, as the visit delivers them
+|--------------------------------------------------------------------------
+|
+| The list itself is composed on the client (`lib/channelRoster.ts`) rather than
+| shipped, so what a visit owes is the *inputs*: the workspace roster for a
+| standard channel, the conversation's own participants for a direct message.
+|
+*/
+
 test('a standard channel ships the whole team for mention autocomplete', function (): void {
     $owner = User::factory()->create(['name' => 'Zoe Owner']);
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -16,9 +27,9 @@ test('a standard channel ships the whole team for mention autocomplete', functio
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->has('members', 2)
-            ->where('members.0.name', 'Amy Member')
-            ->where('members.1.name', 'Zoe Owner')
+            ->has('teamMembers', 2)
+            ->where('teamMembers.0.name', 'Amy Member')
+            ->where('teamMembers.1.name', 'Zoe Owner')
         );
 });
 
@@ -36,9 +47,10 @@ test('a direct message scopes mention autocomplete to its participants', functio
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]))
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->has('members', 2)
-            // Only the two DM participants, ordered by name; the bystander is excluded.
-            ->where('members.0.name', 'Amy Member')
-            ->where('members.1.name', 'Zoe Owner')
+            // Only the viewer's counterpart — the client adds the viewer
+            // themselves; the bystander is not in the conversation and so is not
+            // mentionable in it, whatever the workspace roster holds.
+            ->has('channel.dmParticipants', 1)
+            ->where('channel.dmParticipants.0.name', 'Amy Member')
         );
 });

--- a/tests/Feature/Channels/MentionTest.php
+++ b/tests/Feature/Channels/MentionTest.php
@@ -169,9 +169,11 @@ test('the channel page exposes team members for the composer autocomplete', func
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        // The composer's list is composed on the client from the workspace
+        // roster the shell ships, so that is where the visit carries them.
         ->assertInertia(fn (Assert $page): Assert => $page
-            ->has('members', 2)
-            ->where('members', fn ($members): bool => collect($members)->pluck('name')->contains('Bea Member')
+            ->has('teamMembers', 2)
+            ->where('teamMembers', fn ($members): bool => collect($members)->pluck('name')->contains('Bea Member')
                 && collect($members)->pluck('name')->contains($owner->name))
         );
 });

--- a/tests/Integration/Support/ChannelPageQueryCountTest.php
+++ b/tests/Integration/Support/ChannelPageQueryCountTest.php
@@ -4,7 +4,6 @@ use App\Models\Channel;
 use App\Models\Message;
 use App\Models\MessagePin;
 use App\Models\ScheduledMessage;
-use App\Models\Team;
 use App\Models\User;
 use App\Support\ChannelPage;
 use Database\Factories\ChannelMemberFactory;
@@ -16,7 +15,7 @@ use Illuminate\Support\Facades\DB;
 |--------------------------------------------------------------------------
 |
 | Every reading on `ChannelPage` is a fixed number of queries by construction —
-| the pins, the roster, the receipts and the schedules each cost their own query
+| the pins, the bots, the receipts and the schedules each cost their own query
 | plus their eager loads, whatever they hold. Nothing enforces that but a test
 | that counts, so this is the channel page's equivalent of
 | `SidebarChannelsQueryCountTest` for the sidebar, and of `MessageLoadSetScopeTest`
@@ -30,19 +29,22 @@ use Illuminate\Support\Facades\DB;
 
 /**
  * Everything a channel render asks the database, with nothing on the page:
- * the membership, the capability gates, the member count, the pins, the roster,
- * the receipts, the schedules, and each reading's eager loads.
+ * the membership, the capability gates, the member count, the pins, the
+ * channel's bots, the receipts, the schedules, and each reading's eager loads.
+ *
+ * One lower since #1254: the page no longer reads the team's roster, which the
+ * shell already ships, so the visit both serialises and queries it once.
  */
-const CHANNEL_PAGE_QUERY_BUDGET = 28;
+const CHANNEL_PAGE_QUERY_BUDGET = 27;
 
 /**
  * Draw every prop group the channel page ships and report the queries it took.
  *
  * @return array{queries: int, page: array<string, mixed>}
  */
-function channelPageRender(Channel $channel, User $viewer, Team $team): array
+function channelPageRender(Channel $channel, User $viewer): array
 {
-    $page = new ChannelPage($channel, $viewer, $team);
+    $page = new ChannelPage($channel, $viewer);
 
     DB::connection()->flushQueryLog();
     DB::connection()->enableQueryLog();
@@ -54,7 +56,7 @@ function channelPageRender(Channel $channel, User $viewer, Team $team): array
         'lastReadMessageId' => $page->lastReadMessageId(),
         'memberCount' => $page->memberCount(),
         'pins' => $page->pins(),
-        'roster' => $page->roster(),
+        'botMembers' => $page->botMembers(),
         'readers' => $page->readers(),
         'scheduledMessages' => $page->scheduledMessages(),
     ];
@@ -89,15 +91,15 @@ function fillChannelPage(Channel $channel, User $author, int $times): void
 }
 
 it('renders the channel payload in a constant number of queries however much the page holds', function (): void {
-    ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
+    ['owner' => $viewer, 'channel' => $general] = teamWithChannel();
 
     fillChannelPage($general, $viewer, 2);
 
-    $small = channelPageRender($general, $viewer, $team);
+    $small = channelPageRender($general, $viewer);
 
     fillChannelPage($general, $viewer, 4);
 
-    $large = channelPageRender($general, $viewer, $team);
+    $large = channelPageRender($general, $viewer);
 
     expect($small['queries'])->toBe(CHANNEL_PAGE_QUERY_BUDGET)
         ->and($large['queries'])->toBe(CHANNEL_PAGE_QUERY_BUDGET);

--- a/tests/Integration/Support/ChannelPageTest.php
+++ b/tests/Integration/Support/ChannelPageTest.php
@@ -29,17 +29,17 @@ use Database\Factories\ChannelMemberFactory;
 |
 */
 
-test('the page is constructible from a channel, a viewer and a team alone', function (): void {
+test('the page is constructible from a channel and a viewer alone', function (): void {
     ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
 
-    $page = new ChannelPage($general, $viewer, $team);
+    $page = new ChannelPage($general, $viewer);
 
     expect($page->channel()->slug)->toBe($general->slug)
         ->and($page->isMember())->toBeTrue()
         ->and($page->lastReadMessageId())->toBeNull()
         ->and($page->memberCount())->toBe(1)
         ->and($page->pins())->toBe(['pins' => [], 'pinCount' => 0])
-        ->and(array_column($page->roster(), 'id'))->toBe([$viewer->id])
+        ->and($page->botMembers())->toBe([])
         ->and($page->readers())->toBe([])
         ->and($page->scheduledMessages())->toBe([]);
 });
@@ -58,7 +58,7 @@ test('the channel DTO carries the viewer own membership state without it being w
 
     $channel = Channel::query()->findOrFail($general->id);
 
-    expect(new ChannelPage($channel, $viewer, $team)->channel())
+    expect(new ChannelPage($channel, $viewer)->channel())
         ->muted->toBeTrue()
         ->notificationLevel->toBe(NotificationLevel::Mentions)
         ->draft->toBe('half a thought')
@@ -80,7 +80,7 @@ test('a non-member reading a public channel is not a member and gets the DTO def
     $stranger = User::factory()->create();
     $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
 
-    $page = new ChannelPage($public, $stranger, $team);
+    $page = new ChannelPage($public, $stranger);
 
     expect($page->isMember())->toBeFalse()
         ->and($page->lastReadMessageId())->toBeNull()
@@ -101,7 +101,7 @@ test('the read pointer is the viewer own, as a string the client can compare ids
         fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->state(['last_read_message_id' => $message->id]),
     );
 
-    expect(new ChannelPage($general, $viewer, $team)->lastReadMessageId())->toBe($message->id);
+    expect(new ChannelPage($general, $viewer)->lastReadMessageId())->toBe($message->id);
 });
 
 test('the capabilities are the seven gates the page draws its controls from', function (): void {
@@ -114,7 +114,7 @@ test('the capabilities are the seven gates the page draws its controls from', fu
     $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
     $channel->members()->attach([$owner->id, $member->id]);
 
-    expect(new ChannelPage($channel, $owner, $team)->capabilities())->toBe([
+    expect(new ChannelPage($channel, $owner)->capabilities())->toBe([
         'canArchive' => true,
         'canManagePreferences' => true,
         'canEditChannel' => true,
@@ -126,7 +126,7 @@ test('the capabilities are the seven gates the page draws its controls from', fu
 
     // #general is the protected channel: it cannot be archived, renamed, deleted
     // or left, however senior the viewer is.
-    expect(new ChannelPage($general, $owner, $team)->capabilities())->toBe([
+    expect(new ChannelPage($general, $owner)->capabilities())->toBe([
         'canArchive' => false,
         'canManagePreferences' => true,
         'canEditChannel' => true,
@@ -147,10 +147,10 @@ test('the member count is the humans in the channel, never its bots', function (
     $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
     channelMembership($general, $bot);
 
-    $page = new ChannelPage($general, $viewer, $team);
+    $page = new ChannelPage($general, $viewer);
 
     expect($page->memberCount())->toBe(2)
-        ->and(array_column($page->roster(), 'name'))->toContain('Deploy Bot');
+        ->and(array_column($page->botMembers(), 'name'))->toContain('Deploy Bot');
 });
 
 test('the pins and their count are one reading, most-recently-pinned first', function (): void {
@@ -162,7 +162,7 @@ test('the pins and their count are one reading, most-recently-pinned first', fun
     MessagePin::factory()->for($older)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => now()->subMinute()]);
     MessagePin::factory()->for($newer)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => now()]);
 
-    $pins = new ChannelPage($general, $viewer, $team)->pins();
+    $pins = new ChannelPage($general, $viewer)->pins();
 
     expect($pins['pinCount'])->toBe(2)
         ->and(array_column($pins['pins'], 'id'))->toBe([$newer->id, $older->id])
@@ -183,7 +183,7 @@ test('two pins landing in the same second still list newest first', function ():
     MessagePin::factory()->for($first)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => $pinnedAt]);
     MessagePin::factory()->for($second)->for($general)->for($viewer, 'pinnedBy')->create(['created_at' => $pinnedAt]);
 
-    expect(array_column(new ChannelPage($general, $viewer, $team)->pins()['pins'], 'id'))
+    expect(array_column(new ChannelPage($general, $viewer)->pins()['pins'], 'id'))
         ->toBe([$second->id, $first->id]);
 });
 
@@ -201,7 +201,7 @@ test('a pin whose message has been deleted leaves the panel and the badge togeth
     // panel, which is the disagreement one reading makes impossible.
     $deleted->delete();
 
-    $pins = new ChannelPage($general, $viewer, $team)->pins();
+    $pins = new ChannelPage($general, $viewer)->pins();
 
     expect($pins['pinCount'])->toBe(1)
         ->and(array_column($pins['pins'], 'id'))->toBe([$live->id]);
@@ -214,18 +214,19 @@ test('a pinned message carries its attribution, so the panel renders it like the
     $message = Message::factory()->for($general)->for($viewer)->create(['body' => 'the pinned one']);
     MessagePin::factory()->for($message)->for($general)->for($pinner, 'pinnedBy')->create();
 
-    $pins = new ChannelPage($general, $viewer, $team)->pins();
+    $pins = new ChannelPage($general, $viewer)->pins();
 
     expect($pins['pins'][0]->body)->toBe('the pinned one')
         ->and($pins['pins'][0]->pin?->pinnedBy->name)->toBe('Ada Lovelace');
 });
 
-test('the roster of a standard channel is the whole team plus the channel own bots', function (): void {
+test('a standard channel adds its own bots and nobody else the visit already carries', function (): void {
     ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $viewer->update(['name' => 'Marie Curie']);
 
-    // On the team but not in this channel: still mentionable, so still listed.
-    $elsewhere = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+    // A team member, in this channel: mentionable, and already on the workspace
+    // roster the shell ships, so the page does not name them a second time.
+    teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
     $channel = Channel::factory()->for($team)->create(['created_by' => $viewer->id]);
     $channel->members()->attach($viewer->id);
 
@@ -236,12 +237,11 @@ test('the roster of a standard channel is the whole team plus the channel own bo
     $otherBot = User::factory()->bot($team)->create(['name' => 'Other Bot']);
     channelMembership($general, $otherBot);
 
-    expect(array_column(new ChannelPage($channel, $viewer, $team)->roster(), 'name'))
-        ->toBe(['Ada Lovelace', 'Marie Curie', 'Deploy Bot'])
-        ->and($elsewhere->name)->toBe('Ada Lovelace');
+    expect(array_column(new ChannelPage($channel, $viewer)->botMembers(), 'name'))
+        ->toBe(['Deploy Bot']);
 });
 
-test('the roster of a direct message is its own participants and nobody else', function (): void {
+test('a direct message adds nobody, its participants riding the channel itself', function (): void {
     ['owner' => $viewer, 'team' => $team, 'channel' => $general] = teamWithChannel();
     $viewer->update(['name' => 'Marie Curie']);
 
@@ -249,9 +249,13 @@ test('the roster of a direct message is its own participants and nobody else', f
     teamMemberInChannel($general, ['name' => 'Not In The Conversation']);
 
     $dm = app(OpenDirectMessage::class)->handle($team, $viewer, $other);
+    $page = new ChannelPage($dm, $viewer);
 
-    expect(array_column(new ChannelPage($dm, $viewer, $team)->roster(), 'name'))
-        ->toBe(['Ada Lovelace', 'Marie Curie']);
+    expect($page->botMembers())->toBe([])
+        // The counterpart the client composes the conversation's roster from,
+        // and nobody else.
+        ->and(array_column($page->channel()->dmParticipants ?? [], 'name'))
+        ->toBe(['Ada Lovelace']);
 });
 
 test('the readers are the other members who share read receipts', function (): void {
@@ -275,7 +279,7 @@ test('the readers are the other members who share read receipts', function (): v
         fn (ChannelMemberFactory $factory): ChannelMemberFactory => $factory->state(['last_read_message_id' => $message->id]),
     );
 
-    $readers = new ChannelPage($general, $viewer, $team)->readers();
+    $readers = new ChannelPage($general, $viewer)->readers();
 
     expect($readers)->toHaveCount(1)
         ->and($readers[0]->user->name)->toBe('Ada Lovelace')
@@ -303,7 +307,7 @@ test('the scheduled messages are the viewer own pending ones, soonest first, quo
     ScheduledMessage::factory()->for($general)->for(teamMemberInChannel($general))->create();
     ScheduledMessage::factory()->for($general)->for($viewer)->sent()->create();
 
-    $scheduled = new ChannelPage($general, $viewer, $team)->scheduledMessages();
+    $scheduled = new ChannelPage($general, $viewer)->scheduledMessages();
 
     expect(array_column($scheduled, 'id'))->toBe([$sooner->id, $later->id])
         ->and($scheduled[0]->replyTo?->body)->toBe('the parent')


### PR DESCRIPTION
Closes #1254. Child 6 of #1248.

## What

A channel visit serialised the team roster twice: once as the `members` page prop, once as the shell's `teamMembers`, byte-identical.

`members` becomes `botMembers` — the channel's own bots, which are channel members rather than team members and so appear in no other prop. The client composes the rest in `lib/channelRoster.ts`:

- a standard channel: the shared `teamMembers` plus those bots
- a direct message: the participants already on its `channel` prop, plus the viewer

Composing a DM from its own participants rather than from the team roster is also what keeps someone who has since left the team in the conversation.

`ChannelPage` no longer needs the team at all, so it drops from the constructor and the render costs one query less (`CHANNEL_PAGE_QUERY_BUDGET` 28 → 27).

## Number

Measured on the 7-member demo workspace (`#general`, props JSON of a real Inertia visit):

| | before | after |
| --- | --- | --- |
| channel-visit props | 68,488 B | 66,141 B |
| `members` | 2,352 B | — |
| `teamMembers` | 2,352 B | 2,352 B |
| `botMembers` | — | 2 B |

The whole duplicate goes: 2,347 B off a visit, at 336 B per member. **Extrapolated** from that per-member figure, a 300-member workspace sheds ~100 KB per click (the epic's ~200 KB is the pair of copies; this child removes one, #1253 `once`s the other).

## Testing

- `tests/Feature/Channels/ChannelRosterDeltaTest.php` — the delta and the shared roster do not overlap, a channel with a bot still ships it, a bot-less channel and a DM add nothing.
- `resources/js/lib/channelRoster.test.ts` — the composition, including a DM participant who has left the team.
- `MentionMembersPropTest`, `MentionTest` and `BotVisibilityTest` restated against the props that now carry those facts; `ChannelPageTest` and `ChannelPageQueryCountTest` follow the reading's rename.
- Full gate green: `composer test` at `Total: 100.0 %`, plus lint/format/types/vitest/build. `tests/Browser` re-run for the masthead facepile.

No user-facing copy and no operator-facing setting, so no i18n keys or docs changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788637949&installation_model_id=428379&pr_number=1274&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1274&signature=8deb120dd65c7453296a5f53f1095d77f4842a166bf07cb131b00166aa28190c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->