### PR TITLE
feat: prefetch a channel before the click, per device, flushed by Echo

### DIFF
--- a/resources/js/components/ChannelListItem.test.ts
+++ b/resources/js/components/ChannelListItem.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import type { Channel } from '@/types/channels';
@@ -9,19 +9,45 @@ import type { UnreadCounts } from '@/types/unread';
  * the draft cue, the unread dot — renders in isolation. `stub(tag)` builds a
  * passthrough component; hoisted so the vi.mock factories can reach it.
  */
-const { stub } = await vi.hoisted(async () => {
+const { stub, linkAttrs, recordingLink } = await vi.hoisted(async () => {
     const { defineComponent, h: hyper } = await import('vue');
 
+    const stub = (tag: string) =>
+        defineComponent({
+            setup:
+                (_: unknown, ctx: { slots: { default?: () => unknown } }) =>
+                () =>
+                    hyper(tag, ctx.slots.default?.() as never),
+        });
+
+    /**
+     * Everything the row hands its navigation link, recorded per render. The
+     * link declaring the right prefetch contract *is* the seam here — Inertia's
+     * cache is the framework's to test, not ours.
+     */
+    const linkAttrs: Record<string, unknown>[] = [];
+
     return {
-        stub: (tag: string) =>
-            defineComponent({
-                setup:
-                    (_: unknown, ctx: { slots: { default?: () => unknown } }) =>
-                    () =>
-                        hyper(tag, ctx.slots.default?.() as never),
-            }),
+        stub,
+        linkAttrs,
+        recordingLink: defineComponent({
+            setup(
+                _: unknown,
+                ctx: {
+                    attrs: Record<string, unknown>;
+                    slots: { default?: () => unknown };
+                },
+            ) {
+                linkAttrs.push(ctx.attrs);
+
+                return () => hyper('a', ctx.slots.default?.() as never);
+            },
+        }),
     };
 });
+
+/** Whether the rendered device hovers before it clicks. */
+const device = await vi.hoisted(async () => ({ canHover: { value: true } }));
 
 /**
  * The shared props the row reads its badge from. The `channel` prop carries no
@@ -34,9 +60,12 @@ const page = await vi.hoisted(async () => ({
 }));
 
 vi.mock('@inertiajs/vue3', () => ({
-    Link: stub('a'),
+    Link: recordingLink,
     router: { patch: vi.fn() },
     usePage: () => page,
+}));
+vi.mock('@/composables/useCanHover', () => ({
+    useCanHover: () => device.canHover,
 }));
 vi.mock('@lucide/vue', () => ({
     GripVertical: stub('svg'),
@@ -114,6 +143,8 @@ async function render(
 ): Promise<string> {
     const row = channel(overrides);
 
+    linkAttrs.length = 0;
+
     page.props.unread = {
         channels: unread ? { [row.id]: unread } : {},
         teams: {},
@@ -189,5 +220,42 @@ describe('ChannelListItem badges', () => {
 
         expect(html).not.toContain('data-test="mention-badge"');
         expect(html).not.toContain('data-test="unread-dot"');
+    });
+});
+
+describe('ChannelListItem prefetch', () => {
+    beforeEach(() => {
+        device.canHover = { value: true };
+    });
+
+    it('prefetches on hover where a pointer can hover', async () => {
+        await render();
+
+        expect(linkAttrs[0].prefetch).toBe('hover');
+    });
+
+    it('prefetches on click where nothing hovers before the tap', async () => {
+        device.canHover = { value: false };
+
+        await render();
+
+        expect(linkAttrs[0].prefetch).toBe('click');
+    });
+
+    it('tags the entry with the channel it holds, so an arrival can flush it', async () => {
+        await render();
+
+        expect(linkAttrs[0].cacheTags).toEqual(['channel:ch-1']);
+    });
+
+    /**
+     * `only` is part of Inertia's prefetch cache key and the once-exclusion
+     * already omits the shell, so a nav link carrying one would silently miss
+     * its own prefetched entry.
+     */
+    it('carries no `only`, which would break its own prefetch', async () => {
+        await render();
+
+        expect(linkAttrs[0]).not.toHaveProperty('only');
     });
 });

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -19,10 +19,12 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useCanHover } from '@/composables/useCanHover';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { useUnreadDigest } from '@/composables/useUnreadDigest';
 import { notificationIndicator } from '@/lib/notificationIndicator';
