### PR TITLE
feat: prefetch the palette's highlighted result and the adjacent channels

### DIFF
--- a/resources/js/components/CommandPalette.doubles.ts
+++ b/resources/js/components/CommandPalette.doubles.ts
@@ -59,8 +59,8 @@ export function teamPresenceDouble(): Record<string, unknown> {
     };
 }
 
-/** Where a picked row sends the viewer. */
-export const router = { visit: vi.fn() };
+/** Where a picked row sends the viewer, and what it fetches ahead of the pick. */
+export const router = { visit: vi.fn(), prefetch: vi.fn() };
 
 /**
  * The page, read through getters rather than rebuilt per call: the command
@@ -91,8 +91,19 @@ const page = {
     },
 };
 
+/**
+ * The hover delay the prediction debounce reads, stood in for so these suites
+ * need no real Inertia. That it is genuinely Inertia's own number, rather than
+ * one typed twice, is pinned against the real config in `lib/prefetch.test.ts`.
+ */
+const PREFETCH_CONFIG: Record<string, number> = { 'prefetch.hoverDelay': 75 };
+
 export function inertiaDouble(): Record<string, unknown> {
-    return { router, usePage: () => page };
+    return {
+        router,
+        usePage: () => page,
+        config: { get: (key: string) => PREFETCH_CONFIG[key] },
+    };
 }
 
 /**
@@ -190,6 +201,7 @@ export function resetDoubles(): void {
     presence.presenceFor = () => 'active';
     presence.isDndFor = () => false;
     router.visit.mockClear();
+    router.prefetch.mockClear();
     messageSearch.results.value = [];
     messageSearch.isSearching.value = false;
     messageSearch.search.mockClear();

--- a/resources/js/components/CommandPalette.prefetch.test.ts
+++ b/resources/js/components/CommandPalette.prefetch.test.ts
@@ -1,0 +1,288 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * What the palette fetches before the viewer has picked anything (#1257).
+ *
+ * The palette is the one navigation path with no hover to trigger on, so it
+ * predicts instead: whichever row `Enter` would run is fetched once the
+ * arrowing settles. The seam is the speculative request itself — which row it
+ * names, how many of them there are, and that it carries the sidebar's cache
+ * contract — never how long Inertia then holds the entry, which is the
+ * framework's to test.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble } = await import('./CommandPalette.doubles');
+
+    return inertiaDouble();
+});
+
+vi.mock('@lucide/vue', async () => {
+    const { lucideDouble } = await import('./CommandPalette.stubs');
+
+    return lucideDouble();
+});
+
+vi.mock('reka-ui', async () => {
+    const { rekaDouble } = await import('./CommandPalette.stubs');
+
+    return rekaDouble();
+});
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/ChannelController',
+    async () => {
+        const { channelActionDouble } =
+            await import('./CommandPalette.doubles');
+
+        return channelActionDouble();
+    },
+);
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/SearchController',
+    async () => {
+        const { searchActionDouble } = await import('./CommandPalette.doubles');
+
+        return searchActionDouble();
+    },
+);
+
+vi.mock('@/components/PresenceDot.vue', async () => {
+    const { presenceDotDouble } = await import('./CommandPalette.stubs');
+
+    return presenceDotDouble();
+});
+
+vi.mock('@/components/SafeHtml.vue', async () => {
+    const { safeHtmlDouble } = await import('./CommandPalette.stubs');
+
+    return safeHtmlDouble();
+});
+
+vi.mock('@/components/ui/button', async () => {
+    const { buttonDouble } = await import('./CommandPalette.stubs');
+
+    return buttonDouble();
+});
+
+vi.mock('@/components/ui/command', async () => {
+    const { commandDouble } = await import('./CommandPalette.stubs');
+
+    return commandDouble();
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { dialogDouble } = await import('./CommandPalette.stubs');
+
+    return dialogDouble();
+});
+
+vi.mock('@/components/ui/sidebar', async () => {
+    const { sidebarDouble } = await import('./CommandPalette.doubles');
+
+    return sidebarDouble();
+});
+
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./CommandPalette.doubles');
+
+    return teamPresenceDouble();
+});
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { isMobileDouble } = await import('./CommandPalette.doubles');
+
+    return isMobileDouble();
+});
+
+vi.mock('@/composables/useMessageSearch', async () => {
+    const { messageSearchDouble } = await import('./CommandPalette.doubles');
+
+    return messageSearchDouble();
+});
+
+vi.mock('@/composables/useOpenDirectMessage', async () => {
+    const { openDirectMessageDouble } =
+        await import('./CommandPalette.doubles');
+
+    return openDirectMessageDouble();
+});
+
+vi.mock('@/lib/pinUrl', async () => {
+    const { pinUrlDouble } = await import('./CommandPalette.doubles');
+
+    return pinUrlDouble();
+});
+
+import { channelCacheTag, predictionDelay } from '@/lib/prefetch';
+import {
+    channel,
+    mountSwitcher,
+    person,
+    resetDoubles,
+    router,
+    unmountAll,
+} from './CommandPalette.doubles';
+import { highlighter } from './CommandPalette.stubs';
+import CommandPalette from './CommandPalette.vue';
+
+const DESIGN = channel({ id: 'c-design', name: 'design', slug: 'design' });
+const RANDOM = channel({ id: 'c-random', name: 'random', slug: 'random' });
+
+function mount() {
+    return mountSwitcher(CommandPalette, {
+        channels: [DESIGN, RANDOM],
+        members: [person()],
+    });
+}
+
+/** Land the keyboard on a row, the way reka-ui reports it. */
+function highlight(value: unknown): void {
+    highlighter.settle?.(value === undefined ? undefined : { value });
+}
+
+/** Let the prediction window elapse without waiting out real time. */
+function settle(): void {
+    vi.advanceTimersByTime(predictionDelay());
+}
+
+/** The URLs speculatively fetched so far, in the order they were asked for. */
+function fetched(): string[] {
+    return router.prefetch.mock.calls.map((call) => call[0] as string);
+}
+
+describe('the palette predicting where Enter would go', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        resetDoubles();
+        highlighter.settle = null;
+    });
+
+    afterEach(() => {
+        unmountAll();
+        vi.useRealTimers();
+    });
+
+    it('fetches the channel the highlight settled on', () => {
+        mount();
+
+        highlight('channel:c-design');
+        settle();
+
+        expect(fetched()).toEqual(['/t/acme/c/design']);
+    });
+
+    /**
+     * The acceptance criterion the whole debounce exists for: arrowing through
+     * ten rows must cost one request, not ten.
+     */
+    it('spends one request on a burst of arrowing, for the row it stopped on', () => {
+        mount();
+
+        highlight('channel:c-design');
+        highlight('channel:c-random');
+        highlight('channel:c-design');
+        highlight('channel:c-random');
+        settle();
+
+        expect(fetched()).toEqual(['/t/acme/c/random']);
+    });
+
+    it('waits for the selection to settle before fetching anything', () => {
+        mount();
+
+        highlight('channel:c-design');
+        vi.advanceTimersByTime(predictionDelay() - 1);
+
+        expect(router.prefetch).not.toHaveBeenCalled();
+    });
+
+    it('files the entry under the channel it holds', () => {
+        mount();
+
+        highlight('channel:c-design');
+        settle();
+
+        expect(router.prefetch.mock.calls[0][2]).toEqual({
+            cacheTags: [channelCacheTag('c-design')],
+        });
+    });
+
+    /**
+     * `only` is part of the prefetch cache key, so a prediction carrying one
+     * could never be claimed by the `router.visit` that picking the row fires.
+     */
+    it('carries no `only`, so the pick that follows can claim the entry', () => {
+        mount();
+
+        highlight('channel:c-design');
+        settle();
+
+        expect(router.prefetch.mock.calls[0][1]).not.toHaveProperty('only');
+    });
+
+    /** A person opens through a POST, which cannot be prefetched at all. */
+    it('predicts nothing for a person', () => {
+        mount();
+
+        highlight('person:p1');
+        settle();
+
+        expect(router.prefetch).not.toHaveBeenCalled();
+    });
+
+    it('predicts nothing for a command, which has no URL to fetch', () => {
+        mount();
+
+        highlight('command:create-channel');
+        settle();
+
+        expect(router.prefetch).not.toHaveBeenCalled();
+    });
+
+    /**
+     * A message result carries no channel id, so its entry could never be
+     * flushed by the fleet — an untagged entry is worse than no entry.
+     */
+    it('predicts nothing for a message result', () => {
+        mount();
+
+        highlight('message:m1');
+        settle();
+
+        expect(router.prefetch).not.toHaveBeenCalled();
+    });
+
+    it('predicts nothing for a channel that is no longer in the list', () => {
+        mount();
+
+        highlight('channel:c-gone');
+        settle();
+
+        expect(router.prefetch).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Arrowing off a channel and onto a verb must not leave the channel's
+     * request in flight behind it.
+     */
+    it('drops a pending prediction when the keyboard leaves the channel', () => {
+        mount();
+
+        highlight('channel:c-design');
+        highlight('command:create-channel');
+        settle();
+
+        expect(router.prefetch).not.toHaveBeenCalled();
+    });
+
+    it('predicts nothing when the highlight is cleared altogether', () => {
+        mount();
+
+        highlight(undefined);
+        settle();
+
+        expect(router.prefetch).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/components/CommandPalette.prefetch.test.ts
+++ b/resources/js/components/CommandPalette.prefetch.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 
 /**
  * What the palette fetches before the viewer has picked anything (#1257).
@@ -171,6 +172,22 @@ describe('the palette predicting where Enter would go', () => {
         settle();
 
         expect(fetched()).toEqual(['/t/acme/c/design']);
+    });
+
+    /**
+     * Dismissing the palette answers the prediction: the viewer is not going
+     * anywhere, so a request still queued behind them would buy nothing and
+     * still cost a framework boot.
+     */
+    it('drops a pending prediction when the palette is dismissed', async () => {
+        const { open } = mount();
+
+        highlight('channel:c-design');
+        open.value = false;
+        await nextTick();
+        settle();
+
+        expect(router.prefetch).not.toHaveBeenCalled();
     });
 
     /**

--- a/resources/js/components/CommandPalette.stubs.ts
+++ b/resources/js/components/CommandPalette.stubs.ts
@@ -140,9 +140,38 @@ const commandList = defineComponent({
             ),
 });
 
+/** How reka-ui names the row the keyboard has landed on. */
+type HighlightPayload = { value: unknown } | undefined;
+
+/**
+ * The listbox root's announcement of which row is highlighted, held where a
+ * suite can fire it.
+ *
+ * Unlike the inert stubs this one has to be reachable: the highlight is not a
+ * gesture a viewer makes on an element, it is reka-ui reporting where the
+ * arrow keys have arrived, and it is the whole trigger for the palette's
+ * prefetch. A suite settles a selection by calling this rather than by
+ * simulating a keyboard the stubs do not have.
+ */
+export const highlighter = {
+    settle: null as ((payload: HighlightPayload) => void) | null,
+};
+
+const commandRoot = defineComponent({
+    name: 'CommandStub',
+    inheritAttrs: false,
+    setup(_props, { attrs, slots }) {
+        highlighter.settle = attrs.onHighlight as (
+            payload: HighlightPayload,
+        ) => void;
+
+        return () => h('div', attrs, slots.default?.());
+    },
+});
+
 export function commandDouble(): Record<string, Component> {
     return {
-        Command: passthrough('div'),
+        Command: commandRoot,
         CommandGroup: commandGroup,
         CommandItem: commandItem,
         CommandList: commandList,

--- a/resources/js/components/CommandPalette.vue
+++ b/resources/js/components/CommandPalette.vue
@@ -150,13 +150,6 @@ const groupOrder = computed<RankedGroup[]>(() => {
         .map((scored) => scored.group);
 });
 
-// Reset everything on dismiss so the palette always reopens blank.
-watch(open, (isOpen) => {
-    if (!isOpen) {
-        clear();
-    }
-});
-
 /**
  * Fetch a channel once the arrowing has stopped on it, so the pick that
  * follows paints without a round trip.
@@ -173,6 +166,17 @@ const predict = useDebouncedPost<Channel>(
         ),
     { delay: predictionDelay() },
 );
+
+// Reset everything on dismiss so the palette always reopens blank — the queued
+// prediction included, since a viewer who has closed the palette is not going
+// where it was pointing. Picking a row closes it too, and cancelling there is
+// right for the same reason: the visit is already on its way to the server.
+watch(open, (isOpen) => {
+    if (!isOpen) {
+        clear();
+        predict.cancel();
+    }
+});
 
 /**
  * Answer reka-ui's report of which row the keyboard has landed on.

--- a/resources/js/components/CommandPalette.vue
+++ b/resources/js/components/CommandPalette.vue
@@ -23,9 +23,11 @@ import {
     scoreChannelName,
 } from '@/composables/quickSwitcher';
 import { useCommandPaletteSearch } from '@/composables/useCommandPaletteSearch';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { useIsMobile } from '@/composables/useIsMobile';
 import { useOpenDirectMessage } from '@/composables/useOpenDirectMessage';
 import { rankPeople } from '@/lib/peopleDirectory';
+import { predictionDelay, prefetchChannel } from '@/lib/prefetch';
 import type { MessageSearchResult } from '@/types';
 import type { Channel } from '@/types/channels';
 import type { PersonRef } from '@/types/people';
@@ -155,6 +157,46 @@ watch(open, (isOpen) => {
     }
 });
 
+/**
+ * Fetch a channel once the arrowing has stopped on it, so the pick that
+ * follows paints without a round trip.
+ *
+ * Debounced because the list re-highlights on every keystroke: walking ten
+ * rows would otherwise be ten speculative requests, each paying a full
+ * framework boot. The window is the one Inertia's own hover links wait out.
+ */
+const predict = useDebouncedPost<Channel>(
+    (channel) =>
+        prefetchChannel(
+            show({ team: props.teamSlug, channel: channel.slug }).url,
+            channel.id,
+        ),
+    { delay: predictionDelay() },
+);
+
+/**
+ * Answer reka-ui's report of which row the keyboard has landed on.
+ *
+ * Only channels are predicted, and matching on the row's own `channel:` value
+ * is what keeps that true by construction rather than by an exclusion list
+ * that would rot: a person opens through a POST, a command has no URL, and a
+ * message result carries no channel id to tag its entry with — so an entry for
+ * one could never be flushed when the channel moves on.
+ *
+ * Anything else cancels, because arrowing off a channel and pressing Enter
+ * must not leave that channel's request in flight behind it.
+ */
+function predictHighlight(payload?: { value: unknown }): void {
+    const id = String(payload?.value ?? '').match(/^channel:(.+)$/)?.[1];
+    const channel = props.channels.find((candidate) => candidate.id === id);
+
+    if (channel) {
+        predict.schedule(channel);
+    } else {
+        predict.cancel();
+    }
+}
+
 function selectChannel(channel: Channel): void {
     open.value = false;
     router.visit(show({ team: props.teamSlug, channel: channel.slug }).url);
@@ -199,7 +241,7 @@ function runCommand(command: PaletteCommand): void {
                     $t('Search channels, people and messages, or run a command')
                 }}</DialogDescription>
             </DialogHeader>
-            <Command>
+            <Command @highlight="predictHighlight">
                 <SwitcherField
                     v-model="query"
                     :is-mobile="isMobile"

--- a/resources/js/composables/useAdjacentChannelPrefetch.test.ts
+++ b/resources/js/composables/useAdjacentChannelPrefetch.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import type * as InertiaVue from '@inertiajs/vue3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick, reactive } from 'vue';
+
+const { prefetch } = vi.hoisted(() => ({ prefetch: vi.fn() }));
+
+const page = reactive<{ props: Record<string, unknown> }>({ props: {} });
+
+// `config` stays real so the module under test keeps reading Inertia's own
+// prefetch defaults; only the router and the page are stood in for.
+vi.mock('@inertiajs/vue3', async (importOriginal) => ({
+    ...(await importOriginal<typeof InertiaVue>()),
+    router: { prefetch },
+    usePage: () => page,
+}));
+
+import { useAdjacentChannelPrefetch } from '@/composables/useAdjacentChannelPrefetch';
+import { channelCacheTag } from '@/lib/prefetch';
+import type { Channel } from '@/types/channels';
+
+let app: App | null = null;
+
+function channel(slug: string): Channel {
+    return { id: `id-${slug}`, slug, name: slug } as Channel;
+}
+
+/** Seed the shared props the prediction reads, in sidebar order. */
+function seed(overrides: Record<string, unknown> = {}): void {
+    page.props = {
+        currentTeam: { id: 't1', slug: 'acme' },
+        channels: ['general', 'design', 'random'].map(channel),
+        channel: { id: 'id-design', slug: 'design' },
+        ...overrides,
+    };
+}
+
+function boot(): void {
+    app = createApp({
+        setup: () => {
+            useAdjacentChannelPrefetch();
+
+            return () => h('div');
+        },
+    });
+    app.mount(document.createElement('div'));
+}
+
+/** The URLs speculatively fetched so far, in the order they were asked for. */
+function fetched(): string[] {
+    return prefetch.mock.calls.map((call) => call[0] as string);
+}
+
+describe('useAdjacentChannelPrefetch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        seed();
+    });
+
+    afterEach(() => {
+        app?.unmount();
+        app = null;
+    });
+
+    it('fetches the two channels the walk can reach, and no others', () => {
+        boot();
+
+        expect(fetched()).toEqual(['/t/acme/c/random', '/t/acme/c/general']);
+    });
+
+    /**
+     * The cost that makes prediction safe here where `mount` was not: it is two
+     * requests whether the workspace holds three channels or two hundred.
+     */
+    it('spends two requests regardless of how large the workspace is', () => {
+        seed({
+            channels: Array.from({ length: 200 }, (_, index) =>
+                channel(`c${index}`),
+            ),
+            channel: { id: 'id-c100', slug: 'c100' },
+        });
+
+        boot();
+
+        expect(prefetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('files each entry under the channel it holds', () => {
+        boot();
+
+        expect(prefetch.mock.calls[0][2]).toEqual({
+            cacheTags: [channelCacheTag('id-random')],
+        });
+    });
+
+    it('predicts again when the viewer moves to another channel', async () => {
+        boot();
+        prefetch.mockClear();
+
+        page.props.channel = { id: 'id-general', slug: 'general' };
+        await nextTick();
+
+        expect(fetched()).toEqual(['/t/acme/c/design', '/t/acme/c/random']);
+    });
+
+    /**
+     * A star, a reorder, or a first-ever direct message moves who the
+     * neighbours are without the active channel changing at all.
+     */
+    it('predicts again when the roster itself moves', async () => {
+        boot();
+        prefetch.mockClear();
+
+        page.props.channels = ['design', 'random'].map(channel);
+        await nextTick();
+
+        expect(fetched()).toEqual(['/t/acme/c/random']);
+    });
+
+    /**
+     * Settings and browse pages mount the same shell. There is no walk in
+     * progress there, so predicting would spend two requests on a guess.
+     */
+    it('predicts nothing on a page with no channel open', () => {
+        seed({ channel: undefined });
+
+        boot();
+
+        expect(prefetch).not.toHaveBeenCalled();
+    });
+
+    it('predicts nothing before a workspace is loaded', () => {
+        seed({ currentTeam: undefined });
+
+        boot();
+
+        expect(prefetch).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/composables/useAdjacentChannelPrefetch.ts
+++ b/resources/js/composables/useAdjacentChannelPrefetch.ts
@@ -1,0 +1,47 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed, watch } from 'vue';
+import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { adjacentChannels, prefetchChannel } from '@/lib/prefetch';
+
+/**
+ * Fetch the two channels a ⌘↑ / ⌘↓ walk can reach from the open one.
+ *
+ * Prediction rather than intent, because the walk has no hover to trigger on:
+ * the sidebar rows buy their head start from a pointer travelling towards them,
+ * and a keyboard jump offers nothing to read. For any active channel, though,
+ * its neighbours are exactly two computable URLs — so the head start can be
+ * taken speculatively instead.
+ *
+ * The cost is therefore fixed at two speculative requests per navigation and
+ * does not grow with the workspace, which is the property that ruled `mount`
+ * out for the sidebar, where it would have been one request per row. It is
+ * still two full framework boots, which is why it is bounded at two.
+ *
+ * Runs only while a channel is open. Settings and browse pages mount this same
+ * shell, and there is no walk in progress on them.
+ */
+export function useAdjacentChannelPrefetch(): void {
+    const page = usePage();
+
+    const activeSlug = computed(
+        () =>
+            (page.props.channel as { slug?: string } | undefined)?.slug ?? null,
+    );
+
+    watch(
+        [activeSlug, () => page.props.channels, () => page.props.currentTeam],
+        ([slug, channels, team]) => {
+            if (slug === null || !team) {
+                return;
+            }
+
+            for (const channel of adjacentChannels(channels ?? [], slug)) {
+                prefetchChannel(
+                    show({ team: team.slug, channel: channel.slug }).url,
+                    channel.id,
+                );
+            }
+        },
+        { immediate: true },
+    );
+}

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/sidebar';
 import { Toaster } from '@/components/ui/sonner';
 import UpdateIndicator from '@/components/UpdateIndicator.vue';
+import { useAdjacentChannelPrefetch } from '@/composables/useAdjacentChannelPrefetch';
 import { useChannelSections } from '@/composables/useChannelSections';
 import { useChannelUploadToasts } from '@/composables/useChannelUploadToasts';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
@@ -77,6 +78,11 @@ const { demoMode } = useDemoMode();
 // Keep the sidebar unread/mention badges live as messages arrive in channels the
 // user is a member of but not currently viewing.
 useSidebarBadges();
+
+// Fetch the two channels the ⌘↑ / ⌘↓ walk can reach from the open one. The
+// same fleet subscribed above is what flushes those entries when a message
+// lands in one of them.
+useAdjacentChannelPrefetch();
 
 // Surface a brand-new direct message in the sidebar the moment someone messages
 // the viewer for the first time, without a manual reload.

--- a/resources/js/lib/prefetch.test.ts
+++ b/resources/js/lib/prefetch.test.ts
@@ -1,5 +1,41 @@
-import { describe, expect, it } from 'vitest';
-import { channelCacheTag, prefetchTrigger } from '@/lib/prefetch';
+// @vitest-environment jsdom
+import { config } from '@inertiajs/vue3';
+import type * as InertiaVue from '@inertiajs/vue3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { prefetch } = vi.hoisted(() => ({ prefetch: vi.fn() }));
+
+// Only the router is stood in for: `config` stays the real one, so the delay
+// this module publishes is genuinely the delay Inertia's own links wait out.
+vi.mock('@inertiajs/vue3', async (importOriginal) => ({
+    ...(await importOriginal<typeof InertiaVue>()),
+    router: { prefetch },
+}));
+
+import {
+    adjacentChannels,
+    channelCacheTag,
+    predictionDelay,
+    prefetchChannel,
+    prefetchTrigger,
+} from '@/lib/prefetch';
+import type { Channel } from '@/types/channels';
+
+/** A sidebar row, carrying only what the prediction reads off it. */
+function channel(slug: string): Channel {
+    return { id: `id-${slug}`, slug, name: slug } as Channel;
+}
+
+/** The roster in sidebar order, which is the order the walk steps through. */
+const ROSTER = ['general', 'design', 'random'].map(channel);
+
+/** The slugs a prediction would fetch, in the order it fetches them. */
+function predicted(
+    channels: readonly Channel[],
+    activeSlug: string | null,
+): string[] {
+    return adjacentChannels(channels, activeSlug).map((found) => found.slug);
+}
 
 describe('the prefetch cache tag', () => {
     it('names the channel it caches, so an arrival can flush exactly that entry', () => {
@@ -28,5 +64,95 @@ describe('the prefetch trigger', () => {
     it('never asks for both modes at once', () => {
         expect(prefetchTrigger(true)).not.toBeInstanceOf(Array);
         expect(prefetchTrigger(false)).not.toBeInstanceOf(Array);
+    });
+});
+
+describe('the channels a walk can reach in one step', () => {
+    it('is the next and the previous row, and nothing else', () => {
+        expect(predicted(ROSTER, 'design')).toEqual(['random', 'general']);
+    });
+
+    /**
+     * The jump wraps at either end, so the ends are neighbours rather than
+     * dead stops — and the prediction has to agree with the jump or it fetches
+     * a channel ⌘↑ / ⌘↓ never lands on.
+     */
+    it('wraps at the top of the list, as the jump itself does', () => {
+        expect(predicted(ROSTER, 'general')).toEqual(['design', 'random']);
+    });
+
+    it('wraps at the bottom of the list', () => {
+        expect(predicted(ROSTER, 'random')).toEqual(['general', 'design']);
+    });
+
+    /** Both neighbours are the same row, so the cost is one request, not two. */
+    it('spends one request in a two-channel workspace', () => {
+        expect(predicted(ROSTER.slice(0, 2), 'general')).toEqual(['design']);
+    });
+
+    /** Both neighbours are the channel already on screen. */
+    it('spends nothing in a one-channel workspace', () => {
+        expect(predicted(ROSTER.slice(0, 1), 'general')).toEqual([]);
+    });
+
+    it('spends nothing on an empty roster', () => {
+        expect(predicted([], null)).toEqual([]);
+    });
+
+    /**
+     * An archived or just-deleted slug still leaves the walk somewhere to go —
+     * `adjacentSlug` falls back to either end — so the prediction stays two
+     * real URLs rather than a guess at a channel that is gone.
+     */
+    it('falls back to the ends for a channel that has left the list', () => {
+        expect(predicted(ROSTER, 'archived')).toEqual(['general', 'random']);
+    });
+
+    it('never predicts the channel already on screen', () => {
+        expect(predicted(ROSTER, 'design')).not.toContain('design');
+    });
+});
+
+describe('a speculative fetch of a channel', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('files the entry under the channel it holds, so an arrival can flush it', () => {
+        prefetchChannel('/t/acme/c/design', 'c1');
+
+        expect(prefetch).toHaveBeenCalledWith(
+            '/t/acme/c/design',
+            expect.anything(),
+            { cacheTags: [channelCacheTag('c1')] },
+        );
+    });
+
+    /**
+     * `only` is part of Inertia's prefetch cache key, so a prediction carrying
+     * one could never be claimed by the bare `router.visit` that follows it.
+     * Nothing fails loudly when that drifts, which is why it is asserted here.
+     */
+    it('carries no `only`, the same as the sidebar rows it must match', () => {
+        prefetchChannel('/t/acme/c/design', 'c1');
+
+        expect(prefetch.mock.calls[0][1]).not.toHaveProperty('only');
+    });
+
+    /**
+     * `router.prefetch` falls back to `config.get('prefetch.cacheFor')`, which
+     * is the same value a `<Link>` falls back to. Naming it here would be a
+     * second place for the lifetime to drift from the sidebar's.
+     */
+    it('names no lifetime, inheriting the one the links inherit', () => {
+        prefetchChannel('/t/acme/c/design', 'c1');
+
+        expect(prefetch.mock.calls[0][2]).not.toHaveProperty('cacheFor');
+    });
+});
+
+describe('the delay a prediction waits out', () => {
+    it('is the one Inertia already makes its own hover links wait', () => {
+        expect(predictionDelay()).toBe(config.get('prefetch.hoverDelay'));
     });
 });

--- a/resources/js/lib/prefetch.ts
+++ b/resources/js/lib/prefetch.ts
@@ -1,4 +1,22 @@
 import type { LinkPrefetchOption } from '@inertiajs/core';
+import { config, router } from '@inertiajs/vue3';
+import { adjacentSlug } from '@/composables/keyboardShortcuts';
+import type { Channel } from '@/types/channels';
+
+/**
+ * How long a settled prediction waits before it is believed.
+ *
+ * Read off Inertia's own configuration rather than re-typed, so a palette
+ * arrowed through and a sidebar row hovered over wait exactly as long as each
+ * other — including if the framework's default ever moves.
+ *
+ * Deliberately a call rather than a module constant: a constant would read the
+ * framework's configuration at *import* time, which every consumer of this
+ * module would then inherit whether or not it predicts anything.
+ */
+export function predictionDelay(): number {
+    return config.get('prefetch.hoverDelay');
+}
 
 /**
  * The prefetch cache tag a channel's speculative visit is filed under.
@@ -26,4 +44,51 @@ export function channelCacheTag(channelId: string): string {
  */
 export function prefetchTrigger(canHover: boolean): LinkPrefetchOption {
     return canHover ? 'hover' : 'click';
+}
+
+/**
+ * Fetch a channel ahead of a click that has not happened, under the very
+ * contract the sidebar rows declare through their `<Link>`.
+ *
+ * The empty visit options are the load-bearing half. `only` is part of the
+ * prefetch cache key, so a prediction that carried one could never be claimed
+ * by the bare `router.visit` that follows it — and nothing would fail loudly,
+ * the click would simply go to the server. `cacheFor` is left unnamed for the
+ * same reason in reverse: `router.prefetch` falls back to the config default a
+ * `<Link>` also falls back to, and naming it here would be a second place for
+ * the lifetime to drift from the sidebar's.
+ *
+ * Every predicting caller goes through here, which is what makes that sameness
+ * structural rather than three call sites that happen to agree today.
+ */
+export function prefetchChannel(url: string, channelId: string): void {
+    router.prefetch(url, {}, { cacheTags: [channelCacheTag(channelId)] });
+}
+
+/**
+ * The channels a ⌘↑ / ⌘↓ walk from `activeSlug` can reach in one step: at most
+ * two, deduped, and never the channel already on screen.
+ *
+ * Built on the same {@see adjacentSlug} the jump itself calls, so a prediction
+ * can never point somewhere the jump would not go — including at the ends of
+ * the list, which wrap rather than stop. Next is offered before previous, the
+ * commoner direction first.
+ *
+ * The dedupe is what keeps the cost honest at the small end: in a two-channel
+ * workspace both neighbours are the same row, and in a one-channel workspace
+ * both are the active channel.
+ */
+export function adjacentChannels(
+    channels: readonly Channel[],
+    activeSlug: string | null,
+): Channel[] {
+    const slugs = channels.map((channel) => channel.slug);
+
+    const neighbours = [1, -1]
+        .map((delta) => adjacentSlug(slugs, activeSlug, delta))
+        .filter((slug): slug is string => slug !== null && slug !== activeSlug);
+
+    return [...new Set(neighbours)].flatMap(
+        (slug) => channels.find((channel) => channel.slug === slug) ?? [],
+    );
 }

--- a/tests/Browser/CommandPalettePrefetchTest.php
+++ b/tests/Browser/CommandPalettePrefetchTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Channels\JoinChannel;
+use App\Models\Channel;
+use App\Models\Team;
+
+/**
+ * What the shell fetches before the viewer has asked for anything (#1257).
+ *
+ * Two navigation paths have no hover to trigger on, so both predict instead:
+ * the palette fetches the row `Enter` would run once the arrowing settles, and
+ * the shell fetches the two channels a ⌘↑ / ⌘↓ walk can reach. Which URLs those
+ * are, which cache tags they carry and how many requests a burst costs are
+ * pinned in Vitest, where they are deterministic. What only a browser shows is
+ * the halves meeting: real speculative requests leaving the page, and the pick
+ * that follows still arriving at the right channel with a prediction live in
+ * front of it.
+ *
+ * Deliberately no timing assertion. The requests are polled for rather than
+ * slept on, and nothing here claims a navigation was fast.
+ *
+ * The roster sorts by name (see `SidebarChannels`), so with the channels below
+ * it reads alpha, beta, general, zulu. Sitting in #general puts the walk's two
+ * neighbours at beta and zulu and leaves **alpha** reachable only through the
+ * palette — which is what lets one test speak for one path.
+ */
+
+/** The channels this suite's workspace holds, in the order the sidebar lists them. */
+function paletteWorkspace(): array
+{
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    foreach (['alpha', 'beta', 'zulu'] as $name) {
+        $channel = Channel::factory()->for($team)->create([
+            'name' => $name,
+            'slug' => $name,
+        ]);
+        app(JoinChannel::class)->handle($channel, $alice);
+    }
+
+    return ['owner' => $alice, 'team' => $team, 'active' => $general];
+}
+
+/**
+ * A script resolving once the browser has fetched `$path`.
+ *
+ * Read off `PerformanceResourceTiming` rather than a network panel: the app
+ * registers a no-op service worker, which makes every request appear twice to
+ * Playwright's own reporting. Existence is all this asks, so a duplicate is
+ * harmless — but the entry lands a debounce after the row is highlighted, and
+ * `assertScript` never retries (#947), so the frames are polled out here.
+ */
+function speculativeFetchArrives(string $path): string
+{
+    return <<<JS
+    (async () => {
+        const fetched = () => performance
+            .getEntriesByType('resource')
+            .some((entry) => entry.name.includes('{$path}'));
+
+        for (let frame = 0; frame < 240 && ! fetched(); frame++) {
+            await new Promise(requestAnimationFrame);
+        }
+
+        return fetched();
+    })()
+    JS;
+}
+
+/** Whether `$path` has been fetched at all, asked once and now. */
+function hasBeenFetched(string $path): string
+{
+    return <<<JS
+    (() => performance
+        .getEntriesByType('resource')
+        .some((entry) => entry.name.includes('{$path}')))()
+    JS;
+}
+
+test('the highlighted row is fetched before it is picked, and picking it lands there', function (): void {
+    ['owner' => $alice, 'team' => $team, 'active' => $general] = paletteWorkspace();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $general))
+        // Nothing has reason to want #alpha yet: it is neither open nor a
+        // neighbour of the open channel. Asserting that here is what stops the
+        // walk's own prediction from standing in for the palette's below — and
+        // fails loudly if the roster ever stops sorting the way this assumes.
+        ->assertScript(hasBeenFetched('/c/alpha'), false)
+        ->click('@quick-switcher-trigger')
+        // Narrowing to one row names which channel the prediction is for
+        // without simulating a single arrow key: the list highlights its first.
+        ->type('@quick-switcher-input', 'alpha')
+        ->assertScript(speculativeFetchArrives('/c/alpha'), true)
+        ->click('@quick-switcher-channel')
+        ->assertPathContains('/c/alpha');
+});
+
+test('the channels either side of the open one are fetched without being asked for', function (): void {
+    ['owner' => $alice, 'team' => $team, 'active' => $general] = paletteWorkspace();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $general))
+        ->assertScript(speculativeFetchArrives('/c/beta'), true)
+        ->assertScript(speculativeFetchArrives('/c/zulu'), true)
+        // The walk reaches two channels, so the prediction stops at two: #alpha
+        // is in the same workspace and stays unfetched.
+        ->assertScript(hasBeenFetched('/c/alpha'), false);
+});
+
+test('a channel the walk cannot reach in one step is left alone in a large workspace', function (): void {
+    ['owner' => $alice, 'team' => $team] = paletteWorkspace();
+
+    $far = Channel::factory()->for($team)->create(['name' => 'middle', 'slug' => 'middle']);
+    app(JoinChannel::class)->handle($far, $alice);
+
+    $team = Team::findOrFail($team->id);
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, Channel::where('slug', 'alpha')->firstOrFail()))
+        // Sitting at the top of the list, the walk wraps: beta below, zulu
+        // above. #general and #middle sit between them and are never fetched,
+        // which is the cost not growing with the workspace.
+        ->assertScript(speculativeFetchArrives('/c/beta'), true)
+        ->assertScript(hasBeenFetched('/c/middle'), false)
+        ->assertScript(hasBeenFetched('/c/general'), false);
+});


### PR DESCRIPTION
Closes #1257.

Two navigation paths have no hover to trigger on, so the hover/click prefetch from #1256 never reached them: the command palette (`commands.ts` was a bare `router.visit`) and the ⌘↑ / ⌘↓ channel walk. Both now predict instead.

## What changed

**The palette fetches the row `Enter` would run**, once the arrowing settles. Debounced on Inertia's own `prefetch.hoverDelay` — read off `config` rather than re-typed as `75` — so walking ten rows costs one request rather than ten.

Channel rows only, and matching on the row's own `channel:` value is what keeps that true by construction rather than by an exclusion list that would rot:

- **People** open through a `router.post`, and `router.prefetch` throws on any method but GET.
- **Commands** have no URL.
- **Message results** carry `channelSlug` but no channel id (`MessageSearchResultData` has no such field) and the search is cross-team, so their entries could never be flushed by the sidebar's fleet. An entry nothing can invalidate is worse than no entry.

**The shell fetches the two channels the walk can reach**, whenever the active channel changes. Built on the same `adjacentSlug()` the jump itself calls, so a prediction can never point somewhere the jump would not go. Two requests regardless of workspace size — the fixed cost that makes this safe where `mount` was not — and it runs only while a channel is open, since a settings page has no walk in progress.

**Both paths go through one helper**, `prefetchChannel()`, carrying the sidebar rows' contract: the same `channel:{id}` tag, the same inherited lifetime, and the same empty `only`. `only` is part of the prefetch cache key, so a mismatch between the prediction and the click is a guaranteed miss that fails silently — making that sameness structural rather than three call sites that happen to agree.

`cacheFor` is deliberately not passed: `router.prefetch` falls back to the same config default `<Link>` does, and naming it here would be a second place for the lifetime to drift.

## One deviation from the acceptance criteria

The issue expects "the first and last channel in the list predict one neighbour, not a broken URL". `adjacentSlug` actually **wraps**, so the ends are ordinary neighbours and no URL was ever at risk — and the prediction must wrap too, or it would fetch a channel the jump never lands on. The end cases that do exist are about count, and those are what the tests pin: a two-channel workspace yields one request, a one-channel workspace none.

## The number

The request delta is +2 by construction and asserted rather than assumed: the browser suite proves exactly the two neighbours are fetched and that a third channel in the same workspace is not.

The painted-p50 and request-count figures the issue asks for come from the pinned `research/navigation-baseline` harness against `demo.thedeskhq.app` in a specific window, which is not runnable from here — still outstanding for the epic's closing run (#1248), along with the per-⌘K cost noted below.

## Testing

- **Vitest** (`lib/prefetch.test.ts`, `useAdjacentChannelPrefetch.test.ts`, `CommandPalette.prefetch.test.ts`): the neighbour computation including both wrap ends, the dedupe cases and a channel that has left the list; one request per settled selection and none per keystroke; every row kind that must predict nothing; and the cache-parameter assertion that catches a future `only` or `cacheFor` appearing on one path and not the other.
- **Pest browser** (`CommandPalettePrefetchTest.php`): the halves meeting — real speculative requests leaving the page and the pick still landing on the right channel. Requests are polled for off `PerformanceResourceTiming`, never slept on, and nothing asserts timing. All three were confirmed to fail with the feature disabled.
- Full gate green: `Total: 100.0 %`, 3601 tests; frontend lint/format/types/build clean.

## Notes

- Opening ⌘K now costs one speculative request: reka-ui highlights the first row immediately, so the palette settles on a channel before any typing. Accepted deliberately — that row *is* the `Enter` target, and ⌘K → Enter is the palette's fastest path — and worth reporting in the epic's closing measurement.
- Dismissing the palette cancels a queued prediction, so a viewer who has closed it does not pay for where it was pointing.
- No new user-facing copy, so no `lang/fr.json` change; nothing operator-facing, so no `docs/` change.
- Blind spots are inherited unchanged from #1256 and bounded by the 30 s lifetime: the fleet hears `MessageSent` only, and a dropped socket stops the flushing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788731618&installation_model_id=428379&pr_number=1278&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1278&signature=b2af7729eea47fbbb7846983dfd32630fa53e03c5b53ca6ef19f61aa2de707f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->