+import { channelCacheTag, prefetchTrigger } from '@/lib/prefetch';
 import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import { channelUnread } from '@/lib/unreadDigest';
 import type { Channel, ChannelSection } from '@/types/channels';
@@ -65,6 +67,17 @@ const indicator = computed(() =>
     notificationIndicator(props.channel.muted, props.channel.notificationLevel),
 );
 
+// Fetch the channel before the click asks for it: on hover where a pointer can
+// hover, on mousedown where nothing can. `mount` is deliberately not an option
+// here — the sidebar is not virtualized, so it would put a 200-channel
+// workspace's worth of framework boots on the wire at once.
+const canHover = useCanHover();
+const prefetch = computed(() => prefetchTrigger(canHover.value));
+
+// The cached entry is filed under the channel it holds, so a realtime arrival
+// can flush exactly that one ({@see useSidebarBadges}).
+const cacheTags = computed(() => [channelCacheTag(props.channel.id)]);
+
 /**
  * Star or unstar the channel, reloading only the shared `channels` prop so the
  * sidebar re-partitions between the "Starred" and "Channels" sections.
@@ -96,6 +109,12 @@ function toggleStar(): void {
             :data-muted="channel.muted"
             class="h-11 gap-2 rounded-[10px] py-0 pr-2.5 pl-7 text-[15px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:shadow-[0_2px_6px_rgba(29,26,21,0.25)] data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100 md:h-8 md:rounded-[9px] md:text-[13.5px]"
         >
+            <!-- This link must never carry `only`: `only` is part of Inertia's
+                 prefetch cache key, so a prefetch and the click that follows
+                 only match while both leave it empty, and adding one here would
+                 silently break this row's own prefetch. It is not needed either
+                 — the shell's `once` props are excluded before they resolve on
+                 an ordinary visit. Nothing fails loudly if this is violated. -->
             <Link
                 :href="
                     show({
@@ -103,6 +122,8 @@ function toggleStar(): void {
                         channel: channel.slug,
                     }).url
                 "
+                :prefetch="prefetch"
+                :cacheTags="cacheTags"
                 :aria-current="
                     channel.slug === activeChannelSlug ? 'page' : undefined
                 "

--- a/resources/js/components/DirectMessageListItem.test.ts
+++ b/resources/js/components/DirectMessageListItem.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import type { Channel } from '@/types/channels';
@@ -10,19 +10,45 @@ import type { UnreadCounts } from '@/types/unread';
  * `stub(tag)` builds a passthrough component; hoisted so the vi.mock factories
  * (which run before the module body) can reach it.
  */
-const { stub } = await vi.hoisted(async () => {
+const { stub, linkAttrs, recordingLink } = await vi.hoisted(async () => {
     const { defineComponent, h: hyper } = await import('vue');
 
+    const stub = (tag: string) =>
+        defineComponent({
+            setup:
+                (_: unknown, ctx: { slots: { default?: () => unknown } }) =>
+                () =>
+                    hyper(tag, ctx.slots.default?.() as never),
+        });
+
+    /**
+     * Everything the row hands its navigation link, recorded per render. The
+     * link declaring the right prefetch contract *is* the seam here — Inertia's
+     * cache is the framework's to test, not ours.
+     */
+    const linkAttrs: Record<string, unknown>[] = [];
+
     return {
-        stub: (tag: string) =>
-            defineComponent({
-                setup:
-                    (_: unknown, ctx: { slots: { default?: () => unknown } }) =>
-                    () =>
-                        hyper(tag, ctx.slots.default?.() as never),
-            }),
+        stub,
+        linkAttrs,
+        recordingLink: defineComponent({
+            setup(
+                _: unknown,
+                ctx: {
+                    attrs: Record<string, unknown>;
+                    slots: { default?: () => unknown };
+                },
+            ) {
+                linkAttrs.push(ctx.attrs);
+
+                return () => hyper('a', ctx.slots.default?.() as never);
+            },
+        }),
     };
 });
+
+/** Whether the rendered device hovers before it clicks. */
+const device = await vi.hoisted(async () => ({ canHover: { value: true } }));
 
 /**
  * The row reads its badge off the shared unread digest, so the stubbed page
@@ -36,9 +62,12 @@ const page = await vi.hoisted(async () => ({
 }));
 
 vi.mock('@inertiajs/vue3', () => ({
-    Link: stub('a'),
+    Link: recordingLink,
     router: { post: vi.fn() },
     usePage: () => page,
+}));
+vi.mock('@/composables/useCanHover', () => ({
+    useCanHover: () => device.canHover,
 }));
 vi.mock('@/composables/useToast', () => {
     const toast = {
@@ -108,6 +137,8 @@ async function render(
     unread: UnreadCounts = { unread: 0, mention: 0 },
     overrides: Partial<Channel> = {},
 ): Promise<string> {
+    linkAttrs.length = 0;
+
     page.props.unread = {
         channels: { [channel(overrides).id]: unread },
         teams: {},
@@ -165,5 +196,42 @@ describe('DirectMessageListItem unread badge', () => {
         const html = await render();
 
         expect(html).not.toContain('data-test="dm-unread-badge"');
+    });
+});
+
+describe('DirectMessageListItem prefetch', () => {
+    beforeEach(() => {
+        device.canHover = { value: true };
+    });
+
+    it('prefetches on hover where a pointer can hover', async () => {
+        await render();
+
+        expect(linkAttrs[0].prefetch).toBe('hover');
+    });
+
+    it('prefetches on click where nothing hovers before the tap', async () => {
+        device.canHover = { value: false };
+
+        await render();
+
+        expect(linkAttrs[0].prefetch).toBe('click');
+    });
+
+    it('tags the entry with the conversation it holds, so an arrival can flush it', async () => {
+        await render();
+
+        expect(linkAttrs[0].cacheTags).toEqual(['channel:ch-1']);
+    });
+
+    /**
+     * `only` is part of Inertia's prefetch cache key and the once-exclusion
+     * already omits the shell, so a nav link carrying one would silently miss
+     * its own prefetched entry.
+     */
+    it('carries no `only`, which would break its own prefetch', async () => {
+        await render();
+
+        expect(linkAttrs[0]).not.toHaveProperty('only');
     });
 });

--- a/resources/js/components/DirectMessageListItem.vue
+++ b/resources/js/components/DirectMessageListItem.vue
@@ -15,12 +15,14 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
+import { useCanHover } from '@/composables/useCanHover';
 import { useInitials } from '@/composables/useInitials';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { useUnreadDigest } from '@/composables/useUnreadDigest';
 import { groupDmSidebarName } from '@/lib/groupDm';
 import { notificationIndicator } from '@/lib/notificationIndicator';
+import { channelCacheTag, prefetchTrigger } from '@/lib/prefetch';
 import { presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
 import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
@@ -91,6 +93,15 @@ const indicator = computed(() =>
     notificationIndicator(props.channel.muted, props.channel.notificationLevel),
 );
 
+// Fetch the conversation before the click asks for it: on hover where a pointer
+// can hover, on mousedown where nothing can.
+const canHover = useCanHover();
+const prefetch = computed(() => prefetchTrigger(canHover.value));
+
+// The cached entry is filed under the conversation it holds, so a realtime
+// arrival can flush exactly that one ({@see useSidebarBadges}).
+const cacheTags = computed(() => [channelCacheTag(props.channel.id)]);
+
 /**
  * Close (hide) this DM from the sidebar. Closing a DM the user isn't viewing just
  * reloads the shared `channels` prop so the row leaves in place; closing the DM
@@ -129,8 +140,16 @@ function hide(): void {
             :data-muted="channel.muted"
             class="h-11 gap-2 rounded-[10px] py-0 pr-2.5 pl-2.5 text-[15px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:shadow-[0_2px_6px_rgba(29,26,21,0.25)] data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100 md:h-8 md:rounded-[9px] md:text-[13.5px]"
         >
+            <!-- This link must never carry `only`: `only` is part of Inertia's
+                 prefetch cache key, so a prefetch and the click that follows
+                 only match while both leave it empty, and adding one here would
+                 silently break this row's own prefetch. It is not needed either
+                 — the shell's `once` props are excluded before they resolve on
+                 an ordinary visit. Nothing fails loudly if this is violated. -->
             <Link
                 :href="show({ team: teamSlug, channel: channel.slug }).url"
+                :prefetch="prefetch"
+                :cacheTags="cacheTags"
                 :data-test="`dm-row-${channel.slug}`"
                 :aria-current="isActive ? 'page' : undefined"
             >

--- a/resources/js/composables/useCanHover.test.ts
+++ b/resources/js/composables/useCanHover.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HOVER_MEDIA_QUERY } from '@/composables/useCanHover';
+
+/**
+ * Stand in for the browser's media-query engine with one that answers the
+ * `hover` feature the way a real device would, so the query below is asserted
+ * against pointer semantics rather than against a hand-fed boolean.
+ */
+function deviceThatHovers(canHover: boolean): void {
+    vi.stubGlobal('window', {
+        matchMedia: (query: string) => ({
+            media: query,
+            matches: /\(\s*hover:\s*hover\s*\)/.test(query) && canHover,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        }),
+    });
+}
+
+beforeEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('the hover-capability query', () => {
+    it('matches a device whose primary pointer can hover', () => {
+        deviceThatHovers(true);
+
+        expect(window.matchMedia(HOVER_MEDIA_QUERY).matches).toBe(true);
+    });
+
+    it('does not match a touch device, where nothing hovers before a tap', () => {
+        deviceThatHovers(false);
+
+        expect(window.matchMedia(HOVER_MEDIA_QUERY).matches).toBe(false);
+    });
+
+    /**
+     * `(any-hover: hover)` would call a laptop with a touchscreen — or a phone
+     * with a mouse plugged in — hover-capable regardless of what the person is
+     * actually using. The plain feature asks about the *primary* pointer.
+     */
+    it('asks about the primary pointer rather than any attached one', () => {
+        expect(HOVER_MEDIA_QUERY).not.toContain('any-hover');
+    });
+});

--- a/resources/js/composables/useCanHover.test.ts
+++ b/resources/js/composables/useCanHover.test.ts
@@ -1,38 +1,36 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { HOVER_MEDIA_QUERY } from '@/composables/useCanHover';
+import { HOVER_MEDIA_QUERY, useCanHover } from '@/composables/useCanHover';
 
 /**
- * Stand in for the browser's media-query engine with one that answers the
- * `hover` feature the way a real device would, so the query below is asserted
- * against pointer semantics rather than against a hand-fed boolean.
+ * Answer the `hover` feature the way a real device would. jsdom ships a
+ * `matchMedia` that reports every query as unmatched, so a composable that
+ * genuinely reads the media-query engine needs one that evaluates the feature
+ * rather than a hand-fed boolean.
  */
 function deviceThatHovers(canHover: boolean): void {
-    vi.stubGlobal('window', {
-        matchMedia: (query: string) => ({
-            media: query,
-            matches: /\(\s*hover:\s*hover\s*\)/.test(query) && canHover,
-            addEventListener: () => {},
-            removeEventListener: () => {},
-        }),
-    });
+    window.matchMedia = ((query: string) => ({
+        media: query,
+        matches: /\(\s*hover:\s*hover\s*\)/.test(query) && canHover,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+    })) as unknown as typeof window.matchMedia;
 }
 
 beforeEach(() => {
-    vi.unstubAllGlobals();
+    deviceThatHovers(true);
 });
 
-describe('the hover-capability query', () => {
-    it('matches a device whose primary pointer can hover', () => {
-        deviceThatHovers(true);
-
-        expect(window.matchMedia(HOVER_MEDIA_QUERY).matches).toBe(true);
+describe('the hover capability', () => {
+    it('is true on a device whose primary pointer can hover', () => {
+        expect(useCanHover().value).toBe(true);
     });
 
-    it('does not match a touch device, where nothing hovers before a tap', () => {
+    it('is false on a touch device, where nothing hovers before a tap', () => {
         deviceThatHovers(false);
 
-        expect(window.matchMedia(HOVER_MEDIA_QUERY).matches).toBe(false);
+        expect(useCanHover().value).toBe(false);
     });
 
     /**

--- a/resources/js/composables/useCanHover.ts
+++ b/resources/js/composables/useCanHover.ts
@@ -1,0 +1,22 @@
+import { useMediaQuery } from '@vueuse/core';
+import type { Ref } from 'vue';
+
+/**
+ * The media query for "the primary pointer can hover".
+ *
+ * Deliberately `hover` and not `any-hover`: the latter answers yes for a laptop
+ * with a touchscreen or a phone with a mouse plugged in, whichever the person is
+ * actually holding, and the whole point of the question is what the *current*
+ * interaction can offer.
+ */
+export const HOVER_MEDIA_QUERY = '(hover: hover)';
+
+/**
+ * Whether this device hovers before it clicks. The single source of truth for
+ * that question, the way {@see useIsMobile} owns the breakpoint — read by the
+ * nav links to choose their prefetch trigger, since a `hover` prefetch buys a
+ * pointer the whole travel-to-click time and buys a finger nothing at all.
+ */
+export function useCanHover(): Ref<boolean> {
+    return useMediaQuery(HOVER_MEDIA_QUERY);
+}

--- a/resources/js/composables/useSidebarBadges.test.ts
+++ b/resources/js/composables/useSidebarBadges.test.ts
@@ -2,10 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRenderer, defineComponent } from 'vue';
 
 const reload = vi.fn();
+const flushByCacheTags = vi.fn();
 const page = {
     props: {
         auth: { user: { id: 'viewer-id' } },
-        channels: [],
+        channels: [] as { id: string }[],
         channel: undefined as { id?: string } | undefined,
     },
 };
@@ -17,6 +18,7 @@ const left: string[] = [];
 vi.mock('@inertiajs/vue3', () => ({
     router: {
         reload: (...args: unknown[]) => reload(...args),
+        flushByCacheTags: (...args: unknown[]) => flushByCacheTags(...args),
     },
     usePage: () => page,
 }));
@@ -79,14 +81,28 @@ function harness(): { unmount: () => void } {
 }
 
 /** Fire an event on a subscribed Echo channel, as Reverb would. */
-function emit(channel: string, event: string): void {
-    listeners.get(channel)?.get(event)?.({});
+function emit(channel: string, event: string, payload: unknown = {}): void {
+    listeners.get(channel)?.get(event)?.(payload);
+}
+
+/** A teammate's arrival, carrying only what the sidebar reads off it. */
+function arrival(): unknown {
+    return {
+        id: 'msg-1',
+        user: { id: 'someone-else' },
+        mentions: [],
+        threadRootId: null,
+        sentToChannel: false,
+    };
 }
 
 describe('useSidebarBadges cross-device read sync', () => {
     beforeEach(() => {
         vi.useFakeTimers();
         reload.mockClear();
+        flushByCacheTags.mockClear();
+        page.props.channels = [];
+        page.props.channel = undefined;
         listeners.clear();
         left.length = 0;
     });
@@ -126,6 +142,30 @@ describe('useSidebarBadges cross-device read sync', () => {
         vi.runAllTimers();
 
         expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * The fleet is already subscribed to every channel in the sidebar, which is
+     * exactly the set the rows prefetch — so the event that makes a prefetched
+     * timeline wrong is already arriving, and flushing its tag is what stops the
+     * click that follows from painting a message-old screen.
+     */
+    it('flushes the prefetched entry of the channel a message arrived in', () => {
+        page.props.channels = [{ id: 'ch-1' }, { id: 'ch-2' }];
+        harness();
+
+        emit('channel.ch-1', 'MessageSent', arrival());
+
+        expect(flushByCacheTags).toHaveBeenCalledWith('channel:ch-1');
+    });
+
+    it('leaves the entries of the channels nothing arrived in alone', () => {
+        page.props.channels = [{ id: 'ch-1' }, { id: 'ch-2' }];
+        harness();
+
+        emit('channel.ch-1', 'MessageSent', arrival());
+
+        expect(flushByCacheTags).not.toHaveBeenCalledWith('channel:ch-2');
     });
 
     it('leaves the private channel on teardown', () => {

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -5,6 +5,7 @@ import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscr
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { backgroundVisit } from '@/lib/backgroundVisit';
 import { isChannelTraffic } from '@/lib/channelTraffic';
+import { channelCacheTag } from '@/lib/prefetch';
 import { CHANNEL_LIST_PROPS, UNREAD_DIGEST_PROPS } from '@/lib/reloadProps';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
 
@@ -30,6 +31,16 @@ const REFRESH_DEBOUNCE_MS = 500;
  * desktop showing the channel unread until its next navigation. Sharing one
  * debounced reload with the arrival side means a read and an arrival landing
  * together still cost a single request.
+ *
+ * The same arrivals also invalidate what the sidebar has *prefetched*. The rows
+ * fetch their channel ahead of the click and tag the entry with
+ * {@see channelCacheTag}; this fleet is subscribed to exactly that set, so the
+ * flush costs one call inside a callback that already runs — no second
+ * subscription, no polling, no fingerprint. Two blind spots ride along and are
+ * bounded by the 30 s cache lifetime: the fleet hears `MessageSent` only, so an
+ * edit, deletion, reaction or pin elsewhere never reaches it, and a dropped
+ * socket stops the flushing entirely (Echo is never load-bearing for
+ * correctness).
  */
 export function useSidebarBadges(): void {
     const page = usePage();
@@ -71,6 +82,14 @@ export function useSidebarBadges(): void {
     );
 
     useChannelFleetSubscription((channelId, message) => {
+        // The sidebar rows prefetch the channels this same fleet is subscribed
+        // to, so the event that makes a prefetched timeline wrong is already
+        // arriving here: drop that entry and the click after it goes back to
+        // the server rather than painting a message-old screen. It runs ahead
+        // of — and independently of — the badge decision below, which
+        // deliberately ignores arrivals a badge does not move.
+        router.flushByCacheTags(channelCacheTag(channelId));
+
         const decision = shouldRefreshSidebar({
             isOwnMessage: message.user.id === currentUserId.value,
             isChannelMessage: isChannelTraffic(message),

--- a/resources/js/lib/prefetch.test.ts
+++ b/resources/js/lib/prefetch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { channelCacheTag, prefetchTrigger } from '@/lib/prefetch';
+
+describe('the prefetch cache tag', () => {
+    it('names the channel it caches, so an arrival can flush exactly that entry', () => {
+        expect(channelCacheTag('9f1c-abcd')).toBe('channel:9f1c-abcd');
+    });
+
+    it('gives two channels two different tags', () => {
+        expect(channelCacheTag('one')).not.toBe(channelCacheTag('two'));
+    });
+});
+
+describe('the prefetch trigger', () => {
+    it('buys the travel-to-click time on a device that can hover', () => {
+        expect(prefetchTrigger(true)).toBe('hover');
+    });
+
+    it('falls back to the mousedown-to-mouseup window where nothing hovers', () => {
+        expect(prefetchTrigger(false)).toBe('click');
+    });
+
+    /**
+     * `['hover', 'click']` renders as `if hover → hoverEvents; else if click →
+     * clickEvents`, so the click half is silently dropped. The mode is chosen
+     * once, and it is never an array.
+     */
+    it('never asks for both modes at once', () => {
+        expect(prefetchTrigger(true)).not.toBeInstanceOf(Array);
+        expect(prefetchTrigger(false)).not.toBeInstanceOf(Array);
+    });
+});

--- a/resources/js/lib/prefetch.ts
+++ b/resources/js/lib/prefetch.ts
@@ -1,0 +1,29 @@
+import type { LinkPrefetchOption } from '@inertiajs/core';
+
+/**
+ * The prefetch cache tag a channel's speculative visit is filed under.
+ *
+ * One home for the string so the link that tags an entry and the realtime
+ * arrival that flushes it can never drift apart — a rename on one side alone
+ * would leave a stale timeline behind with nothing failing loudly.
+ */
+export function channelCacheTag(channelId: string): string {
+    return `channel:${channelId}`;
+}
+
+/**
+ * Which trigger a nav link prefetches on, given whether the device can hover.
+ *
+ * Hover is the only trigger that reliably beats the bar, because it buys the
+ * whole travel-to-click time — but on touch `mouseenter` fires ~0 ms before
+ * `click` and so gives a phone nothing, while click mode's mousedown → mouseup
+ * window (80–150 ms there) is the only head start available. The mode is
+ * therefore chosen per device rather than per link.
+ *
+ * It is deliberately a single mode and never `['hover', 'click']`: Inertia's
+ * link renders `if hover → hoverEvents; else if click → clickEvents`, so
+ * asking for both silently drops the click half.
+ */
+export function prefetchTrigger(canHover: boolean): LinkPrefetchOption {
+    return canHover ? 'hover' : 'click';
+}

--- a/tests/Browser/SidebarPrefetchTest.php
+++ b/tests/Browser/SidebarPrefetchTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Channels\JoinChannel;
+use App\Models\Channel;
+
+/**
+ * Sidebar rows fetch their channel before the click asks for it (#1256).
+ *
+ * What is asserted here is the seam and the outcome — the hover happens, the
+ * click lands on the hovered channel — and never the timing. Whether the paint
+ * beat a wall-clock number is a measurement, not a test: a duration assertion on
+ * a shared runner is a flake that gets deleted within a month, and the deletion
+ * takes the intent with it.
+ */
+
+/** A script resolving once the address bar has reached the given path. */
+function channelPathSettles(string $path): string
+{
+    return <<<JS
+    (async () => {
+        const settled = () => location.pathname === '{$path}';
+
+        for (let frame = 0; frame < 300 && ! settled(); frame++) {
+            await new Promise(requestAnimationFrame);
+        }
+
+        return settled();
+    })()
+    JS;
+}
+
+test('hovering a channel row and then clicking it opens that channel', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $design = Channel::factory()->for($team)->create([
+        'name' => 'design',
+        'slug' => 'design',
+    ]);
+    app(JoinChannel::class)->handle($design, $alice);
+
+    $target = browserChannelUrl($team, $design);
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $general))
+        ->assertPresent('@channel-name-design')
+        // The hover is what fires the speculative visit on a pointer device;
+        // the click that follows is served by it, or falls back to the wire.
+        // Either way the navigation has to complete and land on the channel
+        // that was hovered.
+        ->hover('a[href$="/c/design"]')
+        ->click('a[href$="/c/design"]')
+        ->assertScript(channelPathSettles($target), true)
+        ->assertPathIs($target)
+        ->assertSee('design');
+});


### PR DESCRIPTION
Closes #1256. Part of #1248 (the epic's critical path — prefetch is the only lever that crosses the 150 ms line, since the network floor alone puts a click that waits for a server out of reach).

## What

`ChannelListItem` and `DirectMessageListItem` fetch their channel before the click asks for it, and a realtime arrival drops the entry it would have served stale.

- **`lib/prefetch.ts`** — `channelCacheTag(id)` and `prefetchTrigger(canHover)`. One home for the tag string, so the link that files an entry and the arrival that flushes it cannot drift apart, and one home for the rule that the mode is a single value and never `['hover', 'click']` (Inertia renders `if hover → hoverEvents; else if click → clickEvents`, so the array form silently drops the click half).
- **`composables/useCanHover.ts`** — `(hover: hover)` through `useMediaQuery`, sitting beside `useIsMobile.ts`. Deliberately not `any-hover`, which would call a laptop with a touchscreen hover-capable regardless of what the person is actually holding.
- **Both rows** — `:prefetch="canHover ? 'hover' : 'click'"` and `:cacheTags="['channel:{id}']"`. No `cacheFor`: Inertia's 30 s default stands (`3e4` in `@inertiajs/core`, and the app sets no `prefetch.cacheFor` override). `mount` is out — the sidebar is not virtualized, so it would put a 200-channel workspace's worth of framework boots on the wire at once.
- **`useSidebarBadges.ts`** — one `router.flushByCacheTags()` inside the fleet callback that already runs. `useChannelFleetSubscription` is already subscribed to every channel in the sidebar, which is exactly the set the rows prefetch, so the event that invalidates a prefetched timeline is already arriving: no new subscription, no polling, no fingerprint. It runs ahead of and independently of the badge decision, which deliberately ignores arrivals that move no badge.

**The written rule this introduces:** nav links must not carry `only`. `only` is part of Inertia's prefetch cache key, so a prefetch and the click that follows only match while both leave it empty — and the once-exclusion already omits the shell, so it buys nothing either. It lives as a comment at each link because nothing fails loudly when it is violated.

## Why these knobs and not others

Hover is the only trigger that reliably beats the bar, because it buys the whole travel-to-click time. But on touch `mouseenter` fires ~0 ms before `click` and gives a phone literally nothing, while click mode's mousedown → mouseup window is the only head start available there — so the mode is chosen per device rather than globally.

Two blind spots in the Echo flushing are accepted and bounded by the 30 s TTL: the fleet listens for `MessageSent` only, so an edit, deletion, reaction or pin on a non-active channel never reaches it; and a dropped socket stops the flushing, per the standing rule that Echo is never load-bearing for correctness.

## Testing

**Vitest** — the hover-capability composable (under `jsdom`, driven through a `matchMedia` that evaluates the feature); both rows declaring the right mode per device class, the right cache tags, and no `only`; the fleet callback flushing the arriving channel's tag and leaving its siblings alone.

**Pest browser** — `SidebarPrefetchTest`: a hover-then-click navigation completes and opens the hovered channel. It asserts the seam and the outcome and never the timing; a duration assertion on a shared runner is a flake that gets deleted within a month, and the deletion takes the intent with it.

**Two acceptance criteria measured rather than assumed**, via a throwaway browser probe that was removed afterwards:

- *A prefetched click paints without a round trip.* Counting `PerformanceResourceTiming` entries for the target path: 1 after the hover, still 1 after the click had landed on `/t/acme/c/design`.
- *A prefetched visit omits the shell.* The prefetch XHR carries `X-Inertia-Except-Once-Props` naming the whole shell set (instance config, translations, `channels`, `teamMembers`, `customEmojis`, …), so the once-exclusion does ride prefetch requests now that the shell-contract children have landed.

**Gates** — Vitest 2759/2759, ESLint 0 errors, Prettier, `vue-tsc`, `vite build`, `artisan test --parallel --coverage --min=100` at `Total: 100.0 %`, and the full `tests/Browser` suite 357/357.

**i18n / docs** — no user-facing copy and nothing operator-facing, so neither `lang/fr.json` nor `docs/` changes.

## Not included

The issue's optional p50 painted-time number. It is specified against the pinned `research/navigation-baseline` harness on `demo.thedeskhq.app`, which measures whatever is deployed there — so it can only be taken once this ships, and a local figure would be below the floor the budget declared quotable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788723285&installation_model_id=428379&pr_number=1277&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1277&signature=f9cd7c085ec66be029908926908a6cd1184ec9a56a01bdae69f4e0de85a123be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->